### PR TITLE
Export upload file buffer size to cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,9 @@ dxR.Rcheck
 /bin/dx-download-all-inputs
 /bin/dx-download-input
 /bin/dx-upload-all-outputs
+/bin/docker2aci
+/bin/dx-docker
+/bin/proot
 /src/ua/dist/ua
 /src/ua/dnanexus-upload-agent-*-linux.tar.gz
 /src/ua/dnanexus-upload-agent-*-linux

--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -350,7 +350,7 @@ def upload_local_file(filename=None, file=None, media_type=None, keep_open=False
 
         # Use 'a' mode because we will be responsible for closing the file
         # ourselves later (if requested).
-        handler = new_dxfile(mode='a', media_type=media_type, write_buffer_size=dxfile.DEFAULT_BUFFER_SIZE,
+        handler = new_dxfile(mode='a', media_type=media_type,
                              expected_file_size=file_size, file_is_mmapd=file_is_mmapd, **creation_kwargs)
 
     # For subsequent API calls, don't supply the dataobject metadata

--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -283,7 +283,7 @@ def _download_dxfile(dxid, filename, part_retry_counter,
 
         return True
 
-def upload_local_file(filename=None, file=None, media_type=None, keep_open=False,
+def upload_local_file(filename=None, file=None, media_type=None, keep_open=False, write_buffer_size=None,
                       wait_on_close=False, use_existing_dxfile=None, show_progress=False, **kwargs):
     '''
     :param filename: Local filename
@@ -294,6 +294,8 @@ def upload_local_file(filename=None, file=None, media_type=None, keep_open=False
     :type media_type: string
     :param keep_open: If False, closes the file after uploading
     :type keep_open: boolean
+    :param write_buffer_size: Buffer size to use for upload
+    :type write_buffer_size: int
     :param wait_on_close: If True, waits for the file to close
     :type wait_on_close: boolean
     :param use_existing_dxfile: Instead of creating a new file object, upload to the specified file
@@ -330,11 +332,8 @@ def upload_local_file(filename=None, file=None, media_type=None, keep_open=False
 
     file_is_mmapd = hasattr(fd, "fileno")
 
-    if 'write_buffer_size' in kwargs and kwargs['write_buffer_size'] is not None:
-        buf_size=kwargs['write_buffer_size']
-    else:
-        buf_size=dxfile.DEFAULT_BUFFER_SIZE
-    del kwargs['write_buffer_size']
+    if write_buffer_size is None:
+        write_buffer_size=dxfile.DEFAULT_BUFFER_SIZE
 
     if use_existing_dxfile:
         handler = use_existing_dxfile
@@ -356,7 +355,7 @@ def upload_local_file(filename=None, file=None, media_type=None, keep_open=False
 
         # Use 'a' mode because we will be responsible for closing the file
         # ourselves later (if requested).
-        handler = new_dxfile(mode='a', media_type=media_type, write_buffer_size=buf_size,
+        handler = new_dxfile(mode='a', media_type=media_type, write_buffer_size=write_buffer_size,
                              expected_file_size=file_size, file_is_mmapd=file_is_mmapd, **creation_kwargs)
 
     # For subsequent API calls, don't supply the dataobject metadata

--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -288,8 +288,9 @@ def _download_dxfile(dxid, filename, part_retry_counter,
 
         return True
 
-def upload_local_file(filename=None, file=None, media_type=None, keep_open=False, write_buffer_size=None,
-                      wait_on_close=False, use_existing_dxfile=None, show_progress=False, **kwargs):
+def upload_local_file(filename=None, file=None, media_type=None, keep_open=False,
+                      wait_on_close=False, use_existing_dxfile=None, show_progress=False,
+                      write_buffer_size=None, **kwargs):
     '''
     :param filename: Local filename
     :type filename: string

--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -330,6 +330,12 @@ def upload_local_file(filename=None, file=None, media_type=None, keep_open=False
 
     file_is_mmapd = hasattr(fd, "fileno")
 
+    if 'write_buffer_size' in kwargs:
+        buf_size=kwargs['write_buffer_size']
+        del kwargs['write_buffer_size']
+    else:
+        buf_size=dxfile.DEFAULT_BUFFER_SIZE
+
     if use_existing_dxfile:
         handler = use_existing_dxfile
     else:
@@ -350,7 +356,7 @@ def upload_local_file(filename=None, file=None, media_type=None, keep_open=False
 
         # Use 'a' mode because we will be responsible for closing the file
         # ourselves later (if requested).
-        handler = new_dxfile(mode='a', media_type=media_type,
+        handler = new_dxfile(mode='a', media_type=media_type, write_buffer_size=buf_size,
                              expected_file_size=file_size, file_is_mmapd=file_is_mmapd, **creation_kwargs)
 
     # For subsequent API calls, don't supply the dataobject metadata

--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -330,7 +330,7 @@ def upload_local_file(filename=None, file=None, media_type=None, keep_open=False
 
     file_is_mmapd = hasattr(fd, "fileno")
 
-    if 'write_buffer_size' in kwargs:
+    if 'write_buffer_size' in kwargs and kwargs['write_buffer_size'] is not None:
         buf_size=kwargs['write_buffer_size']
         del kwargs['write_buffer_size']
     else:

--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -332,9 +332,9 @@ def upload_local_file(filename=None, file=None, media_type=None, keep_open=False
 
     if 'write_buffer_size' in kwargs and kwargs['write_buffer_size'] is not None:
         buf_size=kwargs['write_buffer_size']
-        del kwargs['write_buffer_size']
     else:
         buf_size=dxfile.DEFAULT_BUFFER_SIZE
+    del kwargs['write_buffer_size']
 
     if use_existing_dxfile:
         handler = use_existing_dxfile

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -1958,7 +1958,7 @@ def upload_one(args):
             if args.write_buffer_size is None:
                 write_buffer_size = dxfile.DEFAULT_BUFFER_SIZE
             else:
-                write_buffer_size = args.write_buffer_size
+                write_buffer_size = int(args.write_buffer_size)
             dxfile = dxpy.upload_local_file(filename=(None if args.filename == '-' else args.filename),
                                             file=(sys.stdin.buffer if args.filename == '-' else None),
                                             name=name,
@@ -1971,7 +1971,7 @@ def upload_one(args):
                                             folder=folder,
                                             parents=args.parents,
                                             show_progress=args.show_progress,
-                                            write_buffer_size = write_buffer_size)
+                                            write_buffer_size=write_buffer_size)
             if args.wait:
                 dxfile._wait_on_close()
             if args.brief:

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -33,7 +33,7 @@ wrap_stdio_in_codecs()
 decode_command_line_args()
 
 import dxpy
-from ..bindings.dxfile import DEFAULT_BUFFER_SIZE
+
 from ..cli import try_call, prompt_for_yn, INTERACTIVE_CLI
 from ..cli import workflow as workflow_cli
 from ..cli.cp import cp
@@ -1955,13 +1955,10 @@ def upload_one(args):
                 upload_one(sub_args)
     else:
         try:
-
-            if args.write_buffer_size is None:
-                write_buffer_size = DEFAULT_BUFFER_SIZE
-            else:
-                write_buffer_size = int(args.write_buffer_size)
             dxfile = dxpy.upload_local_file(filename=(None if args.filename == '-' else args.filename),
                                             file=(sys.stdin.buffer if args.filename == '-' else None),
+                                            write_buffer_size=(int(args.write_buffer_size) if args.write_buffer_size is not None
+                                                               else None),
                                             name=name,
                                             tags=args.tags,
                                             types=args.types,
@@ -1971,8 +1968,7 @@ def upload_one(args):
                                             details=args.details,
                                             folder=folder,
                                             parents=args.parents,
-                                            show_progress=args.show_progress,
-                                            write_buffer_size=write_buffer_size)
+                                            show_progress=args.show_progress)
             if args.wait:
                 dxfile._wait_on_close()
             if args.brief:

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -3744,7 +3744,7 @@ parser_upload.add_argument('-r', '--recursive', help='Upload directories recursi
 parser_upload.add_argument('--wait', help='Wait until the file has finished closing', action='store_true')
 parser_upload.add_argument('--no-progress', help='Do not show a progress bar', dest='show_progress',
                            action='store_false', default=sys.stderr.isatty())
-parser_upload.add_argument('--buffer-size', help='Set the write buffer size', dest='write_buffer_size')
+parser_upload.add_argument('--buffer-size', help='Set the write buffer size (in bytes)', dest='write_buffer_size')
 parser_upload.set_defaults(func=upload, mute=False)
 register_parser(parser_upload, categories='data')
 

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -1954,6 +1954,11 @@ def upload_one(args):
                 upload_one(sub_args)
     else:
         try:
+
+            if args.write_buffer_size is None:
+                write_buffer_size = dxfile.DEFAULT_BUFFER_SIZE
+            else:
+                write_buffer_size = args.write_buffer_size
             dxfile = dxpy.upload_local_file(filename=(None if args.filename == '-' else args.filename),
                                             file=(sys.stdin.buffer if args.filename == '-' else None),
                                             name=name,
@@ -1965,7 +1970,8 @@ def upload_one(args):
                                             details=args.details,
                                             folder=folder,
                                             parents=args.parents,
-                                            show_progress=args.show_progress)
+                                            show_progress=args.show_progress,
+                                            write_buffer_size = write_buffer_size)
             if args.wait:
                 dxfile._wait_on_close()
             if args.brief:
@@ -3741,6 +3747,7 @@ parser_upload.add_argument('-r', '--recursive', help='Upload directories recursi
 parser_upload.add_argument('--wait', help='Wait until the file has finished closing', action='store_true')
 parser_upload.add_argument('--no-progress', help='Do not show a progress bar', dest='show_progress',
                            action='store_false', default=sys.stderr.isatty())
+parser_upload.add_argument('--buffer-size', help='Set the write buffer size', dest='write_buffer_size')
 parser_upload.set_defaults(func=upload, mute=False)
 register_parser(parser_upload, categories='data')
 

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -33,6 +33,7 @@ wrap_stdio_in_codecs()
 decode_command_line_args()
 
 import dxpy
+from ..bindings.dxfile import DEFAULT_BUFFER_SIZE
 from ..cli import try_call, prompt_for_yn, INTERACTIVE_CLI
 from ..cli import workflow as workflow_cli
 from ..cli.cp import cp
@@ -1956,7 +1957,7 @@ def upload_one(args):
         try:
 
             if args.write_buffer_size is None:
-                write_buffer_size = dxfile.DEFAULT_BUFFER_SIZE
+                write_buffer_size = DEFAULT_BUFFER_SIZE
             else:
                 write_buffer_size = int(args.write_buffer_size)
             dxfile = dxpy.upload_local_file(filename=(None if args.filename == '-' else args.filename),

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -1957,8 +1957,8 @@ def upload_one(args):
         try:
             dxfile = dxpy.upload_local_file(filename=(None if args.filename == '-' else args.filename),
                                             file=(sys.stdin.buffer if args.filename == '-' else None),
-                                            write_buffer_size=(int(args.write_buffer_size) if args.write_buffer_size is not None
-                                                               else None),
+                                            write_buffer_size=(None if args.write_buffer_size is None
+                                                               else int(args.write_buffer_size)),
                                             name=name,
                                             tags=args.tags,
                                             types=args.types,


### PR DESCRIPTION
Allow performing a dx upload, while setting the buffer chunk size. This should significantly reduce the overhead on the backend database when uploading large files. This is a situation we run into while executing parallel GLnexus runs.  