### PR TITLE
Removing the SIGPIPE hack from dxcpp

### DIFF
--- a/src/cpp/dxcpp/dxcpp.cc
+++ b/src/cpp/dxcpp/dxcpp.cc
@@ -485,6 +485,8 @@ namespace dx {
     }the_only_instance;
   }
 
+// Disabling the SIGPIPE hack, because fix for http://sourceforge.net/p/curl/bugs/1180/ was introduced in libcurl 7.32
+/*
   // Ignore SIGPIPE to deal with PTFM-8366 & PTFM-7251 (Also see: http://sourceforge.net/p/curl/bugs/1180/)
   namespace _internal {
     #if !WINDOWS_BUILD
@@ -507,4 +509,5 @@ namespace dx {
     IgnoreSIGPIPE IgnoreSIGPIPE_static_initializer;
     #endif
   }
+*/
 }

--- a/src/ua/build_curl.sh
+++ b/src/ua/build_curl.sh
@@ -28,11 +28,11 @@
 build_dir=$1
 cd $build_dir
 pwd
-rm -rf curl-7.31.0.tar.bz2 curl-7.31.0
-wget "http://curl.haxx.se/download/curl-7.31.0.tar.bz2"
-tar -xjf curl-7.31.0.tar.bz2
+rm -rf curl-7.32.0.tar.bz2 curl-7.32.0
+wget "http://curl.haxx.se/download/curl-7.32.0.tar.bz2"
+tar -xjf curl-7.32.0.tar.bz2
 rm -f curl
-ln -s curl-7.31.0 curl
+ln -s curl-7.32.0 curl
 cd curl
 unamestr=`uname`
 if [[ "$unamestr" == 'Darwin' ]]; then

--- a/src/ua/centos_build/compile_ua_on_centos54.sh
+++ b/src/ua/centos_build/compile_ua_on_centos54.sh
@@ -65,9 +65,9 @@ make install # Will install it in /usr/local/ssl
 # Install Libcurl from source (using c-ares)
 export LD_LIBRARY_PATH=/usr/local/ssl/lib # So that libcurl find the correct openssl we just built
 cd ${HOME}/sw
-wget "http://curl.haxx.se/download/curl-7.31.0.tar.bz2"
-tar -xjf curl-7.31.0.tar.bz2
-mv curl-7.31.0 curl
+wget "http://curl.haxx.se/download/curl-7.32.0.tar.bz2"
+tar -xjf curl-7.32.0.tar.bz2
+mv curl-7.32.0 curl
 cd curl
 ./configure --prefix=${HOME}/sw/local/curl_build --disable-ldap --disable-ldaps \
   --disable-rtsp --disable-dict --disable-telnet --disable-tftp --disable-pop3 \

--- a/src/ua/main.cpp
+++ b/src/ua/main.cpp
@@ -42,8 +42,8 @@
 #endif
 
 #if !WINDOWS_BUILD
-#if ((LIBCURL_VERSION_MAJOR < 7) || (LIBCURL_VERSION_MAJOR == 7 && LIBCURL_VERSION_MINOR < 31))
-  #error "From UA v1.4.1 onwards, we expect to compile UA on libcurl v7.31+. If you need to override this behavior, edit main.cpp"
+#if ((LIBCURL_VERSION_MAJOR < 7) || (LIBCURL_VERSION_MAJOR == 7 && LIBCURL_VERSION_MINOR < 32))
+  #error "From UA > v1.4.5, we expect to compile UA on libcurl v7.32+. If you need to override this behavior, edit main.cpp"
 #endif
 #endif
 


### PR DESCRIPTION
@jmdale

libcurl 7.32.0 is released today (http://curl.haxx.se/download.html). This fixes the long outstanding bug: http://sourceforge.net/p/curl/bugs/1180/, in particular it contains the following desired commit https://github.com/bagder/curl/commit/7d80ed.

If the libcurl bug fix really works, then we can get rid of the SIGPIPE hack in dxcpp. This pull request does that. I have also updated the libcurl versions in build_curl.sh (and centos build) scripts, and enforced that we compile using libcurl >= 7.32 in ua/main.cpp

If you chose to merge the pull request, a suggested workflow might be:
1) Compile a new version of UA, say UA v1.4.6
2) Run a large scale test to upload using two different versions of UA: new one (1.4.6), and an old one with this problem (I think v1.4.1 had it ? - JIRA ticket about this should contain the exact version number).
3) Assume the bug fix to work after achieving some arbitrary threshold of satisfaction: (i.e., new UA fail 0 time, and the old one fails N time (N != 0)).

If the libcurl fix works, then I can think of following changes being required:
1) Update the libcurl on idna2
2) Update the libcurl locally
3) Bump up the version number of UA to 1.4.6 (in ua/Makefile)
4) Add notes to ua/CHANELOG
5) Compile on all platforms, if a new release is desired (not essential, since our hack also seemed to work fine)

And as a sanity check, please make sure that it compiles fine on Mac & Windows.

PS: For windows we still compile using libcurl 7.28 (if I remember it correctly), and the #error in main.cpp also do not enforce libcurl version requirement on windows. This is because, this bug was not relevant to Windows case, since we do _not_ use OpenSSL there. (and also compiling higher version of libcurl was causing some problem, which I do not recall now).
