### PR TITLE
Add omit-resources feature

### DIFF
--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -1756,7 +1756,7 @@ def get(args):
         fd.write(json.dumps(details, indent=4))
     elif entity_result['describe']['class'] == 'applet':
         from dxpy.utils.app_unbuilder import dump_applet
-        dump_applet(dxpy.DXApplet(entity_result['id'], project=project), output_path)
+        dump_applet(dxpy.DXApplet(entity_result['id'], project=project), output_path, args.omit_resources)
     if fd is not None and args.output != '-':
         fd.close()
 
@@ -4324,6 +4324,7 @@ parser_get = subparsers.add_parser('get', help='Download records, applets, and f
 parser_get.add_argument('path', help='Data object ID or name to access').completer = DXPathCompleter(classes=['file', 'record', 'applet'])
 parser_get.add_argument('-o', '--output', help='local file path where the data is to be saved ("-" indicates stdout output for objects of class file and record). If not supplied, the object\'s name on the platform will be used, along with any applicable extensions. For applets, if OUTPUT does not exist, an applet source directory will be created there; if OUTPUT is an existing directory, a new directory with the applet\'s name will be created inside it.')
 parser_get.add_argument('--no-ext', help='If -o is not provided, do not add an extension to the filename', action='store_true')
+parser_get.add_argument('--omit-resources', help='When downloading an applet, omit fetching the resources associated with the applet.', action='store_true')
 parser_get.add_argument('-f', '--overwrite', help='Overwrite the local file if necessary', action='store_true')
 parser_get.set_defaults(func=get)
 register_subparser(parser_get, categories='data')

--- a/src/python/dxpy/utils/app_unbuilder.py
+++ b/src/python/dxpy/utils/app_unbuilder.py
@@ -34,7 +34,7 @@ import sys
 from .. import get_handler, download_dxfile
 from ..compat import open
 
-def dump_applet(applet, destination_directory):
+def dump_applet(applet, destination_directory, omit_resources=False):
     """
     Reconstitutes applet into a directory that would create a
     functionally identical app if "dx build" were run on it.
@@ -84,17 +84,18 @@ def dump_applet(applet, destination_directory):
         # resources/ directory
         deps_to_remove = []
         created_resources_directory = False
-        for dep in info["runSpec"]["bundledDepends"]:
-            handler = get_handler(dep["id"])
-            if handler.__class__.__name__ == "DXFile":
-                if not created_resources_directory:
-                    os.mkdir("resources")
-                    created_resources_directory = True
-                fname = "resources/%s.tar.gz" % (handler.get_id())
-                download_dxfile(handler.get_id(), fname)
-                subprocess.check_call(["tar", "-C", "resources", "-zxvf", fname], shell=False)
-                os.unlink(fname)
-                deps_to_remove.append(dep)
+        if not omit_resources:
+            for dep in info["runSpec"]["bundledDepends"]:
+                handler = get_handler(dep["id"])
+                if handler.__class__.__name__ == "DXFile":
+                    if not created_resources_directory:
+                        os.mkdir("resources")
+                        created_resources_directory = True
+                    fname = "resources/%s.tar.gz" % (handler.get_id())
+                    download_dxfile(handler.get_id(), fname)
+                    subprocess.check_call(["tar", "-C", "resources", "-zxvf", fname], shell=False)
+                    os.unlink(fname)
+                    deps_to_remove.append(dep)
 
         # TODO: if output directory is not the same as applet name we
         # should print a warning and/or offer to rewrite the "name"


### PR DESCRIPTION
Add a simple command line argument to dx get to allow users to fetch
the applet without the resources.