### PR TITLE
PTFM-14387 Move job log message truncation

### DIFF
--- a/src/python/scripts/dx-log-stream
+++ b/src/python/scripts/dx-log-stream
@@ -52,11 +52,5 @@ while True:
     line = sys.stdin.readline()
     if line == '':
         break
-    # The Linux domain socket datagram size limit is 8 KB, but with the extra padding introduced by the log function,
-    # the incoming message needs to be smaller - we truncate it to 8100 bytes here.
-    # Note: we use Python 2 semantics here (byte strings). This script is not Python 3 ready. If *line* was a unicode
-    # string with wide chars, its byte length would exceed the limit.
-    if len(line) > 8100:
-        line = line[:8100] + '... [truncated]'
     # print "Logging line:", line.rstrip("\n"), "to log handler w/level", args.level
     log_function(line.rstrip("\n"))


### PR DESCRIPTION
The truncation previously resided in the dx-log-stream wrapper, which
ingests stdout and stderr, but data sent directly to the log socket
bypasses it. The wrapper invokes the logger function, which is
responsible for forwarding the message. The logger function is used in
Python-based apps. This change eliminates confusing JSON parsing
errors when Python-based apps send log lines that are too long.

@psung please review