### PR TITLE
Adding option for supressing running check when exiting ssh

### DIFF
--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -3258,7 +3258,7 @@ def ssh(args, ssh_config_verified=False):
     exit_code = subprocess.call(ssh_args)
     try:
         job_desc = dxpy.describe(args.job_id)
-        if job_desc['state'] == 'running':
+        if args.check_running and job_desc['state'] == 'running':
             msg = "Job {job_id} is still running. Terminate now?".format(job_id=args.job_id)
             if prompt_for_yn(msg, default=False):
                 dxpy.api.job_terminate(args.job_id)
@@ -4190,6 +4190,7 @@ parser_ssh.add_argument('job_id', help='Name of job to connect to')
 parser_ssh.add_argument('ssh_args', help='Command-line arguments to pass to the SSH client', nargs=argparse.REMAINDER)
 parser_ssh.add_argument('--ssh-proxy', metavar=('<address>:<port>'),
                         help='SSH connect via proxy, argument supplied is used as the proxy address and port')
+parser_ssh.add_argument('--suppress-running-check', action='store_false', help=argparse.SUPPRESS, dest='check_running')
 parser_ssh.set_defaults(func=ssh)
 register_parser(parser_ssh, categories='exec')
 

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -4190,6 +4190,12 @@ parser_ssh.add_argument('job_id', help='Name of job to connect to')
 parser_ssh.add_argument('ssh_args', help='Command-line arguments to pass to the SSH client', nargs=argparse.REMAINDER)
 parser_ssh.add_argument('--ssh-proxy', metavar=('<address>:<port>'),
                         help='SSH connect via proxy, argument supplied is used as the proxy address and port')
+# If ssh is run with the  supress-running-check flag, then dx won't prompt
+# the user whether they would like to terminate the currently running job
+# after they exit ssh.  Among other things, this will allow users to setup
+# ssh tunnels using dx ssh, and exit the ssh command with the tunnel still 
+# in place, and not be prompted to terminate the instance (which would close
+# the tunnel).
 parser_ssh.add_argument('--suppress-running-check', action='store_false', help=argparse.SUPPRESS, dest='check_running')
 parser_ssh.set_defaults(func=ssh)
 register_parser(parser_ssh, categories='exec')


### PR DESCRIPTION
We occasionally set up a tunnel over ssh to a worker.  When setting up the tunnel,
we want to exit the ssh command with the tunnel still open.  Today, when dx sees the
ssh exit, it prompts users to ask if they'd like to terminate the job.  We'd like to
be able to optionally supress this inquiry.

This commit adds a hidden command line to ssh to allow users to optionally supress this
prompt.