### PR TITLE
Mark routes as retryable when a nonce is supplied

### DIFF
--- a/src/api_wrappers/generatePythonAPIWrappers.py
+++ b/src/api_wrappers/generatePythonAPIWrappers.py
@@ -109,8 +109,8 @@ print(preamble)
 for method in json.loads(sys.stdin.read()):
     route, signature, opts = method
     wrapper_method_name = camel_case_to_underscore(signature.split("(")[0])
-    retry = "True" if (opts['retryable']) else "False"
-    accept_nonce = True if 'acceptNonce' in opts else False
+    accept_nonce = opts.get('acceptNonce', False)
+    retry = opts['retryable'] or accept_nonce
     if (opts['objectMethod']):
         root, oid_route, api_method_name = route.split("/")
         if oid_route == 'app-xxxx':

--- a/src/java/src/main/java/com/dnanexus/DXAPI.java
+++ b/src/java/src/main/java/com/dnanexus/DXAPI.java
@@ -3972,7 +3972,7 @@ public final class DXAPI {
         JsonNode input = Nonce.updateNonce(mapper.valueToTree(inputObject));
         return DXJSON.safeTreeToValue(
                 new DXHTTPRequest().request("/" + objectId + "/" + "run",
-                        input, RetryStrategy.UNSAFE_TO_RETRY), outputClass);
+                        input, RetryStrategy.SAFE_TO_RETRY), outputClass);
     }
     /**
      * Invokes the appRun method with an empty input using the given environment, deserializing to an object of the specified class.
@@ -4018,7 +4018,7 @@ public final class DXAPI {
         JsonNode input = Nonce.updateNonce(mapper.valueToTree(inputObject));
         return DXJSON.safeTreeToValue(
             new DXHTTPRequest(env).request("/" + objectId + "/" + "run",
-                    input, RetryStrategy.UNSAFE_TO_RETRY), outputClass);
+                    input, RetryStrategy.SAFE_TO_RETRY), outputClass);
     }
 
     /**
@@ -4547,7 +4547,7 @@ public final class DXAPI {
     public static <T> T appNew(Object inputObject, Class<T> outputClass) {
         JsonNode input = Nonce.updateNonce(mapper.valueToTree(inputObject));
         return DXJSON.safeTreeToValue(
-                new DXHTTPRequest().request("/app/new", input, RetryStrategy.UNSAFE_TO_RETRY),
+                new DXHTTPRequest().request("/app/new", input, RetryStrategy.SAFE_TO_RETRY),
                 outputClass);
     }
     /**
@@ -4571,7 +4571,7 @@ public final class DXAPI {
     public static <T> T appNew(Object inputObject, Class<T> outputClass, DXEnvironment env) {
         JsonNode input = Nonce.updateNonce(mapper.valueToTree(inputObject));
         return DXJSON.safeTreeToValue(
-                new DXHTTPRequest(env).request("/app/new", input, RetryStrategy.UNSAFE_TO_RETRY),
+                new DXHTTPRequest(env).request("/app/new", input, RetryStrategy.SAFE_TO_RETRY),
                 outputClass);
     }
 
@@ -6007,7 +6007,7 @@ public final class DXAPI {
         JsonNode input = Nonce.updateNonce(mapper.valueToTree(inputObject));
         return DXJSON.safeTreeToValue(
                 new DXHTTPRequest().request("/" + objectId + "/" + "run",
-                        input, RetryStrategy.UNSAFE_TO_RETRY), outputClass);
+                        input, RetryStrategy.SAFE_TO_RETRY), outputClass);
     }
     /**
      * Invokes the appletRun method with an empty input using the given environment, deserializing to an object of the specified class.
@@ -6053,7 +6053,7 @@ public final class DXAPI {
         JsonNode input = Nonce.updateNonce(mapper.valueToTree(inputObject));
         return DXJSON.safeTreeToValue(
             new DXHTTPRequest(env).request("/" + objectId + "/" + "run",
-                    input, RetryStrategy.UNSAFE_TO_RETRY), outputClass);
+                    input, RetryStrategy.SAFE_TO_RETRY), outputClass);
     }
 
     /**
@@ -6396,7 +6396,7 @@ public final class DXAPI {
     public static <T> T appletNew(Object inputObject, Class<T> outputClass) {
         JsonNode input = Nonce.updateNonce(mapper.valueToTree(inputObject));
         return DXJSON.safeTreeToValue(
-                new DXHTTPRequest().request("/applet/new", input, RetryStrategy.UNSAFE_TO_RETRY),
+                new DXHTTPRequest().request("/applet/new", input, RetryStrategy.SAFE_TO_RETRY),
                 outputClass);
     }
     /**
@@ -6420,7 +6420,7 @@ public final class DXAPI {
     public static <T> T appletNew(Object inputObject, Class<T> outputClass, DXEnvironment env) {
         JsonNode input = Nonce.updateNonce(mapper.valueToTree(inputObject));
         return DXJSON.safeTreeToValue(
-                new DXHTTPRequest(env).request("/applet/new", input, RetryStrategy.UNSAFE_TO_RETRY),
+                new DXHTTPRequest(env).request("/applet/new", input, RetryStrategy.SAFE_TO_RETRY),
                 outputClass);
     }
 
@@ -10833,7 +10833,7 @@ public final class DXAPI {
     public static <T> T fileNew(Object inputObject, Class<T> outputClass) {
         JsonNode input = Nonce.updateNonce(mapper.valueToTree(inputObject));
         return DXJSON.safeTreeToValue(
-                new DXHTTPRequest().request("/file/new", input, RetryStrategy.UNSAFE_TO_RETRY),
+                new DXHTTPRequest().request("/file/new", input, RetryStrategy.SAFE_TO_RETRY),
                 outputClass);
     }
     /**
@@ -10857,7 +10857,7 @@ public final class DXAPI {
     public static <T> T fileNew(Object inputObject, Class<T> outputClass, DXEnvironment env) {
         JsonNode input = Nonce.updateNonce(mapper.valueToTree(inputObject));
         return DXJSON.safeTreeToValue(
-                new DXHTTPRequest(env).request("/file/new", input, RetryStrategy.UNSAFE_TO_RETRY),
+                new DXHTTPRequest(env).request("/file/new", input, RetryStrategy.SAFE_TO_RETRY),
                 outputClass);
     }
 
@@ -15089,7 +15089,7 @@ public final class DXAPI {
     public static <T> T jobNew(Object inputObject, Class<T> outputClass) {
         JsonNode input = Nonce.updateNonce(mapper.valueToTree(inputObject));
         return DXJSON.safeTreeToValue(
-                new DXHTTPRequest().request("/job/new", input, RetryStrategy.UNSAFE_TO_RETRY),
+                new DXHTTPRequest().request("/job/new", input, RetryStrategy.SAFE_TO_RETRY),
                 outputClass);
     }
     /**
@@ -15113,7 +15113,7 @@ public final class DXAPI {
     public static <T> T jobNew(Object inputObject, Class<T> outputClass, DXEnvironment env) {
         JsonNode input = Nonce.updateNonce(mapper.valueToTree(inputObject));
         return DXJSON.safeTreeToValue(
-                new DXHTTPRequest(env).request("/job/new", input, RetryStrategy.UNSAFE_TO_RETRY),
+                new DXHTTPRequest(env).request("/job/new", input, RetryStrategy.SAFE_TO_RETRY),
                 outputClass);
     }
 
@@ -17070,7 +17070,7 @@ public final class DXAPI {
     public static <T> T orgNew(Object inputObject, Class<T> outputClass) {
         JsonNode input = Nonce.updateNonce(mapper.valueToTree(inputObject));
         return DXJSON.safeTreeToValue(
-                new DXHTTPRequest().request("/org/new", input, RetryStrategy.UNSAFE_TO_RETRY),
+                new DXHTTPRequest().request("/org/new", input, RetryStrategy.SAFE_TO_RETRY),
                 outputClass);
     }
     /**
@@ -17094,7 +17094,7 @@ public final class DXAPI {
     public static <T> T orgNew(Object inputObject, Class<T> outputClass, DXEnvironment env) {
         JsonNode input = Nonce.updateNonce(mapper.valueToTree(inputObject));
         return DXJSON.safeTreeToValue(
-                new DXHTTPRequest(env).request("/org/new", input, RetryStrategy.UNSAFE_TO_RETRY),
+                new DXHTTPRequest(env).request("/org/new", input, RetryStrategy.SAFE_TO_RETRY),
                 outputClass);
     }
 
@@ -23000,7 +23000,7 @@ public final class DXAPI {
     public static <T> T recordNew(Object inputObject, Class<T> outputClass) {
         JsonNode input = Nonce.updateNonce(mapper.valueToTree(inputObject));
         return DXJSON.safeTreeToValue(
-                new DXHTTPRequest().request("/record/new", input, RetryStrategy.UNSAFE_TO_RETRY),
+                new DXHTTPRequest().request("/record/new", input, RetryStrategy.SAFE_TO_RETRY),
                 outputClass);
     }
     /**
@@ -23024,7 +23024,7 @@ public final class DXAPI {
     public static <T> T recordNew(Object inputObject, Class<T> outputClass, DXEnvironment env) {
         JsonNode input = Nonce.updateNonce(mapper.valueToTree(inputObject));
         return DXJSON.safeTreeToValue(
-                new DXHTTPRequest(env).request("/record/new", input, RetryStrategy.UNSAFE_TO_RETRY),
+                new DXHTTPRequest(env).request("/record/new", input, RetryStrategy.SAFE_TO_RETRY),
                 outputClass);
     }
 
@@ -29565,7 +29565,7 @@ public final class DXAPI {
         JsonNode input = Nonce.updateNonce(mapper.valueToTree(inputObject));
         return DXJSON.safeTreeToValue(
                 new DXHTTPRequest().request("/" + objectId + "/" + "run",
-                        input, RetryStrategy.UNSAFE_TO_RETRY), outputClass);
+                        input, RetryStrategy.SAFE_TO_RETRY), outputClass);
     }
     /**
      * Invokes the workflowRun method with an empty input using the given environment, deserializing to an object of the specified class.
@@ -29611,7 +29611,7 @@ public final class DXAPI {
         JsonNode input = Nonce.updateNonce(mapper.valueToTree(inputObject));
         return DXJSON.safeTreeToValue(
             new DXHTTPRequest(env).request("/" + objectId + "/" + "run",
-                    input, RetryStrategy.UNSAFE_TO_RETRY), outputClass);
+                    input, RetryStrategy.SAFE_TO_RETRY), outputClass);
     }
 
     /**
@@ -30884,7 +30884,7 @@ public final class DXAPI {
     public static <T> T workflowNew(Object inputObject, Class<T> outputClass) {
         JsonNode input = Nonce.updateNonce(mapper.valueToTree(inputObject));
         return DXJSON.safeTreeToValue(
-                new DXHTTPRequest().request("/workflow/new", input, RetryStrategy.UNSAFE_TO_RETRY),
+                new DXHTTPRequest().request("/workflow/new", input, RetryStrategy.SAFE_TO_RETRY),
                 outputClass);
     }
     /**
@@ -30908,7 +30908,7 @@ public final class DXAPI {
     public static <T> T workflowNew(Object inputObject, Class<T> outputClass, DXEnvironment env) {
         JsonNode input = Nonce.updateNonce(mapper.valueToTree(inputObject));
         return DXJSON.safeTreeToValue(
-                new DXHTTPRequest(env).request("/workflow/new", input, RetryStrategy.UNSAFE_TO_RETRY),
+                new DXHTTPRequest(env).request("/workflow/new", input, RetryStrategy.SAFE_TO_RETRY),
                 outputClass);
     }
 

--- a/src/python/dxpy/api.py
+++ b/src/python/dxpy/api.py
@@ -194,7 +194,7 @@ def app_remove_tags(app_name_or_id, alias=None, input_params={}, always_retry=Tr
     fully_qualified_version = app_name_or_id + (('/' + alias) if alias else '')
     return DXHTTPRequest('/%s/removeTags' % fully_qualified_version, input_params, always_retry=always_retry, **kwargs)
 
-def app_run(app_name_or_id, alias=None, input_params={}, always_retry=False, **kwargs):
+def app_run(app_name_or_id, alias=None, input_params={}, always_retry=True, **kwargs):
     """
     Invokes the /app-xxxx/run API method.
 
@@ -222,7 +222,7 @@ def app_update(app_name_or_id, alias=None, input_params={}, always_retry=True, *
     fully_qualified_version = app_name_or_id + (('/' + alias) if alias else '')
     return DXHTTPRequest('/%s/update' % fully_qualified_version, input_params, always_retry=always_retry, **kwargs)
 
-def app_new(input_params={}, always_retry=False, **kwargs):
+def app_new(input_params={}, always_retry=True, **kwargs):
     """
     Invokes the /app/new API method.
 
@@ -287,7 +287,7 @@ def applet_rename(object_id, input_params={}, always_retry=True, **kwargs):
     """
     return DXHTTPRequest('/%s/rename' % object_id, input_params, always_retry=always_retry, **kwargs)
 
-def applet_run(object_id, input_params={}, always_retry=False, **kwargs):
+def applet_run(object_id, input_params={}, always_retry=True, **kwargs):
     """
     Invokes the /applet-xxxx/run API method.
 
@@ -304,7 +304,7 @@ def applet_set_properties(object_id, input_params={}, always_retry=True, **kwarg
     """
     return DXHTTPRequest('/%s/setProperties' % object_id, input_params, always_retry=always_retry, **kwargs)
 
-def applet_new(input_params={}, always_retry=False, **kwargs):
+def applet_new(input_params={}, always_retry=True, **kwargs):
     """
     Invokes the /applet/new API method.
 
@@ -495,7 +495,7 @@ def file_upload(object_id, input_params={}, always_retry=True, **kwargs):
     """
     return DXHTTPRequest('/%s/upload' % object_id, input_params, always_retry=always_retry, **kwargs)
 
-def file_new(input_params={}, always_retry=False, **kwargs):
+def file_new(input_params={}, always_retry=True, **kwargs):
     """
     Invokes the /file/new API method.
 
@@ -680,7 +680,7 @@ def job_terminate(object_id, input_params={}, always_retry=True, **kwargs):
     """
     return DXHTTPRequest('/%s/terminate' % object_id, input_params, always_retry=always_retry, **kwargs)
 
-def job_new(input_params={}, always_retry=False, **kwargs):
+def job_new(input_params={}, always_retry=True, **kwargs):
     """
     Invokes the /job/new API method.
 
@@ -765,7 +765,7 @@ def org_update(object_id, input_params={}, always_retry=True, **kwargs):
     """
     return DXHTTPRequest('/%s/update' % object_id, input_params, always_retry=always_retry, **kwargs)
 
-def org_new(input_params={}, always_retry=False, **kwargs):
+def org_new(input_params={}, always_retry=True, **kwargs):
     """
     Invokes the /org/new API method.
 
@@ -1022,7 +1022,7 @@ def record_set_visibility(object_id, input_params={}, always_retry=True, **kwarg
     """
     return DXHTTPRequest('/%s/setVisibility' % object_id, input_params, always_retry=always_retry, **kwargs)
 
-def record_new(input_params={}, always_retry=False, **kwargs):
+def record_new(input_params={}, always_retry=True, **kwargs):
     """
     Invokes the /record/new API method.
 
@@ -1309,7 +1309,7 @@ def workflow_rename(object_id, input_params={}, always_retry=True, **kwargs):
     """
     return DXHTTPRequest('/%s/rename' % object_id, input_params, always_retry=always_retry, **kwargs)
 
-def workflow_run(object_id, input_params={}, always_retry=False, **kwargs):
+def workflow_run(object_id, input_params={}, always_retry=True, **kwargs):
     """
     Invokes the /workflow-xxxx/run API method.
 
@@ -1366,7 +1366,7 @@ def workflow_update_stage_executable(object_id, input_params={}, always_retry=Tr
     """
     return DXHTTPRequest('/%s/updateStageExecutable' % object_id, input_params, always_retry=always_retry, **kwargs)
 
-def workflow_new(input_params={}, always_retry=False, **kwargs):
+def workflow_new(input_params={}, always_retry=True, **kwargs):
     """
     Invokes the /workflow/new API method.
 


### PR DESCRIPTION
Routes that supply a nonce should be retryable (this being the whole
point of adding the nonce). We don't do this by marking such routes as
retryable in the wrapper_table.json, since not all the language bindings
know how to generate the nonces, and this could result in bindings that
didn't supply the nonce but went ahead and considered the route to be
retryable anyway. Therefore, the *bindings generators* for each language
are responsible for marking each route as retryable if and only if they
inserted nonce generation code.

In particular, note that in the Java bindings, each API route has
multiple overloads and we added nonce support in only some of them (not
bothering to add nonce support in the older and deprecated overloads).
In this case, *only* the overloads that specifically support nonces also
mark the request as retryable.