### PR TITLE
dx-app-wizard python test template failure fix. test added. (#229)

### DIFF
--- a/src/python/dxpy/app_builder.py
+++ b/src/python/dxpy/app_builder.py
@@ -45,6 +45,7 @@ import tarfile
 import stat
 
 import dxpy
+import dxpy.executable_builder
 from . import logger
 from .utils import merge
 from .utils.printing import fill
@@ -422,31 +423,6 @@ def upload_resources(src_dir, project=None, folder='/', ensure_upload=False, for
     else:
         return []
 
-def _inline_documentation_files(app_spec, src_dir):
-    """
-    Modifies the provided app_spec dict (which may be an app or applet
-    spec, actually) to inline the contents of the readme file into
-    "description" and the developer readme into "developerNotes".
-    """
-    # Inline description from a readme file
-    if 'description' not in app_spec:
-        readme_filename = None
-        for filename in 'README.md', 'Readme.md', 'readme.md':
-            if os.path.exists(os.path.join(src_dir, filename)):
-                readme_filename = filename
-                break
-        if readme_filename is not None:
-            with open(os.path.join(src_dir, readme_filename)) as fh:
-                app_spec['description'] = fh.read()
-
-    # Inline developerNotes from Readme.developer.md
-    if 'developerNotes' not in app_spec:
-        for filename in 'README.developer.md', 'Readme.developer.md', 'readme.developer.md':
-            if os.path.exists(os.path.join(src_dir, filename)):
-                with open(os.path.join(src_dir, filename)) as fh:
-                    app_spec['developerNotes'] = fh.read()
-                break
-
 
 def upload_applet(src_dir, uploaded_resources, check_name_collisions=True, overwrite=False, archive=False, project=None, override_folder=None, override_name=None, dx_toolkit_autodep="stable", dry_run=False, **kwargs):
     """
@@ -529,7 +505,7 @@ def upload_applet(src_dir, uploaded_resources, check_name_collisions=True, overw
     applet_spec["runSpec"].setdefault("bundledDepends", [])
     applet_spec["runSpec"].setdefault("assetDepends", [])
     if not dry_run:
-        region = dxpy.api.project_describe(project, input_params={"fields": {"region": True}})["region"]
+        region = dxpy.api.project_describe(dest_project, input_params={"fields": {"region": True}})["region"]
         regional_options = applet_spec.get('regionalOptions', {}).get(region, {})
 
         # We checked earlier that if region-specific values for the

--- a/src/python/test/test_dx_app_wizard_and_run_app_locally.py
+++ b/src/python/test/test_dx_app_wizard_and_run_app_locally.py
@@ -205,6 +205,19 @@ class TestDXAppWizardAndRunAppLocally(DXTestCase):
         result = remote_job.describe()
         self.assertEqual(result["output"]["out1"], 140)
 
+    def test_dx_verify_build_app(self):
+        appdir = create_app_dir()
+        print("Setting current project to", self.project)
+        dxpy.WORKSPACE_ID = self.project
+        dxpy.PROJECT_CONTEXT_ID = self.project
+        bundled_resources = dxpy.app_builder.upload_resources(appdir)
+        applet_id, _ignored_applet_spec = dxpy.app_builder.upload_applet(appdir, bundled_resources, overwrite=True, dx_toolkit_autodep=False)
+        app_obj = dxpy.DXApplet(applet_id)
+        try:
+            app_obj.describe()
+        except dxpy.exceptions.ResourceNotFound as dxrne:
+            self.fail(dxrne.error_message())
+
     def test_file_download(self):
         '''
         This test assumes a well-formed input spec and tests that the

--- a/src/python/test/test_dx_app_wizard_and_run_app_locally.py
+++ b/src/python/test/test_dx_app_wizard_and_run_app_locally.py
@@ -205,7 +205,7 @@ class TestDXAppWizardAndRunAppLocally(DXTestCase):
         result = remote_job.describe()
         self.assertEqual(result["output"]["out1"], 140)
 
-    def test_dx_verify_build_app(self):
+    def test_dx_build_app_locally_using_app_builder(self):
         appdir = create_app_dir()
         print("Setting current project to", self.project)
         dxpy.WORKSPACE_ID = self.project
@@ -213,10 +213,8 @@ class TestDXAppWizardAndRunAppLocally(DXTestCase):
         bundled_resources = dxpy.app_builder.upload_resources(appdir)
         applet_id, _ignored_applet_spec = dxpy.app_builder.upload_applet(appdir, bundled_resources, overwrite=True, dx_toolkit_autodep=False)
         app_obj = dxpy.DXApplet(applet_id)
-        try:
-            app_obj.describe()
-        except dxpy.exceptions.ResourceNotFound as dxrne:
-            self.fail(dxrne.error_message())
+        self.assertEqual(app_obj.describe()['id'], app_obj.get_id())
+
 
     def test_file_download(self):
         '''


### PR DESCRIPTION
**Motivation**

The `dx-app-wizard` script generates a `test/test.py` functional test template for apps. This is very useful; however, after [this commit](https://github.com/dnanexus/dx-toolkit/commit/545f4ff3f77cd4c8d25a878c2e7fd84b721cc75b) the script it generates doesn't run due to:

* *dxpy.executable_builder* import error, logic for `inline_documentation_files` was moved here. Since we call *dxpy.app_builder* from *dx_build_app.py* we never saw the missing *dxpy.executable_builder* import.
* Minor typo (wrong var used) in [this commit](https://github.com/dnanexus/dx-toolkit/commit/75ccb04c9e4f1e809dc3ff473bec95c3c2e5f07d#diff-d38613cee6417a94e5af7a9ccf728beeR532).

**Consideration**

Work-around does exist, import *dxpy.executable_builder* and specify `project` param in `dxpy.app_builder.upload_applet` in the actual `test.py` script.

Thought about using and importing `dxpy.scripts import build_and_upload_locally` directly. But it seems `dxpy.app_builder.upload_applet` is meant to be exposed. 

**Test**

Test ran [LINK](https://jenkins2.internal.dnanexus.com/job/dx-toolkit/job/dxpy-branch-integration-tests-on-staging/78/). The one failing integration test fails on [Master too](https://jenkins2.internal.dnanexus.com/job/dx-toolkit/job/dxpy-branch-integration-tests-on-staging/81/console).