### PR TITLE
DEVEX-465: Temporarily update tests in prep for API change

### DIFF
--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -2190,7 +2190,7 @@ def find_executions(args):
                 # If an analysis with cached children, also insert those
                 if execution_desc['class'] == 'analysis':
                     for stage_desc in execution_desc['stages']:
-                        if stage_desc['execution']['parentAnalysis'] != execution_result['id'] and \
+                        if 'parentAnalysis' in stage['execution'] and stage_desc['execution']['parentAnalysis'] != execution_result['id'] and \
                            (args.classname != 'analysis' or stage_desc['execution']['class'] == 'analysis'):
                             # this is a cached stage (with a different parent)
                             executions_by_parent[execution_result['id']].append(stage_desc['execution']['id'])

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -3022,26 +3022,28 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
         self.assertIn(analysis_id, new_workflow_desc)
         self.assertIn(stage_id, new_workflow_desc)
 
-        # Setting the input linking to workflowInputSpec
-        dxpy.api.workflow_update(workflow_id,
-                                 {"editVersion": 2,
-                                  "workflowInputSpec": [{"name": "foo", "class": "int"}],
-                                  "stages": {'stage_0': {'input': {'number': {'$dnanexus_link': {'workflowInputField': 'foo'}}}}}})
-        run("dx describe " + workflow_id)
-        analysis_id = run("dx run " + workflow_id + " -ifoo=474 -y --brief")
-        self.assertTrue(analysis_id.startswith('analysis-'))
-        analysis_desc = run("dx describe " + analysis_id)
-        self.assertIn('foo', analysis_desc)
-        analysis_desc = json.loads(run("dx describe --json " + analysis_id ))
-        self.assertTrue(analysis_desc["runInput"], {"foo": 747})
-        time.sleep(2) # May need to wait for job to be created in the system
-        job_desc = run("dx describe " + analysis_desc["stages"][0]["execution"]["id"])
-        self.assertIn(' number = 474', job_desc)
-
-        # Inputs can only be passed as workflow inputs
-        error_mesg = 'The input.+was passed to a stage but the workflow accepts inputs only on the workflow level'
-        with self.assertSubprocessFailure(stderr_regexp=error_mesg, exit_code=3):
-            run("dx run " + workflow_id + " -istage_0.number=32")
+        #TODO: Workflow API changed; uncomment after replacing workflowInputSpec with inputs
+        # and workflowOutputSpec with outputs
+        # # Setting the input linking to workflowInputSpec
+        # dxpy.api.workflow_update(workflow_id,
+        #                          {"editVersion": 2,
+        #                           "workflowInputSpec": [{"name": "foo", "class": "int"}],
+        #                           "stages": {'stage_0': {'input': {'number': {'$dnanexus_link': {'workflowInputField': 'foo'}}}}}})
+        # run("dx describe " + workflow_id)
+        # analysis_id = run("dx run " + workflow_id + " -ifoo=474 -y --brief")
+        # self.assertTrue(analysis_id.startswith('analysis-'))
+        # analysis_desc = run("dx describe " + analysis_id)
+        # self.assertIn('foo', analysis_desc)
+        # analysis_desc = json.loads(run("dx describe --json " + analysis_id ))
+        # self.assertTrue(analysis_desc["runInput"], {"foo": 747})
+        # time.sleep(2) # May need to wait for job to be created in the system
+        # job_desc = run("dx describe " + analysis_desc["stages"][0]["execution"]["id"])
+        # self.assertIn(' number = 474', job_desc)
+        #
+        # # Inputs can only be passed as workflow inputs
+        # error_mesg = 'The input.+was passed to a stage but the workflow accepts inputs only on the workflow level'
+        # with self.assertSubprocessFailure(stderr_regexp=error_mesg, exit_code=3):
+        #     run("dx run " + workflow_id + " -istage_0.number=32")
 
     @unittest.skipUnless(testutil.TEST_RUN_JOBS, 'skipping test that runs jobs')
     def test_dx_run_clone_analysis(self):
@@ -3355,8 +3357,10 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
         desc = run("dx describe " + workflow_id)
         self.assertIn("Input Spec", desc)
         self.assertIn("Output Spec", desc)
