### PR TITLE
PTFM-12580 dx login improvements

### DIFF
--- a/src/python/dxpy/exceptions.py
+++ b/src/python/dxpy/exceptions.py
@@ -23,6 +23,8 @@ from __future__ import (print_function, unicode_literals)
 import os, sys, json, traceback, errno
 from .packages import requests
 
+EXPECTED_ERR_EXIT_STATUS = 3
+
 class DXError(Exception):
     '''Base class for exceptions in this package.'''
     pass
@@ -214,7 +216,8 @@ def err_exit(message='', code=None, expected_exceptions=default_expected_excepti
 
     exc = exception if exception is not None else sys.exc_info()[1]
     if isinstance(exc, expected_exceptions):
-        exit_with_exc_info(3, message, print_tb=True if '_DX_DEBUG' in os.environ else False,
+        exit_with_exc_info(EXPECTED_ERR_EXIT_STATUS, message,
+                           print_tb=True if '_DX_DEBUG' in os.environ else False,
                            exception=exception)
     elif ignore_sigpipe and isinstance(exc, IOError) and getattr(exc, 'errno', None) == errno.EPIPE:
         sys.exit(3)

--- a/src/python/test/dxpy_testutil.py
+++ b/src/python/test/dxpy_testutil.py
@@ -33,6 +33,8 @@ TEST_NO_RATE_LIMITS = _run_all_tests or 'DXTEST_NO_RATE_LIMITS' in os.environ
 TEST_RUN_JOBS = _run_all_tests or 'DXTEST_RUN_JOBS' in os.environ
 TEST_TCSH = _run_all_tests or 'DXTEST_TCSH' in os.environ
 
+TEST_DX_LOGIN = 'DXTEST_LOGIN' in os.environ
+
 def _transform_words_to_regexp(s):
     return r"\s+".join(re.escape(word) for word in s.split())
 


### PR DESCRIPTION
- Allow up to 3 login retries
- Re-query username on empty input
- Cache username and password upon otp required message (which indicates username and password match)
- Produce a more specific error on otp mismatch
- Introduce a test case (disabled by default)

@kjlai to review
