### PR TITLE
PTFM-12873 Fix file part sizes for large (>~ 160GB) files

### DIFF
--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -142,6 +142,26 @@ def download_dxfile(dxid, filename, chunksize=dxfile.DEFAULT_BUFFER_SIZE, append
 
             fd.write(file_content)
 
+def _get_buffer_size_for_file(file_size, file_is_mmapd=False):
+    """Returns an upload buffer size that is appropriate to use for a file
+    of size file_size. If file_is_mmapd is True, the size is further
+    constrained to be suitable for passing to mmap.
+
+    """
+    # Raise buffer size (for files exceeding DEFAULT_BUFFER_SIZE * 10k
+    # bytes) in order to prevent us from exceeding 10k parts limit.
+    min_buffer_size = int(math.ceil(float(file_size) / 10000))
+    buffer_size = max(dxfile.DEFAULT_BUFFER_SIZE, min_buffer_size)
+    if file_size >= 0 and file_is_mmapd:
+        # For mmap'd uploads the buffer size additionally must be a
+        # multiple of the ALLOCATIONGRANULARITY.
+        buffer_size = int(math.ceil(float(buffer_size) / mmap.ALLOCATIONGRANULARITY)) * mmap.ALLOCATIONGRANULARITY
+    if buffer_size * 10000 < file_size:
+        raise AssertionError('part size is not large enough to complete upload')
+    if file_is_mmapd and buffer_size % mmap.ALLOCATIONGRANULARITY != 0:
+        raise AssertionError('part size will not be accepted by mmap')
+    return buffer_size
+
 def upload_local_file(filename=None, file=None, media_type=None, keep_open=False,
                       wait_on_close=False, use_existing_dxfile=None, show_progress=False, **kwargs):
     '''
@@ -186,14 +206,7 @@ def upload_local_file(filename=None, file=None, media_type=None, keep_open=False
         file_size = os.fstat(fd.fileno()).st_size
     except:
         file_size = 0
-    # Raise buffer size (for files exceeding DEFAULT_BUFFER_SIZE * 10k
-    # bytes) in order to prevent us from exceeding 10k parts limit.
-    min_buffer_size = file_size / 10000 + 1
-    if file_size >= 0 and hasattr(fd, "fileno"):
-        # For mmap'd uploads the buffer size additionally must be a
-        # multiple of the ALLOCATIONGRANULARITY.
-        min_buffer_size = int(math.ceil(min_buffer_size / mmap.ALLOCATIONGRANULARITY)) * mmap.ALLOCATIONGRANULARITY
-    buffer_size = max(dxfile.DEFAULT_BUFFER_SIZE, min_buffer_size)
+    buffer_size = _get_buffer_size_for_file(file_size, file_is_mmapd=hasattr(fd, "fileno"))
 
     if use_existing_dxfile:
         handler = use_existing_dxfile

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -192,6 +192,18 @@ class TestDXProject(unittest.TestCase):
         with self.assertRaises(DXAPIError):
             dxrecord.describe()
 
+class TestDXFileFunctions(unittest.TestCase):
+    def test_get_buffer_size(self):
+        for file_is_mmapd in (False, True):
+            # This method implements its own sanity checks, so just
+            # ensure that those pass for a variety of sizes.
+            dxpy.bindings.dxfile_functions._get_buffer_size_for_file(0, file_is_mmapd=file_is_mmapd)
+            dxpy.bindings.dxfile_functions._get_buffer_size_for_file(1, file_is_mmapd=file_is_mmapd)
+            dxpy.bindings.dxfile_functions._get_buffer_size_for_file(5 * 1024 * 1024, file_is_mmapd=file_is_mmapd)
+            dxpy.bindings.dxfile_functions._get_buffer_size_for_file(16 * 1024 * 1024, file_is_mmapd=file_is_mmapd)
+            dxpy.bindings.dxfile_functions._get_buffer_size_for_file(160 * 1024 * 1024 * 1024, file_is_mmapd=file_is_mmapd)
+            dxpy.bindings.dxfile_functions._get_buffer_size_for_file(290 * 1024 * 1024 * 1024, file_is_mmapd=file_is_mmapd)
+
 class TestDXFile(unittest.TestCase):
 
     '''


### PR DESCRIPTION
- Improper division in mmap-specific computation resulted in too low buffer sizes for platform-external uploads larger than 160GB (or internal uploads larger than 960GB) that are backed by a real file.
- Add assertions to fail-fast the file upload if a similar situation is detected in the future
- Factor the relevant code into a separate method and add regression tests
- Ensure that part size is mmappable even if `dxfile.DEFAULT_BUFFER_SIZE` is not (admittedly unlikely unless user overrides the size)
- For consistency, dividing file size by 10000 now also uses `math.ceil` in the proper way instead of doing integer division and adding 1