-        self.assertIn("Workflow Input Spec", desc)
-        self.assertIn("Workflow Output Spec", desc)
+        #TODO: Workflow API changed; uncomment after replacing workflowInputSpec with inputs
+        # and workflowOutputSpec with outputs
+        # self.assertIn("Workflow Input Spec", desc)
+        # self.assertIn("Workflow Output Spec", desc)
         applet_id = dxpy.api.applet_new({"name": "myapplet",
                                          "project": self.project,
                                          "dxapi": "1.0.0",
@@ -3684,8 +3688,10 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
         self.assertEqual(wf_describe["stages"][1]["id"], "stage_1")
         self.assertIsNone(wf_describe["stages"][1]["name"])
         self.assertEqual(wf_describe["stages"][1]["executable"], applet_id)
-        self.assertEqual(wf_describe["workflowInputSpec"], wf_input)
-        self.assertEqual(wf_describe["workflowOutputSpec"], wf_output)
+        #TODO: Workflow API changed; uncomment after replacing workflowInputSpec with inputs
+        # and workflowOutputSpec with outputs
+        # self.assertEqual(wf_describe["workflowInputSpec"], wf_input)
+        # self.assertEqual(wf_describe["workflowOutputSpec"], wf_output)
 
     def test_dx_build_workflow_with_destination(self):
         workflow_spec = {"name": "my_workflow"}
@@ -3749,6 +3755,7 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
                                               exit_code=3):
                 new_workflow = run("dx build --json {src_dir}".format(src_dir=workflow_dir))
 
+    @unittest.skip("Workflow API changed; unskip after replacing workflowInputSpec with inputs")
     def test_dx_build_get_build_workflow(self):
         # When building and getting a workflow multiple times we should
         # obtain functionally identical workflows, ie. identical dxworkflow.json specs.

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -1341,7 +1341,8 @@ def main(number):
         self.assertEqual(analysis_desc["tags"], ["foo"])
         self.assertEqual(analysis_desc["properties"], {"foo": "bar"})
 
-    @unittest.skipUnless(testutil.TEST_RUN_JOBS, 'skipping test that would run a job')
+    # @unittest.skipUnless(testutil.TEST_RUN_JOBS, 'skipping test that would run a job')
+    @unittest.skip("Workflow API changed; unskip after replacing workflowInputSpec/workflowOutputSpec with inputs/outputs")
     def test_run_workflow_with_explicit_input(self):
         dxapplet = dxpy.DXApplet()
         dxapplet.new(name="test_applet",
@@ -1507,6 +1508,7 @@ def main(number):
         self.assertRaisesRegexp(DXError, 'could not be found as a stage ID nor as a stage name',
                                 dxworkflow.run, {"nonexistentstage.number": 32})
 
+    @unittest.skip("Workflow API changed; unskip after replacing workflowInputSpec/workflowOutputSpec with inputs/outputs")
     def test_new_dxworkflow(self):
         # empty workflow
         blankworkflow = dxpy.new_dxworkflow()
@@ -1706,8 +1708,10 @@ def main(number):
         for metadata in ['title', 'summary', 'description']:
             self.assertEqual(getattr(dxworkflow, metadata), metadata.capitalize())
         self.assertEqual(dxworkflow.outputFolder, '/bar/baz')
-        self.assertEqual(dxworkflow.workflowInputSpec, wf_input)
-        self.assertEqual(dxworkflow.workflowOutputSpec, wf_output)
+        #TODO: Workflow API changed; uncomment after replacing workflowInputSpec with inputs
+        # and workflowOutputSpec with outputs
+        # self.assertEqual(dxworkflow.workflowInputSpec, wf_input)
+        # self.assertEqual(dxworkflow.workflowOutputSpec, wf_output)
 
         # use unset_title
         dxworkflow.update(unset_title=True, edit_version=1)
@@ -1722,12 +1726,12 @@ def main(number):
         # use unset_workflow_input_spec
         dxworkflow.update(unset_workflow_input_spec=True, edit_version=3)
         self.assertEqual(dxworkflow.editVersion, 4)
-        self.assertIsNone(dxworkflow.workflowInputSpec)
+        # self.assertIsNone(dxworkflow.workflowInputSpec)
 
         # use unset_workflow_output_spec
         dxworkflow.update(unset_workflow_output_spec=True, edit_version=4)
         self.assertEqual(dxworkflow.editVersion, 5)
-        self.assertIsNone(dxworkflow.workflowOutputSpec)
+        # self.assertIsNone(dxworkflow.workflowOutputSpec)
 
         # can't provide both title and unset_title=True
         with self.assertRaises(DXError):


### PR DESCRIPTION
This comments out tests that use workflowInputSpec/workflowOutputSpec. The toolkit itself will work well after the API change (except for the lockdown, until toolkit update), since these fields will be simply ignored.