### PR TITLE
dx-docker makedirs

### DIFF
--- a/src/python/scripts/dx-docker
+++ b/src/python/scripts/dx-docker
@@ -47,7 +47,7 @@ def makedirs(path):
     try:
         os.makedirs(path)
     except OSError as e:  # If the directory already exists, continue gracefully
-        if e.errno != errno.EEXIST
+        if e.errno != errno.EEXIST:
             raise
         pass
 

--- a/src/python/scripts/dx-docker
+++ b/src/python/scripts/dx-docker
@@ -5,6 +5,7 @@
 import argparse
 import sys
 import os
+import errno
 import subprocess
 import pprint
 import json
@@ -45,7 +46,9 @@ def shell_suppress(cmd, ignore_error=False):
 def makedirs(path):
     try:
         os.makedirs(path)
-    except:  # If the directory already exists, continue gracefully
+    except OSError as e:  # If the directory already exists, continue gracefully
+        if e.errno != errno.EEXIST
+            raise
         pass
 
 parser = argparse.ArgumentParser()


### PR DESCRIPTION
Other OSError exceptions could be raised, but we only want to pass if the directory exists. E.g. permission could be denied, and currently would be passed.