### PR TITLE
Adding bulk data object describe to dxpy.describe

### DIFF
--- a/src/python/dxpy/bindings/dxdataobject_functions.py
+++ b/src/python/dxpy/bindings/dxdataobject_functions.py
@@ -146,7 +146,8 @@ def get_handler(id_or_link, project=None):
 
 def describe(id_or_link, **kwargs):
     '''
-    :param id_or_link: String containing an object ID or dict containing a DXLink
+    :param id_or_link: String containing an object ID or dict containing a DXLink,
+                       or a list of object ID's or dict's containing a DXLink.
 
     Given an object ID, calls :meth:`~dxpy.bindings.DXDataObject.describe` on the object.
 
@@ -154,8 +155,23 @@ def describe(id_or_link, **kwargs):
 
         describe("file-1234")
     '''
-    handler = get_handler(id_or_link)
-    return handler.describe(**kwargs)
+    # If this is a list, extract the ids.
+    if isinstance(id_or_link, list):
+        links = []
+        for link in id_or_link:
+            # If this entry is a dxlink, then get the id.
+            if is_dxlink(link):
+                # Guaranteed by is_dxlink that one of the following will work
+                if isinstance(link['$dnanexus_link'], basestring):
+                    link = link['$dnanexus_link']
+                else:
+                    link = link['$dnanexus_link']['id']
+            links.append(link)
+        retval = dxpy.api.system_describe_data_objects({'objects': links})
+        return [rv['describe'] for rv in retval['results']]
+    else:
+        handler = get_handler(id_or_link)
+        return handler.describe(**kwargs)
 
 def get_details(id_or_link, **kwargs):
     '''

--- a/src/python/dxpy/bindings/dxdataobject_functions.py
+++ b/src/python/dxpy/bindings/dxdataobject_functions.py
@@ -156,7 +156,10 @@ def describe(id_or_link, **kwargs):
         describe("file-1234")
     '''
     # If this is a list, extract the ids.
-    if isinstance(id_or_link, list):
+    if isinstance(id_or_link, string) or is_dxlink(id_or_link):
+        handler = get_handler(id_or_link)
+        return handler.describe(**kwargs)
+    else:
         links = []
         for link in id_or_link:
             # If this entry is a dxlink, then get the id.
@@ -167,11 +170,8 @@ def describe(id_or_link, **kwargs):
                 else:
                     link = link['$dnanexus_link']['id']
             links.append(link)
-        retval = dxpy.api.system_describe_data_objects({'objects': links})
-        return [rv['describe'] for rv in retval['results']]
-    else:
-        handler = get_handler(id_or_link)
-        return handler.describe(**kwargs)
+        data_object_descriptions = dxpy.api.system_describe_data_objects({'objects': links})
+        return [desc['describe'] for desc in data_object_descriptions['results']]
 
 def get_details(id_or_link, **kwargs):
     '''

--- a/src/python/dxpy/bindings/dxdataobject_functions.py
+++ b/src/python/dxpy/bindings/dxdataobject_functions.py
@@ -156,7 +156,7 @@ def describe(id_or_link, **kwargs):
         describe("file-1234")
     '''
     # If this is a list, extract the ids.
-    if isinstance(id_or_link, string) or is_dxlink(id_or_link):
+    if isinstance(id_or_link, basestring) or is_dxlink(id_or_link):
         handler = get_handler(id_or_link)
         return handler.describe(**kwargs)
     else:

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -2592,6 +2592,42 @@ class TestDataobjectFunctions(unittest.TestCase):
         self.assertEqual(handler._name, "swiss-army-knife")
         self.assertEqual(handler._alias, "1.0.0")
 
+    def test_describe_data_objects(self):
+        objects = []
+        types = []
+        tags = []
+        objects.append(dxpy.new_dxrecord())
+        types.append('record')
+        tags.append([])
+        objects.append(dxpy.new_dxfile())
+        types.append('file')
+        tags.append([])
+        objects.append(dxpy.new_dxworkflow())
+        types.append('workflow')
+        tags.append(['my_tag'])
+        objects[-1].add_tags(tags[-1])
+        
+        # Should be able to handle a mix of raw ids and dxlinks.
+        ids = [o.get_id() for o in objects]
+        desc = dxpy.describe(ids)
+
+        self.assertEqual(len(ids), len(desc))
+        for i in xrange(len(desc)):
+            self.assertEqual(desc[i]["project"], self.proj_id)
+            self.assertEqual(desc[i]["id"], ids[i])
+            self.assertEqual(desc[i]["class"], types[i])
+            self.assertEqual(desc[i]["types"], []) 
+            self.assertTrue("created" in desc[i]) 
+            self.assertEqual(desc[i]["state"], "open")
+            self.assertEqual(desc[i]["hidden"], False)
+            self.assertEqual(desc[i]["links"], [])
+            self.assertEqual(desc[i]["folder"], "/")
+            self.assertEqual(desc[i]["tags"], tags[i])
+            self.assertTrue("modified" in desc[i])
+            self.assertFalse("properties" in desc[i])
+            self.assertFalse("details" in desc[i])
+
+
 class TestResolver(testutil.DXTestCase):
     def setUp(self):
         super(TestResolver, self).setUp()

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -2617,15 +2617,15 @@ class TestDataobjectFunctions(unittest.TestCase):
             self.assertEqual(desc[i]["id"], ids[i])
             self.assertEqual(desc[i]["class"], types[i])
             self.assertEqual(desc[i]["types"], []) 
-            self.assertTrue("created" in desc[i]) 
+            self.assertIn("created", desc[i]) 
             self.assertEqual(desc[i]["state"], "open")
             self.assertEqual(desc[i]["hidden"], False)
             self.assertEqual(desc[i]["links"], [])
             self.assertEqual(desc[i]["folder"], "/")
             self.assertEqual(desc[i]["tags"], tags[i])
-            self.assertTrue("modified" in desc[i])
-            self.assertFalse("properties" in desc[i])
-            self.assertFalse("details" in desc[i])
+            self.assertIn("modified", desc[i])
+            self.assertNotIn("properties", desc[i])
+            self.assertNotIn("details", desc[i])
 
 
 class TestResolver(testutil.DXTestCase):


### PR DESCRIPTION
A previous commit added the system_describe_data_objects method to the api module, allowing somewhat easier access to the bulk describeDataObjects API method.  This commit extends this so that users can make use of dxpy.describe() on a list of dxlinks or object-id's to get a list of descriptions back.  This parallels nicely with the existing dxpy.describe function.

Unit test is included.
