### PR TITLE
PTFM-20076: Add dx-toolkit support for downloadRestricted flag

### DIFF
--- a/src/python/dxpy/bindings/dxproject.py
+++ b/src/python/dxpy/bindings/dxproject.py
@@ -283,7 +283,7 @@ class DXProject(DXContainer):
     _class = "project"
 
     def new(self, name, summary=None, description=None, protected=None,
-            restricted=None, contains_phi=None, tags=None,
+            restricted=None, download_restricted=None, contains_phi=None, tags=None,
             properties=None, bill_to=None, **kwargs):
         """
         :param name: The name of the project
@@ -296,6 +296,8 @@ class DXProject(DXContainer):
         :type protected: boolean
         :param restricted: If provided, whether the project should be restricted
         :type restricted: boolean
+        :param download_restricted: If provided, whether the project should be download restricted
+        :type download_restricted: boolean
         :param contains_phi: If provided, whether the project should be marked as containing protected health information (PHI)
         :type contains_phi: boolean
         :param tags: If provided, tags to associate with the project
@@ -322,6 +324,8 @@ class DXProject(DXContainer):
             input_hash["protected"] = protected
         if restricted is not None:
             input_hash["restricted"] = restricted
+        if download_restricted is not None:
+            input_hash["downloadRestricted"] = download_restricted
         if contains_phi is not None:
             input_hash["containsPHI"] = contains_phi
         if bill_to is not None:
@@ -336,7 +340,7 @@ class DXProject(DXContainer):
         return self._dxid
 
     def update(self, name=None, summary=None, description=None, protected=None,
-               restricted=None, version=None, **kwargs):
+               restricted=None, download_restricted=None, version=None, **kwargs):
         """
         :param name: If provided, the new project name
         :type name: string
@@ -348,6 +352,8 @@ class DXProject(DXContainer):
         :type protected: boolean
         :param restricted: If provided, whether the project should be restricted
         :type restricted: boolean
+        :param download_restricted: If provided, whether the project should be download restricted
+        :type download_restricted: boolean
         :param version: If provided, the update will only occur if the value matches the current project's version number
         :type version: int
 
@@ -369,6 +375,8 @@ class DXProject(DXContainer):
             update_hash["protected"] = protected
         if restricted is not None:
             update_hash["restricted"] = restricted
+        if download_restricted is not None:
+            update_hash["downloadRestricted"] = download_restricted
         if version is not None:
             update_hash["version"] = version
         dxpy.api.project_update(self._dxid, update_hash, **kwargs)

--- a/src/python/dxpy/bindings/dxproject.py
+++ b/src/python/dxpy/bindings/dxproject.py
@@ -296,7 +296,7 @@ class DXProject(DXContainer):
         :type protected: boolean
         :param restricted: If provided, whether the project should be restricted
         :type restricted: boolean
-        :param download_restricted: If provided, whether the project should be download restricted
+        :param download_restricted: If provided, whether external downloads should be restricted
         :type download_restricted: boolean
         :param contains_phi: If provided, whether the project should be marked as containing protected health information (PHI)
         :type contains_phi: boolean
@@ -352,7 +352,7 @@ class DXProject(DXContainer):
         :type protected: boolean
         :param restricted: If provided, whether the project should be restricted
         :type restricted: boolean
-        :param download_restricted: If provided, whether the project should be download restricted
+        :param download_restricted: If provided, whether external downloads should be restricted
         :type download_restricted: boolean
         :param version: If provided, the update will only occur if the value matches the current project's version number
         :type version: int

--- a/src/python/dxpy/cli/parsers.py
+++ b/src/python/dxpy/cli/parsers.py
@@ -325,6 +325,8 @@ def get_update_project_args(args):
         input_params["protected"] = True if args.protected == 'true' else False
     if args.restricted is not None:
         input_params["restricted"] = True if args.restricted == 'true' else False
