### PR TITLE
fixed bug allowing user to export specified rows of reads table

### DIFF
--- a/src/python/dxpy/scripts/dx_reads_to_fastq.py
+++ b/src/python/dxpy/scripts/dx_reads_to_fastq.py
@@ -82,15 +82,15 @@ def main(**kwargs):
             raise dxpy.AppError("output parameter is required")
 
     with open(kwargs['output'], 'wb') as out_fh:
-        exportToFile(columns=col, table=table, start_row=kwargs['start_row'], end_row=kwargs['end_row'], output_file=out_fh, hasName=hasName, hasQual=hasQual, FASTA=kwargs['output_FASTA'])
+        exportToFile(columns=col, table=table, output_file=out_fh, hasName=hasName, hasQual=hasQual, FASTA=kwargs['output_FASTA'], start_row=kwargs['start_row'], end_row=kwargs['end_row'])
 
     if isPaired == True:
         if kwargs['output2'] is None:
             raise dxpy.AppError("output2 parameter is required for paired reads")
         with open(kwargs['output2'], 'wb') as out_fh2:
-            exportToFile(columns=col2, table=table, start_row=kwargs['start_row'], end_row=kwargs['end_row'], output_file=out_fh2, hasName=hasName, hasQual=hasQual, FASTA=kwargs['output_FASTA'])
+            exportToFile(columns=col2, table=table, output_file=out_fh2, hasName=hasName, hasQual=hasQual, FASTA=kwargs['output_FASTA'], start_row=kwargs['start_row'], end_row=kwargs['end_row'])
 
-def exportToFile(columns, table, start_row, end_row, output_file, hasName = True, hasQual = True, FASTA = False):
+def exportToFile(columns, table, output_file, hasName = True, hasQual = True, FASTA = False, start_row = 0, end_row = None):
     for row in table.iterate_rows(start=start_row, end=end_row, columns=columns):
         if FASTA == True:
             if hasName == True:


### PR DESCRIPTION
I just added arguments so that the exporter iterates only through the rows specified. If none are specified then the exporter should still go through the entire file. I tested it with the app and it should work.
