### PR TITLE
Fix the build/centos_install_python27.sh script

### DIFF
--- a/build/centos_install_python27.sh
+++ b/build/centos_install_python27.sh
@@ -38,8 +38,8 @@ $MAYBE_SUDO yum install -y zlib-devel bzip2-devel openssl-devel ncurses-devel re
 TEMPDIR=$(mktemp -d)
 
 pushd $TEMPDIR
-curl -L -O https://www.python.org/ftp/python/2.7.9/Python-2.7.9.tar.bz2
-tar -xjf Python-2.7.9.tar.bz2
+curl -L -O https://www.python.org/ftp/python/2.7.9/Python-2.7.9.tar.xz
+tar -xf Python-2.7.9.tar.xz
 cd Python-2.7.9
 ./configure --prefix=/usr/local
 make


### PR DESCRIPTION
Python doesn't seem to make `bz2` files available anymore.