### PR TITLE
dx-docker: Handle workdir properly when overriding image metadata

### DIFF
--- a/src/python/scripts/dx-docker
+++ b/src/python/scripts/dx-docker
@@ -210,9 +210,11 @@ def run(args):
 
     container_cmd = entrypoint + cmd
 
-    workdir = args.workdir
+    workdir = "/"
     if 'workingDirectory' in imagemeta['app']:
        workdir = imagemeta['app']['workingDirectory']
+    if args.workdir:
+       workdir = args.workdir
 
     env = []
     if 'environment' in imagemeta['app']:


### PR DESCRIPTION
@psung Please take a look at your convenience. This is a quick fix to `dx-docker` so that we handle the working directory properly when overriding image metadata. 

I ran into this when testing out the utility in a way I haven't before.  I also added a test to the test suite in a companion pull request.  Thanks in advance!