### PR TITLE
Updating download help message.

### DIFF
--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -3732,7 +3732,7 @@ parser_download_paths_arg = parser_download.add_argument('paths', help='Data obj
                                                          nargs='+', metavar='path')
 parser_download_paths_arg.completer = DXPathCompleter(classes=['file'])
 parser_download.add_argument('-o', '--output', help='Local filename or directory to be used ("-" indicates stdout output); if not supplied or a directory is given, the object\'s name on the platform will be used, along with any applicable extensions')
-parser_download.add_argument('-f', '--overwrite', help='Overwrite the local file if necessary', action='store_true')
+parser_download.add_argument('-f', '--overwrite', help='Resume an interupted download if the local and remote file signatures match.  If the signatures do not match the local file will be overwritten.', action='store_true')
 parser_download.add_argument('-r', '--recursive', help='Download folders recursively', action='store_true')
 parser_download.add_argument('-a', '--all', help='If multiple objects match the input, download all of them',
                              action='store_true')


### PR DESCRIPTION
To resume an interupted download, somewhat confusingly we use the -f or --overwrite flag.
I have updated the help message for this switch to specifically mention that it will resume
the file download if possible.  Long term we may want to either rename this option or separate
the two behaviors, but at least for now this adds some clarity.