### PR TITLE
More informative error for dx add member

### DIFF
--- a/src/python/dxpy/cli/org.py
+++ b/src/python/dxpy/cli/org.py
@@ -74,7 +74,7 @@ def add_membership(args):
     except:
         pass
     else:
-        raise DXCLIError("Cannot add a user who is already a member of the org")
+        raise DXCLIError("Cannot add a user who is already a member of the org. To update existing member's permissions use 'dx update member'")
 
     dxpy.api.org_invite(args.org_id, get_org_invite_args(user_id, args))
 

--- a/src/python/dxpy/cli/org.py
+++ b/src/python/dxpy/cli/org.py
@@ -74,7 +74,7 @@ def add_membership(args):
     except:
         pass
     else:
-        raise DXCLIError("Cannot add a user who is already a member of the org. To update existing member's permissions use 'dx update member'")
+        raise DXCLIError("Cannot add a user who is already a member of the org. To update an existing member's permissions, use 'dx update member'")
 
     dxpy.api.org_invite(args.org_id, get_org_invite_args(user_id, args))
 


### PR DESCRIPTION
The CLI will suggest to the user to use 'dx update member' instead if calling dx add member on existing org member. 

@ptn24 please review