### PR TITLE
Updating dx

### DIFF
--- a/src/python/dxpy/__init__.py
+++ b/src/python/dxpy/__init__.py
@@ -694,7 +694,7 @@ def set_project_context(dxid):
     global PROJECT_CONTEXT_ID
     PROJECT_CONTEXT_ID = dxid
 
-def get_auth_server_name(host_override=None, port_override=None):
+def get_auth_server_name(host_override=None, port_override=None, protocol='https'):
     """
     Chooses the auth server name from the currently configured API server name.
 
@@ -704,11 +704,13 @@ def get_auth_server_name(host_override=None, port_override=None):
     if host_override is not None or port_override is not None:
         if host_override is None or port_override is None:
             raise exceptions.DXError("Both host and port must be specified if either is specified")
-        return 'http://' + host_override + ':' + str(port_override)
+        return protocol + '://' + host_override + ':' + str(port_override)
     elif APISERVER_HOST == 'stagingapi.dnanexus.com':
         return 'https://stagingauth.dnanexus.com'
     elif APISERVER_HOST == 'api.dnanexus.com':
         return 'https://auth.dnanexus.com'
+    elif APISERVER_HOST == 'api.cn.vstg.dnanexus.com':
+        return 'https://auth.cn.dnanexus.com:7001'
     elif APISERVER_HOST == "localhost" or APISERVER_HOST == "127.0.0.1":
         if "DX_AUTHSERVER_HOST" not in os.environ or "DX_AUTHSERVER_PORT" not in os.environ:
             err_msg = "Must set authserver env vars (DX_AUTHSERVER_HOST, DX_AUTHSERVER_PORT) if apiserver is {apiserver}."

--- a/src/python/dxpy/__init__.py
+++ b/src/python/dxpy/__init__.py
@@ -709,8 +709,10 @@ def get_auth_server_name(host_override=None, port_override=None, protocol='https
         return 'https://stagingauth.dnanexus.com'
     elif APISERVER_HOST == 'api.dnanexus.com':
         return 'https://auth.dnanexus.com'
-    elif APISERVER_HOST == 'api.cn.vstg.dnanexus.com':
-        return 'https://auth.cn.dnanexus.com:7001'
+    elif APISERVER_HOST == 'stagingapi.cn.dnanexus.com':
+        return 'https://stagingauth.cn.dnanexus.com:7001'
+    elif APISERVER_HOST == 'api.cn.dnanexus.com':
+        return 'https://auth.cn.dnanexus.com:8001'
     elif APISERVER_HOST == "localhost" or APISERVER_HOST == "127.0.0.1":
         if "DX_AUTHSERVER_HOST" not in os.environ or "DX_AUTHSERVER_PORT" not in os.environ:
             err_msg = "Must set authserver env vars (DX_AUTHSERVER_HOST, DX_AUTHSERVER_PORT) if apiserver is {apiserver}."


### PR DESCRIPTION
Made the following changes:
1. Bug fix for checking version of readline module.  pyreadline module does not have __doc__ variable, so need to check that it's not NONE before searching for libedit.
2. Adding ability to specify protocol to dx logout, just as you can for dx login.
3. Setting default protocol for authserver communication to https. Can be overriden by explicitly passing in a different protocol, but will no longer make assumptions based upon port.
4. Use the same get_auth_server_name helper function in dx login as we use in dx logout code.
5. Add support for China staging api and corresponding auth server to the get_auth_server_name helper function.