### PR TITLE
dx download glob support

### DIFF
--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -1733,7 +1733,7 @@ def download(args):
         cat(parser.parse_args(['cat'] + args.paths))
         return
 
-    import fnmatch
+    from dxpy.utils import pathmatch
 
     def ensure_local_dir(d):
         if not os.path.isdir(d):
@@ -1786,7 +1786,7 @@ def download(args):
         if project not in cached_folder_lists:
             cached_folder_lists[project] = dxpy.DXProject(project).describe(input_params={'folders': True})['folders']
         # TODO: support shell-style path globbing (i.e. /a*/c matches /ab/c but not /a/b/c)
-        # return fnmatch.filter(cached_folder_lists[project], os.path.join(path, '*'))
+        # return pathmatch.filter(cached_folder_lists[project], os.path.join(path, '*'))
         if recurse:
             return [f for f in cached_folder_lists[project] if f.startswith(path)]
         else:
@@ -1810,7 +1810,7 @@ def download(args):
         parent_folder = os.path.dirname(abs_path)
         #folder_listing = dxpy.DXProject(project).list_folder(folder=parent_folder, only='folders')['folders'] # includeHidden=
         folder_listing = list_subfolders(project, parent_folder, recurse=False)
-        matching_folders = fnmatch.filter(folder_listing, abs_path)
+        matching_folders = pathmatch.filter(folder_listing, abs_path)
 
         if len(matching_files) == 0 and len(matching_folders) == 0:
             err_exit(fill('Error: {path} is neither a file nor a folder name'.format(path=path)))

--- a/src/python/dxpy/utils/pathmatch.py
+++ b/src/python/dxpy/utils/pathmatch.py
@@ -1,0 +1,80 @@
+# Copyright (C) 2013 DNAnexus, Inc.
+#
+# This file is part of dx-toolkit (DNAnexus platform client libraries).
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#   use this file except in compliance with the License. You may obtain a copy
+#   of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+
+import re
+
+_cache = {}
+_MAXCACHE = 100
+
+def filter(names, pat):
+    """
+    A copy of fnmatch.filter that replaces with [^\/] instead of . to match path globs.
+    """
+    import os,posixpath
+    result=[]
+    pat=os.path.normcase(pat)
+    if not pat in _cache:
+        res = translate(pat)
+        if len(_cache) >= _MAXCACHE:
+            _cache.clear()
+        _cache[pat] = re.compile(res)
+    match=_cache[pat].match
+    if os.path is posixpath:
+        # normcase on posix is NOP. Optimize it away from the loop.
+        for name in names:
+            if match(name):
+                result.append(name)
+    else:
+        for name in names:
+            if match(os.path.normcase(name)):
+                result.append(name)
+    return result
+
+def translate(pat):
+    """
+    A copy of fnmatch.translate that replaces with [^\/] instead of . to match path globs.
+    """
+
+    i, n = 0, len(pat)
+    res = ''
+    while i < n:
+        c = pat[i]
+        i = i+1
+        if c == '*':
+            res = res + '[^\/]*'
+        elif c == '?':
+            res = res + '[^\/].'
+        elif c == '[':
+            j = i
+            if j < n and pat[j] == '!':
+                j = j+1
+            if j < n and pat[j] == ']':
+                j = j+1
+            while j < n and pat[j] != ']':
+                j = j+1
+            if j >= n:
+                res = res + '\\['
+            else:
+                stuff = pat[i:j].replace('\\','\\\\')
+                i = j+1
+                if stuff[0] == '!':
+                    stuff = '^' + stuff[1:]
+                elif stuff[0] == '^':
+                    stuff = '\\' + stuff
+                res = '%s[%s]' % (res, stuff)
+        else:
+            res = res + re.escape(c)
+    return res + '\Z(?ms)'


### PR DESCRIPTION
@kjlai @psung 

Adds support for globs in the last elements of paths, e.g.

```
dx download foo*
dx download *.fast?
dx download -r /foo/bar*/
dx download -r -f project1:/foo*/ project2:/bar* --output /local/dir/
```

And various other forms of that.

Makes it a non-error to try to download non-file objects and open files (prints a warning instead). Haven't yet decided if this needs a different exit code or any way to control whether this should be an error.

Adds `--all` for getting all objects with the same name, which is not yet useful because it doesn't rename them and instead tries to overwrite one with another and errors out.

Does not yet support full shell-style path element globbing. For example, `dx download /foo*/*.bam` won't work as expected.

Needs a test case, but until I write one, please hammer on this when you have some time.
