### PR TITLE
Escape file name with spaces for dx-unpack

### DIFF
--- a/bin/dx-unpack
+++ b/bin/dx-unpack
@@ -38,7 +38,7 @@ while [[ $# > 0 ]]; do
         output="$2"
         shift 2
     else
-        A="$A $1"
+        A="$A \"$1\""
         shift
     fi
 done

--- a/bin/dx-unpack
+++ b/bin/dx-unpack
@@ -38,7 +38,7 @@ while [[ $# > 0 ]]; do
         output="$2"
         shift 2
     else
-        A="$A \"$1\""
+        A="$A '${1//\'/\'\\\'\'}'"
         shift
     fi
 done

--- a/src/python/dxpy/utils/exec_utils.py
+++ b/src/python/dxpy/utils/exec_utils.py
@@ -23,6 +23,7 @@ from __future__ import print_function, unicode_literals, division, absolute_impo
 import os, sys, json, re, collections, logging, argparse, string, itertools, subprocess, tempfile
 from functools import wraps
 from collections import namedtuple
+import pipes
 
 import dxpy
 from ..compat import USING_PYTHON2, open
@@ -385,7 +386,7 @@ class DXExecDependencyInstaller(object):
         if bundle["id"].get("$dnanexus_link", "").startswith("file-"):
             self.log("Downloading bundled file {name}".format(**bundle))
             dxpy.download_dxfile(bundle["id"], bundle["name"])
-            self.run("dx-unpack '{}'".format(re.escape(bundle["name"])))
+            self.run("dx-unpack {}".format(pipes.quote(bundle["name"])))
         else:
             self.log('Skipping bundled dependency "{name}" because it does not refer to a file'.format(**bundle))
 

--- a/src/python/dxpy/utils/exec_utils.py
+++ b/src/python/dxpy/utils/exec_utils.py
@@ -385,7 +385,7 @@ class DXExecDependencyInstaller(object):
         if bundle["id"].get("$dnanexus_link", "").startswith("file-"):
             self.log("Downloading bundled file {name}".format(**bundle))
             dxpy.download_dxfile(bundle["id"], bundle["name"])
-            self.run("dx-unpack '{}'".format(bundle["name"]))
+            self.run("dx-unpack '{}'".format(re.escape(bundle["name"])))
         else:
             self.log('Skipping bundled dependency "{name}" because it does not refer to a file'.format(**bundle))
 

--- a/src/python/scripts/dx-fetch-bundled-depends
+++ b/src/python/scripts/dx-fetch-bundled-depends
@@ -20,7 +20,7 @@
 Downloads the contents of runSpec.bundledDepends of a job running in the execution environment.
 '''
 
-import os, sys, argparse, subprocess, re
+import os, sys, argparse, subprocess, pipes
 import dxpy
 
 parser = argparse.ArgumentParser(description=__doc__)
@@ -41,4 +41,4 @@ if 'DX_JOB_ID' in os.environ:
             if dep['id']['$dnanexus_link'].startswith('file-'):
                 print "*** Downloading bundled file", dep['name']
                 dxpy.download_dxfile(dep['id'], dep['name'])
-                subprocess.check_call(['dx-unpack', re.escape(dep['name'])])
+                subprocess.check_call(['dx-unpack', pipes.quote(dep['name'])])

--- a/src/python/scripts/dx-fetch-bundled-depends
+++ b/src/python/scripts/dx-fetch-bundled-depends
@@ -20,7 +20,7 @@
 Downloads the contents of runSpec.bundledDepends of a job running in the execution environment.
 '''
 
-import os, sys, argparse, subprocess
+import os, sys, argparse, subprocess, re
 import dxpy
 
 parser = argparse.ArgumentParser(description=__doc__)
@@ -41,4 +41,4 @@ if 'DX_JOB_ID' in os.environ:
             if dep['id']['$dnanexus_link'].startswith('file-'):
                 print "*** Downloading bundled file", dep['name']
                 dxpy.download_dxfile(dep['id'], dep['name'])
-                subprocess.check_call(['dx-unpack', dep['name']])
+                subprocess.check_call(['dx-unpack', re.escape(dep['name'])])

--- a/src/python/scripts/dx-fetch-bundled-depends
+++ b/src/python/scripts/dx-fetch-bundled-depends
@@ -20,7 +20,7 @@
 Downloads the contents of runSpec.bundledDepends of a job running in the execution environment.
 '''
 
-import os, sys, argparse, subprocess, pipes
+import os, sys, argparse, subprocess
 import dxpy
 
 parser = argparse.ArgumentParser(description=__doc__)
@@ -41,4 +41,4 @@ if 'DX_JOB_ID' in os.environ:
             if dep['id']['$dnanexus_link'].startswith('file-'):
                 print "*** Downloading bundled file", dep['name']
                 dxpy.download_dxfile(dep['id'], dep['name'])
-                subprocess.check_call(['dx-unpack', pipes.quote(dep['name'])])
+                subprocess.check_call(['dx-unpack', dep['name']])

--- a/src/python/test/test_dxasset.py
+++ b/src/python/test/test_dxasset.py
@@ -200,7 +200,7 @@ class TestDXBuildAsset(DXTestCase):
     @unittest.skipUnless(testutil.TEST_RUN_JOBS, 'skipping test that would run jobs')
     def test_build_and_use_asset(self):
         asset_spec = {
-            "name": "asset_library_name",
+            "name": "asset library name with space",
             "title": "A human readable name",
             "description": " A detailed description about the asset",
             "version": "0.0.1",

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -2762,6 +2762,17 @@ def main():
         applet_job.wait_on_done()
         self.assertEqual(applet_job.describe()['state'], 'done')
 
+    def test_bundledDepends_name_with_specialChars_locally(self):
+        # upload a tar.gz file with spaces, quotes and escape chars in its name
+        bundle_name = "test 'bundle' \"with\" \"$@#^&%()[]{}\" spaces.tar.gz"
+        bundle_tmp_dir = tempfile.mkdtemp()
+        os.mkdir(os.path.join(bundle_tmp_dir, "a"))
+        with open(os.path.join(bundle_tmp_dir, 'a', 'foo.txt'), 'w') as file_in_bundle:
+            file_in_bundle.write('foo\n')
+        subprocess.check_call(['tar', '-czf', os.path.join(bundle_tmp_dir, bundle_name),
+                               '-C', os.path.join(bundle_tmp_dir, 'a'), '.'])
+        subprocess.check_call(["dx-unpack", os.path.join(bundle_tmp_dir, bundle_name)])
+
 
 class TestDXClientWorkflow(DXTestCase):
     default_inst_type = "mem2_hdd2_x2"

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -2762,7 +2762,7 @@ def main():
         applet_job.wait_on_done()
         self.assertEqual(applet_job.describe()['state'], 'done')
 
-    def test_bundledDepends_name_with_specialChars_locally(self):
+    def test_bundledDepends_name_with_special_chars_locally(self):
         # upload a tar.gz file with spaces, quotes and escape chars in its name
         bundle_name = "test 'bundle' \"with\" \"$@#^&%()[]{}\" spaces.tar.gz"
         bundle_tmp_dir = tempfile.mkdtemp()
@@ -2772,6 +2772,7 @@ def main():
         subprocess.check_call(['tar', '-czf', os.path.join(bundle_tmp_dir, bundle_name),
                                '-C', os.path.join(bundle_tmp_dir, 'a'), '.'])
         subprocess.check_call(["dx-unpack", os.path.join(bundle_tmp_dir, bundle_name)])
+        os.remove(os.path.join(os.getcwd(), 'foo.txt'))
 
 
 class TestDXClientWorkflow(DXTestCase):

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -2732,8 +2732,15 @@ def main():
     def test_bundledDepends_name_with_whitespaces(self):
         # upload a tar.gz file with spaces in its name
         bundle_name = "test bundle with spaces.tar.gz"
-        bundle_file = dxpy.upload_string("xxyyzz", project=self.project, wait_on_close=True,
-                                         name=bundle_name)
+        bundle_tmp_dir = tempfile.mkdtemp()
+        os.mkdir(os.path.join(bundle_tmp_dir, "a"))
+        with open(os.path.join(bundle_tmp_dir, 'a', 'foo.txt'), 'w') as file_in_bundle:
+            file_in_bundle.write('foo\n')
+        subprocess.check_call(['tar', '-czf', os.path.join(bundle_tmp_dir, bundle_name),
+                               '-C', os.path.join(bundle_tmp_dir, 'a'), '.'])
+        bundle_file = dxpy.upload_local_file(filename=os.path.join(bundle_tmp_dir, bundle_name),
+                                             project=self.project,
+                                             wait_on_close=True)
 
         app_spec = {
                     "project": self.project,


### PR DESCRIPTION
@psung please review.

If 'bundledDepends' refers to a file name containing un-escaped spaces, dx-unpack fails as it reads each string in the file name as an argument. The error looks like as follows when a file name is "my asset test.tar.gz":

'
_Downloading bundled file my asset test.tar.gz
>>> Unpacking my to /
 *   dx_helpers.sh, line 20: my does not exist
Traceback (most recent call last):
  File "/usr/bin/dx-prepare-exec-env", line 45, in <module>
    installer.install()
  File "/usr/share/dnanexus/lib/python2.7/site-packages/dxpy/utils/exec_utils.py", line 395, in install
    self._install_dep_bundle(dep_group["deps"][0])
  File "/usr/share/dnanexus/lib/python2.7/site-packages/dxpy/utils/exec_utils.py", line 388, in _install_dep_bundle
    self.run("dx-unpack '{}'".format(bundle["name"]))
  File "/usr/share/dnanexus/lib/python2.7/site-packages/dxpy/utils/exec_utils.py", line 368, in run
    subprocess.check_call(cmd, shell=True, stdout=log_fh, stderr=log_fh)
  File "/usr/lib/python2.7/subprocess.py", line 511, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command 'dx-unpack 'my asset test.tar.gz'' returned non-zero exit status 1_
'

So escaped the file name in subprocess call.
