### PR TITLE
Replace "-" with "+" in UA-linux-old-kernel version string too

### DIFF
--- a/src/ua/centos_build/compile_ua_on_centos54.sh
+++ b/src/ua/centos_build/compile_ua_on_centos54.sh
@@ -158,7 +158,7 @@ echo -e '# -*- mode: Makefile -*-
 # curl:
 # \t$(DNANEXUS_HOME)/src/ua/build_curl.sh $(curl_build_dir)
 
-DXTOOLKIT_GITVERSION := $(shell git describe)
+DXTOOLKIT_GITVERSION := $(shell git describe|sed 's/-/+/')
 
 curl_dir = $(HOME)/sw/local/curl_build
 cpp_dir = $(DNANEXUS_HOME)/src/cpp


### PR DESCRIPTION
Required to be consistent with changes in https://github.com/dnanexus/dx-toolkit/commit/ade947e36de298e49cf788dbe5ec7ae09b93a0bd

PS: Although, we don't necessarily need this transformation for UA make process, since UA is versioned separately (which is semver compatible) from dx-toolkit. But if we keep https://github.com/dnanexus/dx-toolkit/commit/ade947e36de298e49cf788dbe5ec7ae09b93a0bd, then we need to make this change too.
