### PR TITLE
PTFM-15653 Paginated search Java API update

### DIFF
--- a/src/java/src/main/java/com/dnanexus/DXSearch.java
+++ b/src/java/src/main/java/com/dnanexus/DXSearch.java
@@ -1087,6 +1087,9 @@ public final class DXSearch {
             this.response = DXAPI.systemFindDataObjects(request, FindDataObjectsResponse.class, env);
         }
 
+        /**
+         * Returns an amount of items on findDataObjects results page
+         */
         int size() {
             return response.results.size();
         }

--- a/src/java/src/main/java/com/dnanexus/DXSearch.java
+++ b/src/java/src/main/java/com/dnanexus/DXSearch.java
@@ -2214,7 +2214,6 @@ public final class DXSearch {
         /**
          * Iterator implementation for findDataObjects results page items.
          */
-        @VisibleForTesting
         private class ResultIterator implements Iterator<T> {
 
             int nextElementIndex;
@@ -2280,8 +2279,12 @@ public final class DXSearch {
             this.response = DXAPI.systemFindDataObjects(request, FindDataObjectsResponse.class, env);
         }
 
+        /**
+         * Returns an object that can be used in a later call to {@code getSubsequentPage()}
+         * to continue retrieving results where this page leaves off.
+         */
         public JsonNode getNext() {
-            return response.next;
+            return response.next.deepCopy();
         }
 
         public boolean hasNext() {

--- a/src/java/src/main/java/com/dnanexus/DXSearch.java
+++ b/src/java/src/main/java/com/dnanexus/DXSearch.java
@@ -1013,7 +1013,7 @@ public final class DXSearch {
      * @param <T> data object class to be returned
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class SearchPage<T extends DXDataObject> implements Iterator<SearchPage<T>>, Iterable<T> {
+    public static class SearchPage<T extends DXDataObject> implements Iterable<T> {
             private final FindDataObjectsRequest request;
         private final String classConstraint;
         private final DXEnvironment env;
@@ -1097,20 +1097,13 @@ public final class DXSearch {
             return new ResultIterator();
         }
 
-        @Override
         public boolean hasNext() {
             return response.next != null && !response.next.isNull();
         }
 
-        @Override
         public SearchPage<T> next() {
             FindDataObjectsRequest nextRequest = new FindDataObjectsRequest(this.request, response.next, pageSize);
             return new SearchPage(nextRequest, classConstraint, env, pageSize);
-        }
-
-        @Override
-        public void remove() {
-            throw new UnsupportedOperationException();
         }
     }
 

--- a/src/java/src/main/java/com/dnanexus/DXSearch.java
+++ b/src/java/src/main/java/com/dnanexus/DXSearch.java
@@ -35,6 +35,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.collect.AbstractIterator;
 
 /**
  * Utility class containing methods for searching for platform objects by various criteria.
@@ -900,33 +901,6 @@ public final class DXSearch {
          * The page subset of data objects that matched a {@code findDataObjects} query.
          */
         public class Page implements Iterable<T> {
-            /**
-             * Iterator implementation for {@code findDataObjects} results page items.
-             */
-            private class PageIterator implements Iterator<T> {
-
-                int nextElementIndex;
-
-                private PageIterator() {
-                    this.nextElementIndex = 0;
-                }
-
-                @Override
-                public boolean hasNext() {
-                    return nextElementIndex < response.results.size();
-                }
-
-                @Override
-                public T next() {
-                    return getDataObjectInstanceFromResult(response.results.get(nextElementIndex++));
-                }
-
-                @Override
-                public void remove() {
-                    throw new UnsupportedOperationException();
-                }
-            }
-
             private final FindDataObjectsResponse response;
 
             /**
@@ -961,11 +935,19 @@ public final class DXSearch {
             @Override
             public Iterator<T> iterator()
             {
-                return new PageIterator();
+                return new AbstractIterator<T>() {
+                    private int nextElementIndex = 0;
+                    protected T computeNext() {
+                        if (nextElementIndex >= response.results.size()) {
+                            return endOfData();
+                        }
+                        return getDataObjectInstanceFromResult(response.results.get(nextElementIndex++));
+                    }
+                };
             }
 
             /**
-             * Returns an amount of items on findDataObjects results page
+             * Returns an amount of items on {@code findDataObjects} results page
              */
             public int size() {
                 return response.results.size();

--- a/src/java/src/main/java/com/dnanexus/DXSearch.java
+++ b/src/java/src/main/java/com/dnanexus/DXSearch.java
@@ -321,6 +321,9 @@ public final class DXSearch {
          * @return Iterable result set page
          */
         public SearchPage<T> getFirstPage(int pageSize) {
+            if (pageSize <= 0) {
+                throw new IllegalArgumentException("Invalid page size - should be positive");
+            }
             return new SearchPage<T>(this.buildRequestHash(pageSize, null), this.classConstraint, this.env);
         }
 
@@ -333,6 +336,12 @@ public final class DXSearch {
          * @return Iterable result set page
          */
         public SearchPage<T> getSubsequentPage(int pageSize, JsonNode starting) {
+            if (pageSize <= 0) {
+                throw new IllegalArgumentException("Invalid page size - should be positive");
+            }
+            if (starting == null) {
+                throw new IllegalArgumentException("'starting' parameter is null");
+            }
             return new SearchPage<T>(this.buildRequestHash(pageSize, starting), this.classConstraint, this.env);
         }
 
@@ -1024,7 +1033,6 @@ public final class DXSearch {
      *
      * @param <T> data object class to be returned
      */
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class SearchPage<T extends DXDataObject> implements Iterable<T> {
         private final String classConstraint;
         private final DXEnvironment env;
@@ -1036,20 +1044,20 @@ public final class DXSearch {
         @VisibleForTesting
         private class ResultIterator implements Iterator<T> {
 
-            int lastElementIndex;
+            int nextElementIndex;
 
             private ResultIterator() {
-                this.lastElementIndex = -1;
+                this.nextElementIndex = 0;
             }
 
             @Override
             public boolean hasNext() {
-                return lastElementIndex < (response.results.size() - 1);
+                return nextElementIndex < response.results.size();
             }
 
             @Override
             public T next() {
-                return getDataObjectInstanceFromResult(response.results.get(++lastElementIndex));
+                return getDataObjectInstanceFromResult(response.results.get(nextElementIndex++));
             }
 
             @Override
@@ -1098,7 +1106,7 @@ public final class DXSearch {
         /**
          * Returns an amount of items on findDataObjects results page
          */
-        int size() {
+        public int size() {
             return response.results.size();
         }
 

--- a/src/java/src/test/java/com/dnanexus/DXSearchTest.java
+++ b/src/java/src/test/java/com/dnanexus/DXSearchTest.java
@@ -331,8 +331,9 @@ public class DXSearchTest {
             outputRecordIds.add(record.getId());
         }
 
-        DXSearch.SearchPage<DXRecord> page = DXSearch.findDataObjects().inProject(testProject).nameMatchesGlob("foo*")
-                .withClassRecord().getFirstPage(3);
+        DXSearch.FindDataObjectsResult<DXRecord> result = DXSearch.findDataObjects().inProject(testProject).nameMatchesGlob("foo*")
+                .withClassRecord().execute();
+        DXSearch.FindDataObjectsResult<DXRecord>.Page page = result.getFirstPage(3);
         Assert.assertEquals(3, page.size());
         Assert.assertEquals(true, page.hasNext());
 
@@ -344,8 +345,7 @@ public class DXSearchTest {
         }
         Assert.assertEquals(false, iter.hasNext());
 
-        page = DXSearch.findDataObjects().inProject(testProject).nameMatchesGlob("foo*")
-                .withClassRecord().getSubsequentPage(page.getNext(), 3);
+        page = result.getSubsequentPage(page.getNext(), 3);
         Assert.assertEquals(3, page.size());
         Assert.assertEquals(true, page.hasNext());
 
@@ -357,8 +357,7 @@ public class DXSearchTest {
         }
         Assert.assertEquals(false, iter.hasNext());
 
-        page = DXSearch.findDataObjects().inProject(testProject).nameMatchesGlob("foo*")
-                .withClassRecord().getSubsequentPage(page.getNext(), 3);
+        page = result.getSubsequentPage(page.getNext(), 3);
         Assert.assertEquals(2, page.size());
         Assert.assertEquals(false, page.hasNext());
 
@@ -371,8 +370,7 @@ public class DXSearchTest {
         Assert.assertEquals(false, iter.hasNext());
 
         // Checking when the requested page size is greater than amount of items
-        page = DXSearch.findDataObjects().inProject(testProject).nameMatchesGlob("foo*")
-                .withClassRecord().getFirstPage(100);
+        page = result.getFirstPage(100);
         Assert.assertEquals(8, page.size());
         Assert.assertEquals(false, page.hasNext());
         int i = 0;
@@ -382,33 +380,28 @@ public class DXSearchTest {
 
         // Checking invalid arguments
         try {
-            DXSearch.findDataObjects().inProject(testProject).nameMatchesGlob("foo*")
-                    .withClassRecord().getFirstPage(0);
+            result.getFirstPage(0);
             Assert.fail();
         } catch (IllegalArgumentException e) {
         }
         try {
-            DXSearch.findDataObjects().inProject(testProject).nameMatchesGlob("foo*")
-                    .withClassRecord().getFirstPage(-2);
+            result.getFirstPage(-2);
             Assert.fail();
         } catch (IllegalArgumentException e) {
         }
         ObjectMapper mapper = new ObjectMapper();
         try {
-            DXSearch.findDataObjects().inProject(testProject).nameMatchesGlob("foo*")
-                    .withClassRecord().getSubsequentPage(mapper.createObjectNode(), 0);
+            result.getSubsequentPage(mapper.createObjectNode(), 0);
             Assert.fail();
         } catch (IllegalArgumentException e) {
         }
         try {
-            DXSearch.findDataObjects().inProject(testProject).nameMatchesGlob("foo*")
-                    .withClassRecord().getSubsequentPage(mapper.createObjectNode(), -1);
+            result.getSubsequentPage(mapper.createObjectNode(), -1);
             Assert.fail();
         } catch (IllegalArgumentException e) {
         }
         try {
-            DXSearch.findDataObjects().inProject(testProject).nameMatchesGlob("foo*")
-                    .withClassRecord().getSubsequentPage(null, 10);
+            result.getSubsequentPage(null, 10);
             Assert.fail();
         } catch (NullPointerException e) {
         }

--- a/src/java/src/test/java/com/dnanexus/DXSearchTest.java
+++ b/src/java/src/test/java/com/dnanexus/DXSearchTest.java
@@ -312,14 +312,10 @@ public class DXSearchTest {
      */
     @Test
     public void testFindDataObjectsPaginated() {
-        List<DXRecord> records = Lists.newArrayList();
-        Set<String> recordIds = Sets.newHashSet();
         for (int i = 0; i < 8; ++i) {
             DXRecord record =
                     DXRecord.newRecord().setProject(testProject)
                             .setName("foo" + Integer.toString(i)).build();
-            records.add(record);
-            recordIds.add(record.getId());
         }
         List<DXRecord> outputRecords =
                 DXSearch.findDataObjects().inProject(testProject).nameMatchesGlob("foo*")

--- a/src/java/src/test/java/com/dnanexus/DXSearchTest.java
+++ b/src/java/src/test/java/com/dnanexus/DXSearchTest.java
@@ -672,6 +672,39 @@ public class DXSearchTest {
         for (DXRecord r : page) {
             Assert.assertEquals(outputRecords.get(i++).getId(), r.getId());
         }
+
+        // Checking invalid arguments
+        try {
+            DXSearch.findDataObjects().inProject(testProject).nameMatchesGlob("foo*")
+                    .withClassRecord().getFirstPage(0);
+            Assert.fail();
+        } catch (IllegalArgumentException e) {
+        }
+        try {
+            DXSearch.findDataObjects().inProject(testProject).nameMatchesGlob("foo*")
+                    .withClassRecord().getFirstPage(-2);
+            Assert.fail();
+        } catch (IllegalArgumentException e) {
+        }
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            DXSearch.findDataObjects().inProject(testProject).nameMatchesGlob("foo*")
+                    .withClassRecord().getSubsequentPage(0, mapper.createObjectNode());
+            Assert.fail();
+        } catch (IllegalArgumentException e) {
+        }
+        try {
+            DXSearch.findDataObjects().inProject(testProject).nameMatchesGlob("foo*")
+                    .withClassRecord().getSubsequentPage(-1, mapper.createObjectNode());
+            Assert.fail();
+        } catch (IllegalArgumentException e) {
+        }
+        try {
+            DXSearch.findDataObjects().inProject(testProject).nameMatchesGlob("foo*")
+                    .withClassRecord().getSubsequentPage(10, null);
+            Assert.fail();
+        } catch (IllegalArgumentException e) {
+        }
     }
 
     /**

--- a/src/java/src/test/java/com/dnanexus/DXSearchTest.java
+++ b/src/java/src/test/java/com/dnanexus/DXSearchTest.java
@@ -625,7 +625,7 @@ public class DXSearchTest {
         }
 
         DXSearch.SearchPage<DXRecord> page = DXSearch.findDataObjects().inProject(testProject).nameMatchesGlob("foo*")
-                .withClassRecord().getPage(3);
+                .withClassRecord().getFirstPage(3);
         Assert.assertEquals(3, page.size());
         Assert.assertEquals(true, page.hasNext());
 
@@ -637,7 +637,8 @@ public class DXSearchTest {
         }
         Assert.assertEquals(false, iter.hasNext());
 
-        page = page.next();
+        page = DXSearch.findDataObjects().inProject(testProject).nameMatchesGlob("foo*")
+                .withClassRecord().getSubsequentPage(3, page.getNext());
         Assert.assertEquals(3, page.size());
         Assert.assertEquals(true, page.hasNext());
 
@@ -649,7 +650,8 @@ public class DXSearchTest {
         }
         Assert.assertEquals(false, iter.hasNext());
 
-        page = page.next();
+        page = DXSearch.findDataObjects().inProject(testProject).nameMatchesGlob("foo*")
+                .withClassRecord().getSubsequentPage(3, page.getNext());
         Assert.assertEquals(2, page.size());
         Assert.assertEquals(false, page.hasNext());
 
@@ -663,7 +665,7 @@ public class DXSearchTest {
 
         // Checking when the requested page size is greater than amount of items
         page = DXSearch.findDataObjects().inProject(testProject).nameMatchesGlob("foo*")
-                .withClassRecord().getPage(100);
+                .withClassRecord().getFirstPage(100);
         Assert.assertEquals(8, page.size());
         Assert.assertEquals(false, page.hasNext());
         int i = 0;


### PR DESCRIPTION
Hello @psung ,

I have implemented your proposal. I added just one new `public SearchPage<T> getPage(int pageSize)` method to `DXSearch.FindDataObjectsRequestBuilder<T>` class and made iterations to be done using 'public SearchPage<T> next()' method in `DXSearch.SearchPage<T>` class.

That is because this kind of API looks similar to `Iterator<E>`, but I'm not sure about that - it's just a proposal. If you are not comfortable with that - inform me, please, and I would update this PR. It looks like a 5-10 min change...

P.S. I tried to make `DXSearch.SearchPage<T>` to implement `Iterator<DXSearch.SearchPage<T>>` interface, but in that case iterator and actual value are represented by the same object and I do not know is it good or bad.

```
// Iterating current page's items
for (DXRecord r : page) {
    ...
}
// Switching to the next page
if (page.hasNext()) {
    page = page.next(); // <- I suspect this is not compatible with 'Iterator<E>' Java concept
}
```

All the best,
Ilya