### PR TITLE
Allow disabling "watch" on remote builds

### DIFF
--- a/src/python/dxpy/asset_builder.py
+++ b/src/python/dxpy/asset_builder.py
@@ -222,7 +222,7 @@ def build_asset(args):
 
         if not args.json:
             print("\nStarted job '" + str(job_id) + "' to build the asset bundle.\n", file=sys.stderr)
-            if not args.skip_watch:
+            if args.watch:
                 try:
                     subprocess.check_call(["dx", "watch", job_id])
                 except subprocess.CalledProcessError as e:

--- a/src/python/dxpy/asset_builder.py
+++ b/src/python/dxpy/asset_builder.py
@@ -222,18 +222,19 @@ def build_asset(args):
 
         if not args.json:
             print("\nStarted job '" + str(job_id) + "' to build the asset bundle.\n", file=sys.stderr)
-            try:
-                subprocess.check_call(["dx", "watch", job_id])
-            except subprocess.CalledProcessError as e:
-                if e.returncode == 3:
-                    # Some kind of failure to build the asset. The reason
-                    # for the failure is probably self-evident from the
-                    # job log (and if it's not, the CalledProcessError
-                    # is not informative anyway), so just propagate the
-                    # return code without additional remarks.
-                    sys.exit(3)
-                else:
-                    raise e
+            if not args.skip_watch:
+                try:
+                    subprocess.check_call(["dx", "watch", job_id])
+                except subprocess.CalledProcessError as e:
+                    if e.returncode == 3:
+                        # Some kind of failure to build the asset. The reason
+                        # for the failure is probably self-evident from the
+                        # job log (and if it's not, the CalledProcessError
+                        # is not informative anyway), so just propagate the
+                        # return code without additional remarks.
+                        sys.exit(3)
+                    else:
+                        raise e
 
         dxpy.DXJob(job_id).wait_on_done(interval=1)
         asset_id, _ = dxpy.get_dxlink_ids(dxpy.api.job_describe(job_id)['output']['asset_bundle'])

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -3863,8 +3863,8 @@ parser_build_asset.add_argument("-d", "--destination",
                                 default='.')
 parser_build_asset.add_argument("--json", help=fill("Show ID of resulting asset bundle in JSON format"),
                                 action="store_true", dest="json")
-parser_build_asset.add_argument("--skip-watch", help=fill("Don't watch the real-time logs of the asset-builder job."),
-                                action="store_true", dest="skip_watch")
+parser_build_asset.add_argument("--no-watch", help=fill("Don't watch the real-time logs of the asset-builder job."),
+                                action="store_false", dest="watch")
 parser_build_asset.set_defaults(func=build_asset)
 register_parser(parser_build_asset)
 

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -3863,6 +3863,8 @@ parser_build_asset.add_argument("-d", "--destination",
                                 default='.')
 parser_build_asset.add_argument("--json", help=fill("Show ID of resulting asset bundle in JSON format"),
                                 action="store_true", dest="json")
+parser_build_asset.add_argument("--skip-watch", help=fill("Don't watch the real-time logs of the asset-builder job."),
+                                action="store_true", dest="skip_watch")
 parser_build_asset.set_defaults(func=build_asset)
 register_parser(parser_build_asset)
 

