### PR TITLE
'.sh' suffix has been added to the dx environment autoload file

### DIFF
--- a/build/fix_shebang_lines.sh
+++ b/build/fix_shebang_lines.sh
@@ -26,7 +26,7 @@ fi
 
 msg="Please source the environment file at the root of dx-toolkit."
 if [[ $2 == "--debian-system-install" ]]; then
-    msg="Please source the environment file /etc/profile.d/dnanexus.environment."
+    msg="Please source the environment file /etc/profile.d/dnanexus.environment.sh."
     shift
 fi
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -5,7 +5,7 @@ set -e
 
 if [ "$1" = "configure" ]; then
   echo "*****"
-  echo "***** Please source /etc/profile.d/dnanexus.environment (or make"
+  echo "***** Please source /etc/profile.d/dnanexus.environment.sh (or make"
   echo "***** sure your shell does so) before using the DNAnexus tools."
   echo "*****"
 fi

--- a/src/Makefile
+++ b/src/Makefile
@@ -222,7 +222,7 @@ debian_install: base_install
 	../build/fix_shebang_lines.sh $(DESTDIR)/$(PREFIX)/bin --debian-system-install
 
 	mkdir -p $(DESTDIR)/etc/profile.d                                        # Install environment file into etc
-	install -v -m0644 $(DNANEXUS_HOME)/environment $(DESTDIR)/etc/profile.d/dnanexus.environment
+	install -v -m0644 $(DNANEXUS_HOME)/environment $(DESTDIR)/etc/profile.d/dnanexus.environment.sh
 	cp -a $(DNANEXUS_HOME)/share/dnanexus/lib/python2.7/site-packages/* $(DESTDIR)/$(PREFIX)/share/dnanexus/lib/python2.7/site-packages/
 	ls $(DNANEXUS_HOME)/share/dnanexus/lib/python2.7/site-packages | grep dxpy > $(DESTDIR)/$(PREFIX)/share/dnanexus/lib/python2.7/site-packages/dxpy.pth
 

--- a/src/Makefile_modifyed
+++ b/src/Makefile_modifyed
@@ -228,7 +228,7 @@ debian_install: base_install
 	../build/fix_shebang_lines.sh $(DESTDIR)/$(PREFIX)/bin --debian-system-install
 
 	mkdir -p $(DESTDIR)/etc/profile.d                                        # Install environment file into etc
-	install -v -m0644 $(DNANEXUS_HOME)/environment $(DESTDIR)/etc/profile.d/dnanexus.environment
+	install -v -m0644 $(DNANEXUS_HOME)/environment $(DESTDIR)/etc/profile.d/dnanexus.environment.sh
 	cp -a $(DNANEXUS_HOME)/share/dnanexus/lib/python2.7/site-packages/* $(DESTDIR)/$(PREFIX)/share/dnanexus/lib/python2.7/site-packages/
 	ls $(DNANEXUS_HOME)/share/dnanexus/lib/python2.7/site-packages | grep dxpy > $(DESTDIR)/$(PREFIX)/share/dnanexus/lib/python2.7/site-packages/dxpy.pth
 


### PR DESCRIPTION
`/etc/profile` script on Ubuntu processes `/etc/profile.d/*.sh` files only, so I added a respective suffix to the `/etc/profile.d/dnanexus.environment` file.