### PR TITLE
PTFM-14841 Invoke download URL refresh logic in every iteration

### DIFF
--- a/src/python/dxpy/bindings/dxfile.py
+++ b/src/python/dxpy/bindings/dxfile.py
@@ -519,7 +519,7 @@ class DXFile(DXDataObject):
             args["filename"] = filename
         if project is not None:
             args["project"] = project
-        if self._download_url is None or self._download_url_expires > time.time():
+        if self._download_url is None or self._download_url_expires < time.time():
             # logging.debug("Download URL unset or expired, requesting a new one")
             resp = dxpy.api.file_download(self._dxid, args, **kwargs)
             self._download_url = resp["url"]

--- a/src/python/dxpy/bindings/dxfile.py
+++ b/src/python/dxpy/bindings/dxfile.py
@@ -528,8 +528,6 @@ class DXFile(DXDataObject):
         return self._download_url, self._download_url_headers
 
     def _generate_read_requests(self, start_pos=0, end_pos=None, **kwargs):
-        url, headers = self.get_download_url(**kwargs)
-
         if self._file_length == None:
             desc = self.describe(**kwargs)
             self._file_length = int(desc["size"])
@@ -552,6 +550,7 @@ class DXFile(DXDataObject):
                 i += 1
 
         for chunk_start_pos, chunk_end_pos in chunk_ranges(start_pos, end_pos):
+            url, headers = self.get_download_url(**kwargs)
             headers = copy.copy(headers)
             headers['Range'] = "bytes=" + str(chunk_start_pos) + "-" + str(chunk_end_pos)
             yield dxpy.DXHTTPRequest, [url, ''], {'method': 'GET',

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -389,6 +389,18 @@ class TestDXFile(unittest.TestCase):
         dxfile.write("Haha")
         # No assertion here, but this should print an error
 
+    def test_download_url_helper(self):
+        dxfile = dxpy.upload_string(self.foo_str, wait_on_close=True)
+        for opts in {}, {"preauthenticated": True, "filename": "foo"}:
+            dxfile = dxpy.open_dxfile(dxfile.get_id())
+            url1 = dxfile.get_download_url(**opts)
+            url2 = dxfile.get_download_url(**opts)
+            self.assertEqual(url1, url2)
+            dxfile = dxpy.open_dxfile(dxfile.get_id())
+            url3 = dxfile.get_download_url(duration=60, **opts)
+            url4 = dxfile.get_download_url(**opts)
+            self.assertNotEqual(url3, url4)
+
 class TestDXGTable(unittest.TestCase):
     """
     TODO: Test iterators, gri, and other queries

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -392,10 +392,13 @@ class TestDXFile(unittest.TestCase):
     def test_download_url_helper(self):
         dxfile = dxpy.upload_string(self.foo_str, wait_on_close=True)
         for opts in {}, {"preauthenticated": True, "filename": "foo"}:
+            # File download token/URL is cached
             dxfile = dxpy.open_dxfile(dxfile.get_id())
             url1 = dxfile.get_download_url(**opts)
             url2 = dxfile.get_download_url(**opts)
             self.assertEqual(url1, url2)
+            # Cache is invalidated when the client knows the token has expired
+            # (subject to clock skew allowance of 60s)
             dxfile = dxpy.open_dxfile(dxfile.get_id())
             url3 = dxfile.get_download_url(duration=60, **opts)
             url4 = dxfile.get_download_url(**opts)


### PR DESCRIPTION
The download URL cache and refresh logic is already there, but the
file download request iterator was storing a static copy of the
download URL instead of running the cache/refresh helper.

@psung, please review