### PR TITLE
Adding priority arg to build_asset

### DIFF
--- a/src/python/dxpy/asset_builder.py
+++ b/src/python/dxpy/asset_builder.py
@@ -204,6 +204,9 @@ def build_asset(args):
             "input": input_hash
             }
 
+        if args.priority is not None:
+            builder_run_options["priority"] = args.priority
+
         # Add the default destination project to app run options, if it is not run from a job
         if not dxpy.JOB_ID:
             builder_run_options["project"] = dest_project_name

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -4157,6 +4157,7 @@ parser_build_asset.add_argument("--json", help=fill("Show ID of resulting asset 
                                 action="store_true", dest="json")
 parser_build_asset.add_argument("--no-watch", help=fill("Don't watch the real-time logs of the asset-builder job."),
                                 action="store_false", dest="watch")
+parser_build_asset.add_argument("--priority", choices=['normal', 'high'], help=argparse.SUPPRESS)
 parser_build_asset.set_defaults(func=build_asset)
 register_parser(parser_build_asset)
 


### PR DESCRIPTION
Many internal DNAnexus users have their default user policy set to use normal priority.  However, spot isn't available on Azure or in the China region, so when trying to build an asset in those regions, jobs are never launched.  This PR simply allow users to pass in a different priority to build_asset so that they can over-ride their default policy.