### PR TITLE
Fix print_progress bug

### DIFF
--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -124,6 +124,9 @@ def download_dxfile(dxid, filename, chunksize=dxfile.DEFAULT_BUFFER_SIZE, append
         percent = int(round((bytes_downloaded / float(effective_file_size)) * 100))
 
         fmt = "[{done}{pending}] {action} {done_bytes:,}{remaining} bytes ({percent}%) {name}"
+        # Erase the line and return the cursor to the start of the line.
+        # The following VT100 escape sequence will erase the current line.
+        sys.stderr.write("\33[2K")
         sys.stderr.write(fmt.format(action=action,
                                     done=("=" * (ticks - 1) + ">") if ticks > 0 else "",
                                     pending=" " * (num_ticks - ticks),


### PR DESCRIPTION
There was a small bug when printing the status of a download in that
each time we print the new status, we have a carriage return which
resets the cursor to the beginning of the line so that each new progress
overwrites the previous line.  This works fine as long as the new line
is greater than or equal to the previous line's length, but if it's shorter,
then you'll see part of the old line left.