+    if args.download_restricted is not None:
+        input_params["downloadRestricted"] = True if args.download_restricted == 'true' else False
     if args.containsPHI is not None:
         input_params["containsPHI"] = True if args.containsPHI == 'true' else False
     if args.bill_to is not None:

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -4372,6 +4372,8 @@ parser_update_project.add_argument('--protected', choices=["true", "false"],
                                    help="Whether the project should be PROTECTED")
 parser_update_project.add_argument('--restricted', choices=["true", "false"],
                                    help="Whether the project should be RESTRICTED")
+parser_update_project.add_argument('--download-restricted', choices=["true", "false"],
+                                   help="Whether the project should be DOWNLOAD RESTRICTED")
 parser_update_project.add_argument('--containsPHI', choices=["true"],
                                    help="Flag to tell if project contains PHI")
 parser_update_project.add_argument('--bill-to', help="Update the user or org ID of the billing account", type=str)

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -130,6 +130,7 @@ class TestDXProject(unittest.TestCase):
             self.assertEqual(desc["description"], "")
             self.assertEqual(desc["protected"], False)
             self.assertEqual(desc["restricted"], False)
+            self.assertEqual(desc["downloadRestricted"], False)
             self.assertEqual(desc["containsPHI"], False)
             self.assertEqual(desc["tags"], [])
             prop = dxpy.api.project_describe(dxproject.get_id(),
@@ -138,6 +139,7 @@ class TestDXProject(unittest.TestCase):
             modified_proj_id = dxproject.new(name="newprojname2",
                                              protected=True,
                                              restricted=True,
+                                             download_restricted=True,
                                              description="new description",
                                              properties={"prop1": "val1"},
                                              tags=["tag1", "tag2", "tag3"])
@@ -147,8 +149,9 @@ class TestDXProject(unittest.TestCase):
                 self.assertNotEqual(desc2["id"], desc["id"])
                 self.assertEqual(desc2["id"], modified_proj_id)
                 self.assertEqual(desc2["name"], "newprojname2")
-                self.assertEqual(desc2["restricted"], True)
                 self.assertEqual(desc2["protected"], True)
+                self.assertEqual(desc2["restricted"], True)
+                self.assertEqual(desc2["downloadRestricted"], True)
                 self.assertEqual(desc2["description"], "new description")
                 self.assertEqual(desc2["tags"], ["tag1", "tag2", "tag3"])
                 prop2 = dxpy.api.project_describe(dxproject.get_id(),
@@ -177,18 +180,28 @@ class TestDXProject(unittest.TestCase):
 
     def test_update_describe(self):
         dxproject = dxpy.DXProject()
-        dxproject.update(name="newprojname", protected=True, restricted=True, description="new description")
+        dxproject.update(name="newprojname",
+                         protected=True,
+                         restricted=True,
+                         download_restricted=True,
+                         description="new description")
         desc = dxproject.describe()
         self.assertEqual(desc["id"], self.proj_id)
         self.assertEqual(desc["class"], "project")
         self.assertEqual(desc["name"], "newprojname")
         self.assertEqual(desc["protected"], True)
         self.assertEqual(desc["restricted"], True)
+        self.assertEqual(desc["downloadRestricted"], True)
         self.assertEqual(desc["description"], "new description")
         self.assertTrue("created" in desc)
+
         dxproject.update(restricted=False)
         desc = dxproject.describe()
         self.assertEqual(desc["restricted"], False)
+
+        dxproject.update(download_restricted=False)
+        desc = dxproject.describe()
+        self.assertEqual(desc["downloadRestricted"], False)
 
     def test_new_list_remove_folders(self):
         dxproject = dxpy.DXProject()

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -195,12 +195,9 @@ class TestDXProject(unittest.TestCase):
         self.assertEqual(desc["description"], "new description")
         self.assertTrue("created" in desc)
 
-        dxproject.update(restricted=False)
+        dxproject.update(restricted=False, download_restricted=False)
         desc = dxproject.describe()
         self.assertEqual(desc["restricted"], False)
-
-        dxproject.update(download_restricted=False)
-        desc = dxproject.describe()
         self.assertEqual(desc["downloadRestricted"], False)
 
     def test_new_list_remove_folders(self):


### PR DESCRIPTION
Add --download-restricted flag to dx-toolkit.

Test plan: run_integration_tests.sh --client_tests_only --tests test_dxpy.TestDXProject