### PR TITLE
Fix for C++ apps failure to compile after f443cb0

### DIFF
--- a/src/cpp/cmake_include/set_build_version.txt
+++ b/src/cpp/cmake_include/set_build_version.txt
@@ -1,3 +1,16 @@
-# Get the build version and save it in the DXTOOLKIT_GITVERSION variable
-file(STRINGS "$ENV{DNANEXUS_HOME}/build/info/version" DXTOOLKIT_GITVERSION)
+# Get the output of command `git describe`, and save it in DXTOOLKIT_GITVERSION variable
+execute_process(COMMAND git describe WORKING_DIRECTORY $ENV{DNANEXUS_HOME} RESULT_VARIABLE GIT_DESCRIBE_STATUS_CODE OUTPUT_VARIABLE DXTOOLKIT_GITVERSION ERROR_VARIABLE GIT_DESCRIBE_ERROR)
+if (GIT_DESCRIBE_STATUS_CODE EQUAL 0)
+  # Trim the newline at the end of "git describe" output
+  string(REGEX REPLACE "\n" "" DXTOOLKIT_GITVERSION ${DXTOOLKIT_GITVERSION})
+
+  # Replace first (and only first) "-" with "+"
+  string(REGEX REPLACE "-(.+)" "+\\1" DXTOOLKIT_GITVERSION ${DXTOOLKIT_GITVERSION})
+
+  message(STATUS "dx-verify-file CMakeLists.txt says: DXTOOLKIT_GITVERSION= ${DXTOOLKIT_GITVERSION}")
+else()
+  set(DXTOOLKIT_GITVERSION unknown)
+  message(STATUS "dx-verify-file CMakeLists.txt says: The command 'git describe' failed.")
+  message(STATUS "\terror message: '${GIT_DESCRIBE_ERROR}'. Will set DXTOOLKIT_GITVERSION='${DXTOOLKIT_GITVERSION}'")
+endif()
 add_definitions(-DDXTOOLKIT_GITVERSION=\"${DXTOOLKIT_GITVERSION}\")


### PR DESCRIPTION
Potentially interesting to: @kislyuk, @jmdale, @psung
##### This pull request is a fix for the following problem:

**Problem:** Compiling any C++ app fails after this commit: https://github.com/dnanexus/dx-toolkit/commit/f443cb029164f5d49c59e47d326db0502b052974.

**Steps to reproduce:**
1) Checkout fresh dx-toolkit, and set DNANEXUS_HOME env variable accordingly.
2) Checkout any C++ app, say: https://github.com/dnanexus/variants_validator
3) Type `make`, and following error message will be shown:

```
biyani@biyani-vaio:/tmp/variants_validator$ make
make -C src all
make[1]: Entering directory `/tmp/variants_validator/src'
mkdir -p build && cd build && cmake -D CMAKE_BUILD_TYPE:STRING=RELEASE .. && make
-- The C compiler identification is GNU
-- The CXX compiler identification is GNU
-- Check for working C compiler: /usr/bin/gcc
-- Check for working C compiler: /usr/bin/gcc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
CMake Error at /home/biyani/dx-toolkit/src/cpp/cmake_include/set_build_version.txt:2 (file):
  file STRINGS file "/home/biyani/dx-toolkit/build/info/version" cannot be
  read.
Call Stack (most recent call first):
  /home/biyani/dx-toolkit/src/cpp/dxcpp/CMakeLists.txt:15 (include)


-- dxcpp CMakeLists.txt says: libcrypto, and openssl/md5.h found!
--  ** OPENSSL_INCLUDE_PATH = "/usr/include"
--  ** CRYPTO_LIBRARY_PATH = "/usr/lib/x86_64-linux-gnu/libcrypto.so"
-- Boost version: 1.48.0
-- Found the following Boost libraries:
--   thread
--   regex
--   system
-- dxcpp CMakeLists.txt says: Boost libraries found
--  ** BOOST_INCLUDE_DIR="/usr/include"
--  ** BOOST_LIBRARY_DIRS="/usr/lib"
--  ** BOOST_LIBRARIES = "/usr/lib/libboost_thread-mt.so;pthread;/usr/lib/libboost_regex-mt.so;/usr/lib/libboost_system-mt.so"
-- dxjson CMakeLists.txt says: Boost 1.48+ header files found in location /usr/include
-- SimpleHttpLib CMakeLists.txt says: Boost 1.48+ header files found in location /usr/include
CMake Error at /home/biyani/dx-toolkit/src/cpp/cmake_include/set_build_version.txt:2 (file):
  file STRINGS file "/home/biyani/dx-toolkit/build/info/version" cannot be
  read.
Call Stack (most recent call first):
  /home/biyani/dx-toolkit/src/cpp/SimpleHttpLib/CMakeLists.txt:23 (include)


-- SimpleHttpLib CMakeLists.txt says: libcurl found!
--  ** CURL_INCLUDE_PATH = "/usr/include"
--  ** CURL_LIBRARY_PATH = "/usr/lib/x86_64-linux-gnu/libcurl.so"
-- SimpleHttpLib CMakeLists.txt says: libcrypto, and openssl/crypto.h found!
--  ** OPENSSL_INCLUDE_PATH = "/usr/include"
--  ** CRYPTO_LIBRARY_PATH = "/usr/lib/x86_64-linux-gnu/libcrypto.so"
-- Configuring incomplete, errors occurred!
make[1]: *** [build] Error 1
make[1]: Leaving directory `/tmp/variants_validator/src'
make: *** [default] Error 2
```

**Cause of the problem:**
Note these lines in error message:

```
CMake Error at /home/biyani/dx-toolkit/src/cpp/cmake_include/set_build_version.txt:2 (file):
  file STRINGS file "/home/biyani/dx-toolkit/build/info/version" cannot be
  read.
```
- In https://github.com/dnanexus/dx-toolkit/commit/f443cb029164f5d49c59e47d326db0502b052974 this mechanism was added to get dx-toolkit version: https://github.com/dnanexus/dx-toolkit/blob/f443cb029164f5d49c59e47d326db0502b052974/src/cpp/cmake_include/set_build_version.txt
- However, the referenced file `$ENV{DNANEXUS_HOME}/build/info/version` is not present in dx-toolkit by default, but instead assumed to be build by `make toolkit_version` target in toplevel Makefile (https://github.com/dnanexus/dx-toolkit/blob/f443cb029164f5d49c59e47d326db0502b052974/src/Makefile#L50).
- When C++ apps are compiled (and the way they are designed), we don't need to run any `make` in dx-toolkit before compiling them (See CMakeLists.txt in any C++ app repo for example). api_wrapper files (api.cc, api.h) are already checked into the repo.
- Hence, the file `$ENV{DNANEXUS_HOME}/build/info/version` is not guaranteed to be present (esp., if you just checkout the dx-toolkit, or never `make` other parts of it (dx, etc))

**Solution:**
- Use `git describe` output to generate DXTOOLKIT_GITVERSION macro, instead of assuming presence of some file (which is not checked into repo).
- This pull requests adds that (similar to the way it was done before in dxcpp, however removing the redundancy in code by keeping the single "git describe" file as introduced in https://github.com/dnanexus/dx-toolkit/commit/f443cb029164f5d49c59e47d326db0502b052974). We use `REGEX REPLACE` to change the first "-" to "+" in git describe string (in line with conventions set by previous commit in this regard).
