### PR TITLE
PTFM-14962 Use devtools to install versioned CRAN execDepends

### DIFF
--- a/src/python/dxpy/utils/exec_utils.py
+++ b/src/python/dxpy/utils/exec_utils.py
@@ -331,7 +331,6 @@ class DXExecDependencyInstaller(object):
             repo = "http://cran.us.r-project.org"
             r_preamble = "die <- function() { q(status=1) }; options(error=die); options(warn=2);"
             r_preamble += "r <- getOption('repos'); r['CRAN'] = '{repo}'; options(repos=r)".format(repo=repo)
-
             r_cmd_template = "R -e '{preamble}; {cmd}'"
             bootstrap_cmd = 'install.packages("devtools")'
             commands = [r_cmd_template.format(preamble=r_preamble, cmd=bootstrap_cmd)]

--- a/src/python/dxpy/utils/exec_utils.py
+++ b/src/python/dxpy/utils/exec_utils.py
@@ -329,12 +329,14 @@ class DXExecDependencyInstaller(object):
             return "cpanm --notest " + make_pm_atoms(packages, version_separator="~")
         elif dep_type == "cran":
             repo = "http://cran.us.r-project.org"
-            r_preamble = "die <- function() { q(status=1) }; options(error=die); options(warn=2)"
+            r_preamble = "die <- function() { q(status=1) }; options(error=die); options(warn=2);"
+            r_preamble += "r <- getOption('repos'); r['CRAN'] = '{repo}'; options(repos=r)".format(repo=repo)
+
             r_cmd_template = "R -e '{preamble}; {cmd}'"
-            bootstrap_cmd = 'install.packages("devtools", repos="{repo}")'.format(repo=repo)
+            bootstrap_cmd = 'install.packages("devtools")'
             commands = [r_cmd_template.format(preamble=r_preamble, cmd=bootstrap_cmd)]
             for package in packages:
-                args = '"{name}", repos="{repo}"'.format(name=package["name"], repo=repo)
+                args = '"{}"'.format(package["name"])
                 if "version" in package:
                     args += ', version="{}"'.format(package["version"])
                 cmd = "require(devtools); install_version({args})".format(args=args)

--- a/src/python/test/test_dxpy_utils.py
+++ b/src/python/test/test_dxpy_utils.py
@@ -167,6 +167,7 @@ class TestDXExecDependsUtils(unittest.TestCase):
                                         {"name": "Module::Provision", "package_manager": "cpan", "version": "0.36.1"},
                                         {"name": "LWP::MediaTypes", "package_manager": "cpan"},
                                         {"name": "RJSONIO", "package_manager": "cran"},
+                                        {"name": "plyr", "package_manager": "cran", "version": "1.8.1"},
                                         {"name": "ggplot2", "package_manager": "cran", "stages": ["main"],
                                          "version": "1.0.1"},
                                         {"name": "r1", "id": {"$dnanexus_link": "record-123"}},

--- a/src/python/test/test_dxpy_utils.py
+++ b/src/python/test/test_dxpy_utils.py
@@ -184,7 +184,7 @@ class TestDXExecDependsUtils(unittest.TestCase):
         assert_cmd_ran(edi, re.escape("pip install --upgrade pytz==2014.7 certifi"))
         assert_cmd_ran(edi, "apt-get install --yes --no-install-recommends tmux")
         assert_cmd_ran(edi, re.escape("gem install rake --version 10.3.2 && gem install nokogiri"))
-        assert_cmd_ran(edi, "R -e .+ install_version.+\"RJSONIO\".+\"ggplot2\".+version=\"1.0.1\"")
+        assert_cmd_ran(edi, "R -e .+ install.packages.+\"RJSONIO\".+install_version.+\"ggplot2\".+version=\"1.0.1\"")
         assert_log_contains(edi, 'Skipping bundled dependency "r1" because it does not refer to a file')
         assert_cmd_ran(edi, re.escape("cd $(mktemp -d) && git clone https://github.com/dnanexus/oauth2-demo"))
         assert_cmd_ran(edi, "cd /tmp/ee-edi-test-bwa && git clone https://github.com/dnanexus/bwa")

--- a/src/python/test/test_dxpy_utils.py
+++ b/src/python/test/test_dxpy_utils.py
@@ -142,8 +142,9 @@ class TestDXExecDependsUtils(unittest.TestCase):
         with self.assertRaisesRegexp(AppInternalError, 'Expected field "name" to be present'):
             get_edi({"dependencies": [{"foo": "bar"}]})
 
-        with self.assertRaisesRegexp(AppInternalError, "versioning is not supported for CRAN dependencies"):
-            get_edi({"dependencies": [{"name": "foo", "package_manager": "cran", "version": "1.2.3"}]})
+        edi = get_edi({"dependencies": [{"name": "foo", "package_manager": "cran", "version": "1.2.3"}]})
+        edi.install()
+        assert_cmd_ran(edi, "R -e .+ install.packages.+devtools.+install_version.+foo.+version.+1.2.3")
 
         with self.assertRaisesRegexp(AppInternalError, 'does not have a "url" field'):
             get_edi({"dependencies": [{"name": "foo", "package_manager": "git"}]})
@@ -166,7 +167,8 @@ class TestDXExecDependsUtils(unittest.TestCase):
                                         {"name": "Module::Provision", "package_manager": "cpan", "version": "0.36.1"},
                                         {"name": "LWP::MediaTypes", "package_manager": "cpan"},
                                         {"name": "RJSONIO", "package_manager": "cran"},
-                                        {"name": "ggplot2", "package_manager": "cran", "stages": ["main"]},
+                                        {"name": "ggplot2", "package_manager": "cran", "stages": ["main"],
+                                         "version": "1.0.1"},
                                         {"name": "r1", "id": {"$dnanexus_link": "record-123"}},
                                         {"name": "g1",
                                          "package_manager": "git",
@@ -182,7 +184,7 @@ class TestDXExecDependsUtils(unittest.TestCase):
         assert_cmd_ran(edi, re.escape("pip install --upgrade pytz==2014.7 certifi"))
         assert_cmd_ran(edi, "apt-get install --yes --no-install-recommends tmux")
         assert_cmd_ran(edi, re.escape("gem install rake --version 10.3.2 && gem install nokogiri"))
-        assert_cmd_ran(edi, "R -e .+ install.packages.+ --args RJSONIO ggplot2")
+        assert_cmd_ran(edi, "R -e .+ install_version.+\"RJSONIO\".+\"ggplot2\".+version=\"1.0.1\"")
         assert_log_contains(edi, 'Skipping bundled dependency "r1" because it does not refer to a file')
         assert_cmd_ran(edi, re.escape("cd $(mktemp -d) && git clone https://github.com/dnanexus/oauth2-demo"))
         assert_cmd_ran(edi, "cd /tmp/ee-edi-test-bwa && git clone https://github.com/dnanexus/bwa")


### PR DESCRIPTION
@psung please review. @billagee interest

Note: although devtools supports installation of package versions, the R dependency metadata schema does not seem to accommodate it, so dependencies get pulled in versionless. In the case of ggplot2, which fails because the plyr dependency is unavailable, this means the exec depends spec needs to be updated to specify a version for plyr: https://github.com/dnanexus/nucleus/commit/91a75b0