### PR TITLE
PTFM-17112: Revert old commits to re-enable 14.04 as default

### DIFF
--- a/src/python/dxpy/scripts/dx_app_wizard.py
+++ b/src/python/dxpy/scripts/dx_app_wizard.py
@@ -388,16 +388,15 @@ array:boolean  array:int      boolean        hash           string''')
 
     # print('\n' + BOLD('Linux version: '))
     app_json['runSpec']['distribution'] = 'Ubuntu'
-    app_json['runSpec']['release'] = '12.04'
 
-    #if any(instance_type.startswith(prefix) for prefix in ('mem1_hdd2', 'mem2_hdd2', 'mem3_hdd2')):
-    #    print(fill('Your app will run on Ubuntu 12.04. To use Ubuntu 14.04, select from the list of common instance ' +
-    #               'types above.'))
-    #    app_json['runSpec']['release'] = '12.04'
-    #else:
-    #    app_json['runSpec']['release'] = '14.04'
-    #    print(fill('Your app has been configured to run on Ubuntu 14.04. To use Ubuntu 12.04, edit the ' +
-    #               BOLD('runSpec.release') + ' field of your dxapp.json.'))
+    if any(instance_type.startswith(prefix) for prefix in ('mem1_hdd2', 'mem2_hdd2', 'mem3_hdd2')):
+        print(fill('Your app will run on Ubuntu 12.04. To use Ubuntu 14.04, select from the list of common instance ' +
+                   'types above.'))
+        app_json['runSpec']['release'] = '12.04'
+    else:
+        app_json['runSpec']['release'] = '14.04'
+        print(fill('Your app has been configured to run on Ubuntu 14.04. To use Ubuntu 12.04, edit the ' +
+                   BOLD('runSpec.release') + ' field of your dxapp.json.'))
 
     #################
     # WRITING FILES #

--- a/src/python/test/test_dx_app_wizard_and_run_app_locally.py
+++ b/src/python/test/test_dx_app_wizard_and_run_app_locally.py
@@ -168,7 +168,7 @@ class TestDXAppWizardAndRunAppLocally(DXTestCase):
         self.assertEqual(dxapp_json['runSpec']['systemRequirements']['*']['instanceType'],
                          InstanceTypesCompleter.default_instance_type.Name)
         self.assertEqual(dxapp_json['runSpec']['distribution'], 'Ubuntu')
-        self.assertEqual(dxapp_json['runSpec']['release'], '12.04')
+        self.assertEqual(dxapp_json['runSpec']['release'], '14.04')
         self.assertEqual(dxapp_json['timeoutPolicy']['*']['hours'], 24)
 
     def test_dx_run_app_locally_interactively(self):


### PR DESCRIPTION
@psung Please review at your convenience. This commit has the affect of reverting https://github.com/dnanexus/dx-toolkit/commit/8d43eba5141b8ad0b5254f7fa910f7a49bfe7bc3 and https://github.com/dnanexus/dx-toolkit/commit/5522565f48deaf90c5b6ec732baac5320edde304 to enable 14.04 to be the default for `dx-app-wizard`.     Tested manually and ensured 'test_dx_app_wizard_and_run_app_locally.TestDXAppWizardAndRunAppLocally' tests ran successfully. 