--- a/src/python/dxpy/scripts/dx_build_app.py
+++ b/src/python/dxpy/scripts/dx_build_app.py
@@ -99,7 +99,7 @@ app_options.add_argument("--no-publish", help=argparse.SUPPRESS, action="store_f
 # --[no-]remote
 parser.set_defaults(remote=False)
 parser.add_argument("--remote", help="Build the app remotely by uploading the source directory to the DNAnexus Platform and building it there. This option is useful if you would otherwise need to cross-compile the app(let) to target the Execution Environment.", action="store_true", dest="remote")
-parser.add_argument("--skip-watch", help="Don't watch the real-time logs of the remote builder. (This option only applicable if --remote was specified).", action="store_true", dest="skip_watch")
+parser.add_argument("--no-watch", help="Don't watch the real-time logs of the remote builder. (This option only applicable if --remote was specified).", action="store_false", dest="watch")
 parser.add_argument("--no-remote", help=argparse.SUPPRESS, action="store_false", dest="remote")
 
 applet_options.add_argument("-f", "--overwrite", help="Remove existing applet(s) of the same name in the destination folder.",
@@ -568,7 +568,7 @@ def _parse_app_spec(src_dir):
 def _build_app_remote(mode, src_dir, publish=False, destination_override=None,
                       version_override=None, bill_to_override=None, dx_toolkit_autodep="stable",
                       do_version_autonumbering=True, do_try_update=True, do_parallel_build=True,
-                      do_check_syntax=True, region=None, skip_watch=False):
+                      do_check_syntax=True, region=None, watch=True):
     if mode == 'app':
         builder_app = 'app-tarball_app_builder'
     else:
@@ -716,7 +716,7 @@ def _build_app_remote(mode, src_dir, publish=False, destination_override=None,
             app_run_result = dxpy.api.app_run(builder_app, input_params=api_options)
             job_id = app_run_result["id"]
             print("Started builder job %s" % (job_id,))
-            if not skip_watch:
+            if watch:
                 try:
                     subprocess.check_call(["dx", "watch", job_id])
                 except subprocess.CalledProcessError as e:
@@ -986,7 +986,7 @@ def _build_app(args, extra_args):
 
         return _build_app_remote(args.mode, args.src_dir, destination_override=args.destination,
                                  publish=args.publish, dx_toolkit_autodep=args.dx_toolkit_autodep,
-                                 region=args.region, skip_watch=args.skip_watch, **more_kwargs)
+                                 region=args.region, watch=args.watch, **more_kwargs)
 
 
 def main(**kwargs):

--- a/src/python/dxpy/scripts/dx_build_app.py
+++ b/src/python/dxpy/scripts/dx_build_app.py
@@ -99,6 +99,7 @@ app_options.add_argument("--no-publish", help=argparse.SUPPRESS, action="store_f
 # --[no-]remote
 parser.set_defaults(remote=False)
 parser.add_argument("--remote", help="Build the app remotely by uploading the source directory to the DNAnexus Platform and building it there. This option is useful if you would otherwise need to cross-compile the app(let) to target the Execution Environment.", action="store_true", dest="remote")
+parser.add_argument("--skip-watch", help="Don't watch the real-time logs of the remote builder. (This option only applicable if --remote was specified).", action="store_true", dest="skip_watch")
 parser.add_argument("--no-remote", help=argparse.SUPPRESS, action="store_false", dest="remote")
 
 applet_options.add_argument("-f", "--overwrite", help="Remove existing applet(s) of the same name in the destination folder.",
@@ -567,7 +568,7 @@ def _parse_app_spec(src_dir):
 def _build_app_remote(mode, src_dir, publish=False, destination_override=None,
                       version_override=None, bill_to_override=None, dx_toolkit_autodep="stable",
                       do_version_autonumbering=True, do_try_update=True, do_parallel_build=True,
-                      do_check_syntax=True, region=None):
+                      do_check_syntax=True, region=None, skip_watch=False):
     if mode == 'app':
         builder_app = 'app-tarball_app_builder'
     else:
@@ -715,18 +716,19 @@ def _build_app_remote(mode, src_dir, publish=False, destination_override=None,
             app_run_result = dxpy.api.app_run(builder_app, input_params=api_options)
             job_id = app_run_result["id"]
             print("Started builder job %s" % (job_id,))
-            try:
-                subprocess.check_call(["dx", "watch", job_id])
-            except subprocess.CalledProcessError as e:
-                if e.returncode == 3:
-                    # Some kind of failure to build the app. The reason
-                    # for the failure is probably self-evident from the
-                    # job log (and if it's not, the CalledProcessError
-                    # is not informative anyway), so just propagate the
-                    # return code without additional remarks.
-                    sys.exit(3)
-                else:
-                    raise e
+            if not skip_watch:
+                try:
+                    subprocess.check_call(["dx", "watch", job_id])
+                except subprocess.CalledProcessError as e:
+                    if e.returncode == 3:
+                        # Some kind of failure to build the app. The reason
+                        # for the failure is probably self-evident from the
+                        # job log (and if it's not, the CalledProcessError
+                        # is not informative anyway), so just propagate the
+                        # return code without additional remarks.
+                        sys.exit(3)
+                    else:
+                        raise e
 
             dxpy.DXJob(job_id).wait_on_done(interval=1)
 
@@ -984,7 +986,7 @@ def _build_app(args, extra_args):
 
         return _build_app_remote(args.mode, args.src_dir, destination_override=args.destination,
                                  publish=args.publish, dx_toolkit_autodep=args.dx_toolkit_autodep,
-                                 region=args.region, **more_kwargs)
+                                 region=args.region, skip_watch=args.skip_watch, **more_kwargs)
 
 
 def main(**kwargs):


### PR DESCRIPTION
Currently both the asset builder and our remote app/applet builder code paths automatically run "dx watch" on the jobs that are building either the asset or app/applet.   Some customers are sitting behind firewalls that prohibit WebSockets traffic and are therefore unable to run "dx watch".  This causes the asset building and remote app/applet building paths to fail in their environment.

This simple pull request adds a "--skip-watch" flag to these two tools so that one can optionally skip watching the jobs that are building the assets or app/applets.  The code will still wait for the job to complete, but it will remain quiet while the jobs run.
