### PR TITLE
Fixing label for file size

### DIFF
--- a/src/python/dxpy/bindings/dxfile.py
+++ b/src/python/dxpy/bindings/dxfile.py
@@ -70,13 +70,13 @@ def _readable_part_size(num_bytes):
     if B < KB:
         return '{0} {1}'.format(B, 'bytes' if B != 1 else 'byte')
     elif KB <= B < MB:
-        return '{0:.2f} KB'.format(B/KB)
+        return '{0:.2f} KiB'.format(B/KB)
     elif MB <= B < GB:
-        return '{0:.2f} MB'.format(B/MB)
+        return '{0:.2f} MiB'.format(B/MB)
     elif GB <= B < TB:
-        return '{0:.2f} GB'.format(B/GB)
+        return '{0:.2f} GiB'.format(B/GB)
     elif TB <= B:
-        return '{0:.2f} TB'.format(B/TB)
+        return '{0:.2f} TiB'.format(B/TB)
 
 
 def _get_write_buf_size(buffer_size_hint, file_upload_params, expected_file_size, file_is_mmapd=False):

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -272,9 +272,9 @@ class TestDXFileFunctions(unittest.TestCase):
         self.assertEqual(dxpy.dxfile._readable_part_size(0), "0 bytes")
         self.assertEqual(dxpy.dxfile._readable_part_size(1), "1 byte")
         self.assertEqual(dxpy.dxfile._readable_part_size(2), "2 bytes")
-        self.assertEqual(dxpy.dxfile._readable_part_size(2.5 * 1024), "2.50 KB")
-        self.assertEqual(dxpy.dxfile._readable_part_size(1024 * 1024), "1.00 MB")
-        self.assertEqual(dxpy.dxfile._readable_part_size(31415926535), "29.26 GB")
+        self.assertEqual(dxpy.dxfile._readable_part_size(2.5 * 1024), "2.50 KiB")
+        self.assertEqual(dxpy.dxfile._readable_part_size(1024 * 1024), "1.00 MiB")
+        self.assertEqual(dxpy.dxfile._readable_part_size(31415926535), "29.26 GiB")
 
     def test_get_buffer_size(self):
         amazon = {


### PR DESCRIPTION
We were erroneously reporting KB, MB, GB, and TB when we really meant
KiB, MiB, GiB, and TiB.