### PR TITLE
PTFM-14733 Log resource usage through priority socket

### DIFF
--- a/src/python/dxpy/dxlog.py
+++ b/src/python/dxpy/dxlog.py
@@ -84,8 +84,9 @@ class DXLogHandler(SysLogHandler):
         data = json.dumps({"source": self.source, "timestamp": int(round(time.time() * 1000)),
                            "level": level, "msg": message})
 
-        if int(record.levelno) > 40:
-            # Critical, alert or emerg
+        levelno = int(record.levelno)
+        if levelno >= logging.CRITICAL or (levelno == logging.INFO and message.startswith("CPU: ")):
+            # Critical, alert, emerg, or resource status
             cur_socket = self.priority_log_socket
             cur_socket_address = self.priority_log_address
         else:


### PR DESCRIPTION
This is a quick and dirty way to make the resource usage log lines bypass the 2 MB job log limit and continue to be sent even when the bulk logs have been muted.

@psung please review