### PR TITLE
pyOpenSSL dependency added

### DIFF
--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -3,4 +3,5 @@ python-dateutil==2.3
 python-magic==0.4.6
 beautifulsoup4==4.4.1
 psutil==3.3.0
+pyOpenSSL==16.2.0
 requests==2.7.0


### PR DESCRIPTION
Hi @psung and @JoeSachmo,

I faced the following unit-tests execution error while working on upload URL check autotest. This is a small fix for that - review at your convenience, please.

```
(py_env)vagrant@vagrant-base-trusty-amd64:/vagrant/dx-toolkit/src/python/test$ DXTEST_AZURE=1 ./test_dxpy.py TestDXFile
Traceback (most recent call last):
  File "./test_dxpy.py", line 31, in <module>
    import OpenSSL
ImportError: No module named OpenSSL
```

Thank you and all the best,
Ilya