### PR TITLE
bash helpers: flush log messages before starting file transfers

### DIFF
--- a/src/python/scripts/dx-download-all-inputs
+++ b/src/python/scripts/dx-download-all-inputs
@@ -101,6 +101,7 @@ def download_one_file(file_rec):
     src_file = file_rec['src_file_id']
     trg_file = os.path.join(idir, file_rec['trg_fname'])
     print("downloading file: " + src_file + " to filesystem: " + trg_file)
+    sys.stdout.flush()
     dxpy.download_dxfile(src_file, trg_file)
     return file_rec
 

--- a/src/python/scripts/dx-upload-all-outputs
+++ b/src/python/scripts/dx-upload-all-outputs
@@ -295,14 +295,17 @@ def upload_one_file(entry, wait_on_close):
     local_path = os.path.join(entry['local_dir_path'], entry['fname'])
     if entry['target_dir_path'] is None:
         trg_path = "/{}".format(entry['fname'])
+        print("uploading file: {} -> {}".format(local_path, trg_path))
+        sys.stdout.flush()
         f_obj = dxpy.upload_local_file(local_path, wait_on_close=wait_on_close)
     else:
         trg_path = "/{}/{}".format(entry['target_dir_path'], entry['fname'])
+        print("uploading file: {} -> {}".format(local_path, trg_path))
+        sys.stdout.flush()
         f_obj = dxpy.upload_local_file(local_path,
                                        folder=("/" + entry['target_dir_path']),
                                        parents=True, wait_on_close=wait_on_close)
     entry['dxlink'] = dxpy.dxlink(f_obj)
-    print("uploaded file {} -> {}".format(local_path, trg_path))
 
 def sequential_file_upload(to_upload, wait_on_close):
     '''Sequentially upload everything that is in the output directory.


### PR DESCRIPTION
ensure log messages appear in a timely fashion while live-streaming job logs, for situational awareness in large transfers

@orodeh @asimenos 