### PR TITLE
Attempt to pre-load download url cache

### DIFF
--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -255,6 +255,11 @@ def _download_dxfile(dxid, filename, part_retry_counter,
 
         try:
             # Main loop. In parallel: download chunks, verify them, and write them to disk.
+            # We'll make a first request for a download url so that if we need to go through
+            # a proxy url, the cache will be pre-loaded when we use the threadpool to actually
+            # download the data.
+            url, headers = dxfile.get_download_url(project=project, **kwargs)
+            
             cur_part, got_bytes, hasher = None, None, None
             for chunk_part, chunk_data in response_iterator(chunk_requests(), dxfile._http_threadpool):
                 if chunk_part != cur_part:


### PR DESCRIPTION
When downloading a file 8 chunks are downloaded in parallel.  Because all of these download threads are launched simultaneously, when they each go to get a download url, they have a cache-miss, and so 8 proxyDownload requests are made where only 1 should be necessary.  This is my attempt to fix this by requesting a download url prior to the actual downloading of the individual chunks.  This first request is just to pre-load the cache and no data is actually downloaded.  Then the threadpool is used to actually download chunks.