### PR TITLE
Make DXFile appear file-like for pandas

### DIFF
--- a/src/python/dxpy/bindings/dxfile.py
+++ b/src/python/dxpy/bindings/dxfile.py
@@ -321,6 +321,9 @@ class DXFile(DXDataObject):
         if _buffer:
             yield _buffer
 
+    next = next
+    __next__ = next
+            
     def set_ids(self, dxid, project=None):
         '''
         :param dxid: Object ID


### PR DESCRIPTION
Add the methods `next` (Py 2.7 and older) and `__next__` (Py 3.0 and newer) to the DXFile class, completing the iteration interface.

This allows DXFile instances to be recognized as iterable and file-like for pandas functions like `read_table`. Absent this patch, `pandas.read_table` with a DXFile argument raises: "TypeError: coercing to Unicode: need string or buffer, DXFile found"

Monkey-patching the DXFile class is also a viable work-around:

```
>>> from pandas.core.dtypes.inference import is_file_like
>>> import dxpy
>>> dxf = dxpy.DXFile()
>>> is_file_like(dxf)
False
>>> dxpy.DXFile.next = next
>>> dxpy.DXFile.__next__ = next
>>> dxf = dxpy.DXFile()
>>> is_file_like(dxf)
True
```