### PR TITLE
dxpy.download_dxfile: restore positional args compatibility

### DIFF
--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -106,7 +106,7 @@ def download_dxfile(dxid, filename, chunksize=dxfile.DEFAULT_BUFFER_SIZE, append
     :param append: If True, appends to the local file (default is to truncate local file if it exists)
     :type append: boolean
 
-    Downloads the remote file referenced by *dxid* or *dxfile* and saves it to *filename*.
+    Downloads the remote file referenced by *dxid* and saves it to *filename*.
 
     Example::
 

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -301,7 +301,15 @@ class TestDXFile(unittest.TestCase):
                          os.path.basename(self.foo_file.name))
 
         dxpy.download_dxfile(self.dxfile.get_id(), self.new_file.name)
+        self.assertTrue(filecmp.cmp(self.foo_file.name, self.new_file.name))
 
+        dxpy.download_dxfile(filename=self.new_file.name, dxid=self.dxfile.get_id())
+        self.assertTrue(filecmp.cmp(self.foo_file.name, self.new_file.name))
+
+        dxpy.download_dxfile(None, dxfile=self.dxfile, filename=self.new_file.name)
+        self.assertTrue(filecmp.cmp(self.foo_file.name, self.new_file.name))
+
+        dxpy.download_dxfile(dxfile=self.dxfile, filename=self.new_file.name, dxid=None)
         self.assertTrue(filecmp.cmp(self.foo_file.name, self.new_file.name))
 
     def test_upload_string_dxfile(self):

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -306,10 +306,10 @@ class TestDXFile(unittest.TestCase):
         dxpy.download_dxfile(filename=self.new_file.name, dxid=self.dxfile.get_id())
         self.assertTrue(filecmp.cmp(self.foo_file.name, self.new_file.name))
 
-        dxpy.download_dxfile(None, dxfile=self.dxfile, filename=self.new_file.name)
+        dxpy.download_dxfile(dxid=self.dxfile, filename=self.new_file.name)
         self.assertTrue(filecmp.cmp(self.foo_file.name, self.new_file.name))
 
-        dxpy.download_dxfile(dxfile=self.dxfile, filename=self.new_file.name, dxid=None)
+        dxpy.download_dxfile(self.dxfile, filename=self.new_file.name)
         self.assertTrue(filecmp.cmp(self.foo_file.name, self.new_file.name))
 
     def test_upload_string_dxfile(self):


### PR DESCRIPTION
Restore compatibility with function calls that use the dxid positional
argument name as a keyword arg.

@psung, please review