### PR TITLE
DEVEX-436: Change workflowInputSpec to inputs and workflowOutputSpec to outputs

### DIFF
--- a/src/python/dxpy/bindings/dxworkflow.py
+++ b/src/python/dxpy/bindings/dxworkflow.py
@@ -36,7 +36,7 @@ from ..compat import basestring
 ##############
 # DXWorkflow #
 ##############
-_dxworkflow_json_keys = ['name', 'outputFolder', 'workflowInputSpec', 'workflowOutputSpec']
+_dxworkflow_json_keys = ['name', 'outputFolder', 'inputs', 'outputs']
 _dxworkflow_json_stage_keys = ['id', 'name', 'executable', 'folder', 'input', 'executionPolicy', 'systemRequirements']
 
 def new_dxworkflow(title=None, summary=None, description=None, output_folder=None, init_from=None, **kwargs):
@@ -109,8 +109,8 @@ class DXWorkflow(DXDataObject, DXExecutable):
         :type stages: array of dictionaries
         :param workflow_intput_spec: Explicit input specification of the workflow (optional)
         :type workflow_intput_spec: array of dictionaries
-        :param workflow_output_spec: Explicit output specification of the workflow (optional)
-        :type workflow_output_spec: array of dictionaries
+        :param workflow_outputs: Explicit output specification of the workflow (optional)
+        :type workflow_outputs: array of dictionaries
         :param init_from: Another analysis workflow object handler or and analysis (string or handler) from which to initialize the metadata (optional)
         :type init_from: :class:`~dxpy.bindings.dxworkflow.DXWorkflow`, :class:`~dxpy.bindings.dxanalysis.DXAnalysis`, or string (for analysis IDs only)
 
@@ -143,8 +143,8 @@ class DXWorkflow(DXDataObject, DXExecutable):
         _set_dx_hash(kwargs, dx_hash, "description")
         _set_dx_hash(kwargs, dx_hash, "output_folder", "outputFolder")
         _set_dx_hash(kwargs, dx_hash, "stages")
-        _set_dx_hash(kwargs, dx_hash, "workflow_input_spec", "workflowInputSpec")
-        _set_dx_hash(kwargs, dx_hash, "workflow_output_spec", "workflowOutputSpec")
+        _set_dx_hash(kwargs, dx_hash, "workflow_inputs", "inputs")
+        _set_dx_hash(kwargs, dx_hash, "workflow_outputs", "outputs")
 
         resp = dxpy.api.workflow_new(dx_hash, **kwargs)
         self.set_ids(resp["id"], dx_hash["project"])
@@ -298,8 +298,8 @@ class DXWorkflow(DXDataObject, DXExecutable):
 
     def update(self, title=None, unset_title=False, summary=None, description=None,
                output_folder=None, unset_output_folder=False,
-               workflow_input_spec=None, unset_workflow_input_spec=False,
-               workflow_output_spec=None, unset_workflow_output_spec=False,
+               workflow_inputs=None, unset_workflow_inputs=False,
+               workflow_outputs=None, unset_workflow_outputs=False,
                stages=None, edit_version=None, **kwargs):
         '''
         :param title: workflow title to set; cannot be provided with *unset_title* set to True
@@ -316,10 +316,10 @@ class DXWorkflow(DXDataObject, DXExecutable):
         :type unset_folder: boolean
         :param stages: updates to the stages to make; see API documentation for /workflow-xxxx/update for syntax of this field; use :meth:`update_stage()` to update a single stage
         :type stages: dict
-        :param workflow_input_spec: updates to the workflow input to make; see API documentation for /workflow-xxxx/update for syntax of this field
-        :type workflow_input_spec: dict
-        :param workflow_output_spec: updates to the workflow output to make; see API documentation for /workflow-xxxx/update for syntax of this field
-        :type workflow_output_spec: dict
+        :param workflow_inputs: updates to the workflow input to make; see API documentation for /workflow-xxxx/update for syntax of this field
+        :type workflow_inputs: dict
+        :param workflow_outputs: updates to the workflow output to make; see API documentation for /workflow-xxxx/update for syntax of this field
+        :type workflow_outputs: dict
         :param edit_version: if provided, the edit version of the workflow that should be modified; if not provided, the current edit version will be used (optional)
         :type edit_version: int
 
@@ -330,10 +330,10 @@ class DXWorkflow(DXDataObject, DXExecutable):
             raise DXError('dxpy.DXWorkflow.update: cannot provide both "title" and set "unset_title"')
         if output_folder is not None and unset_output_folder:
             raise DXError('dxpy.DXWorkflow.update: cannot provide both "output_folder" and set "unset_output_folder"')
-        if workflow_input_spec is not None and unset_workflow_input_spec:
-            raise DXError('dxpy.DXWorkflow.update: cannot provide both "workflow_input_spec" and set "unset_workflow_input_spec"')
-        if workflow_output_spec is not None and unset_workflow_output_spec:
-            raise DXError('dxpy.DXWorkflow.update: cannot provide both "workflow_output_spec" and set "unset_workflow_output_spec"')
+        if workflow_inputs is not None and unset_workflow_inputs:
+            raise DXError('dxpy.DXWorkflow.update: cannot provide both "workflow_inputs" and set "unset_workflow_inputs"')
+        if workflow_outputs is not None and unset_workflow_outputs:
+            raise DXError('dxpy.DXWorkflow.update: cannot provide both "workflow_outputs" and set "unset_workflow_outputs"')
 
         if title is not None:
             update_input["title"] = title
@@ -349,14 +349,14 @@ class DXWorkflow(DXDataObject, DXExecutable):
             update_input["outputFolder"] = None
         if stages is not None:
             update_input["stages"] = stages
-        if workflow_input_spec is not None:
-            update_input["workflowInputSpec"] = workflow_input_spec
-        elif unset_workflow_input_spec:
-            update_input["workflowInputSpec"] = None
-        if workflow_output_spec is not None:
-            update_input["workflowOutputSpec"] = workflow_output_spec
-        elif unset_workflow_output_spec:
-            update_input["workflowOutputSpec"] = None
+        if workflow_inputs is not None:
+            update_input["inputs"] = workflow_inputs
+        elif unset_workflow_inputs:
+            update_input["inputs"] = None
+        if workflow_outputs is not None:
+            update_input["outputs"] = workflow_outputs
+        elif unset_workflow_outputs:
+            update_input["outputs"] = None
 
         # only perform update if there are changes to make
         if update_input:
@@ -439,7 +439,7 @@ class DXWorkflow(DXDataObject, DXExecutable):
                 self.describe() # update cached describe
 
     def is_locked(self):
-        return self._desc.get('workflowInputSpec') is not None and self._desc.get('state') == 'closed'
+        return self._desc.get('inputs') is not None and self._desc.get('state') == 'closed'
 
     def _get_input_name(self, input_str):
         '''
@@ -529,7 +529,7 @@ class DXWorkflow(DXDataObject, DXExecutable):
           is the name of the input within the stage
 
         * "name" where *name* is the name of a workflow level input
-          (defined in workflowInputSpec) or the name that has been
+          (defined in inputs) or the name that has been
           exported for the workflow (this name will appear as a key
           in the "inputSpec" of this workflow's description if it has
           been exported for this purpose)

--- a/src/python/dxpy/cli/exec_io.py
+++ b/src/python/dxpy/cli/exec_io.py
@@ -436,14 +436,14 @@ class ExecutableInputs(object):
             inaccessible_stages = [stage['id'] for stage in self._desc['stages'] if stage['accessible'] is False]
             raise DXCLIError('The workflow ' + self._desc['id'] + ' has the following inaccessible stage(s): ' + ', '.join(inaccessible_stages))
 
-        # Workflow-level inputs (defined in workflowInputSpec)
-        #  i. The workflow has no workflowInputSpec
+        # Workflow-level inputs (defined in inputs)
+        #  i. The workflow has no inputs
         #   * The inputs can be passed to stages directly
-        # ii. The workflow has workflowInputSpec (in a closed or open state)
-        #   * Only inputs defined in workflowInputSpec can be passed to the workflow,
+        # ii. The workflow has inputs (in a closed or open state)
+        #   * Only inputs defined in inputs can be passed to the workflow,
         #     using workflow-level input names
         if self._accept_only_workflow_level_inputs():
-            input_spec = self._desc.get('workflowInputSpec', [])
+            input_spec = self._desc.get('inputs', [])
 
         for spec_atom in input_spec:
             input_name = spec_atom['name']
@@ -456,7 +456,7 @@ class ExecutableInputs(object):
                 self.required_inputs.append(input_name)
 
     def _accept_only_workflow_level_inputs(self):
-        return self._desc.get('workflowInputSpec') is not None
+        return self._desc.get('inputs') is not None
 
     def update(self, new_inputs, strip_prefix=True):
         """

--- a/src/python/dxpy/utils/describe.py
+++ b/src/python/dxpy/utils/describe.py
@@ -571,7 +571,7 @@ def get_col_str(col_desc):
 
 def print_data_obj_desc(desc, verbose=False):
     recognized_fields = ['id', 'class', 'project', 'folder', 'name', 'properties', 'tags', 'types', 'hidden', 'details', 'links', 'created', 'modified', 'state', 'title', 'subtitle', 'description', 'inputSpec', 'outputSpec', 'runSpec', 'summary', 'dxapi', 'access', 'createdBy', 'summary', 'sponsored', 'developerNotes',
-                         'stages', 'workflowInputSpec', 'workflowOutputSpec', 'latestAnalysis', 'editVersion', 'outputFolder', 'initializedFrom']
+                         'stages', 'inputs', 'outputs', 'latestAnalysis', 'editVersion', 'outputFolder', 'initializedFrom']
 
     def get_advanced_inputs():
         details = desc.get("details")
@@ -628,10 +628,10 @@ def print_data_obj_desc(desc, verbose=False):
         print_nofill_field("Input Spec", get_io_spec(desc['inputSpec'], skip_fields=get_advanced_inputs()))
     if "outputSpec" in desc and desc['outputSpec'] is not None:
         print_nofill_field("Output Spec", get_io_spec(desc['outputSpec']))
-    if "workflowInputSpec" in desc:
-        print_nofill_field("Workflow Input Spec", get_io_spec(desc['workflowInputSpec']))
-    if "workflowOutputSpec" in desc:
-        print_nofill_field("Workflow Output Spec", get_io_spec(desc['workflowOutputSpec']))
+    if "inputs" in desc:
+        print_nofill_field("Workflow Inputs", get_io_spec(desc['inputs']))
+    if "outputs" in desc:
+        print_nofill_field("Workflow Outputs", get_io_spec(desc['outputs']))
     if 'runSpec' in desc:
         print_field("Interpreter", desc["runSpec"]["interpreter"])
         if "resources" in desc['runSpec']:

--- a/src/python/dxpy/workflow_builder.py
+++ b/src/python/dxpy/workflow_builder.py
@@ -152,7 +152,7 @@ def _get_validated_json(json_spec, args):
 
     # print ignored keys if present in json_spec
     supported_keys = set(["project", "folder", "name", "outputFolder", "stages",
-                          "workflowInputSpec", "workflowOutputSpec"])
+                          "inputs", "outputs"])
     unsupported_keys = _get_unsupported_keys(json_spec.keys(), supported_keys)
     if len(unsupported_keys) > 0:
         print("Warning: the following root level fields are not supported and will be ignored: {}"

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -3022,28 +3022,26 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
         self.assertIn(analysis_id, new_workflow_desc)
         self.assertIn(stage_id, new_workflow_desc)
 
-        #TODO: Workflow API changed; uncomment after replacing workflowInputSpec with inputs
-        # and workflowOutputSpec with outputs
-        # # Setting the input linking to workflowInputSpec
-        # dxpy.api.workflow_update(workflow_id,
-        #                          {"editVersion": 2,
-        #                           "workflowInputSpec": [{"name": "foo", "class": "int"}],
-        #                           "stages": {'stage_0': {'input': {'number': {'$dnanexus_link': {'workflowInputField': 'foo'}}}}}})
-        # run("dx describe " + workflow_id)
-        # analysis_id = run("dx run " + workflow_id + " -ifoo=474 -y --brief")
-        # self.assertTrue(analysis_id.startswith('analysis-'))
-        # analysis_desc = run("dx describe " + analysis_id)
-        # self.assertIn('foo', analysis_desc)
-        # analysis_desc = json.loads(run("dx describe --json " + analysis_id ))
-        # self.assertTrue(analysis_desc["runInput"], {"foo": 747})
-        # time.sleep(2) # May need to wait for job to be created in the system
-        # job_desc = run("dx describe " + analysis_desc["stages"][0]["execution"]["id"])
-        # self.assertIn(' number = 474', job_desc)
-        #
-        # # Inputs can only be passed as workflow inputs
-        # error_mesg = 'The input.+was passed to a stage but the workflow accepts inputs only on the workflow level'
-        # with self.assertSubprocessFailure(stderr_regexp=error_mesg, exit_code=3):
-        #     run("dx run " + workflow_id + " -istage_0.number=32")
+        # Setting the input linking to inputs
+        dxpy.api.workflow_update(workflow_id,
+                                 {"editVersion": 2,
+                                  "inputs": [{"name": "foo", "class": "int"}],
+                                  "stages": {'stage_0': {'input': {'number': {'$dnanexus_link': {'workflowInputField': 'foo'}}}}}})
+        run("dx describe " + workflow_id)
+        analysis_id = run("dx run " + workflow_id + " -ifoo=474 -y --brief")
+        self.assertTrue(analysis_id.startswith('analysis-'))
+        analysis_desc = run("dx describe " + analysis_id)
+        self.assertIn('foo', analysis_desc)
+        analysis_desc = json.loads(run("dx describe --json " + analysis_id ))
+        self.assertTrue(analysis_desc["runInput"], {"foo": 747})
+        time.sleep(2) # May need to wait for job to be created in the system
+        job_desc = run("dx describe " + analysis_desc["stages"][0]["execution"]["id"])
+        self.assertIn(' number = 474', job_desc)
+
+        # Inputs can only be passed as workflow inputs
+        error_mesg = 'The input.+was passed to a stage but the workflow accepts inputs only on the workflow level'
+        with self.assertSubprocessFailure(stderr_regexp=error_mesg, exit_code=3):
+            run("dx run " + workflow_id + " -istage_0.number=32")
 
     @unittest.skipUnless(testutil.TEST_RUN_JOBS, 'skipping test that runs jobs')
     def test_dx_run_clone_analysis(self):
@@ -3357,10 +3355,8 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
         desc = run("dx describe " + workflow_id)
         self.assertIn("Input Spec", desc)
         self.assertIn("Output Spec", desc)
-        #TODO: Workflow API changed; uncomment after replacing workflowInputSpec with inputs
-        # and workflowOutputSpec with outputs
-        # self.assertIn("Workflow Input Spec", desc)
-        # self.assertIn("Workflow Output Spec", desc)
+        self.assertIn("Workflow Inputs", desc)
+        self.assertIn("Workflow Outputs", desc)
         applet_id = dxpy.api.applet_new({"name": "myapplet",
                                          "project": self.project,
                                          "dxapi": "1.0.0",
@@ -3658,8 +3654,8 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
         workflow_spec = {"name": "my_workflow",
                         "outputFolder": "/",
                         "stages": [stage0, stage1],
-                        "workflowInputSpec": wf_input,
-                        "workflowOutputSpec": wf_output
+                        "inputs": wf_input,
+                        "outputs": wf_output
                         }
 
         workflow_dir = self.write_workflow_directory("dxbuilt_workflow",
@@ -3688,10 +3684,8 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
         self.assertEqual(wf_describe["stages"][1]["id"], "stage_1")
         self.assertIsNone(wf_describe["stages"][1]["name"])
         self.assertEqual(wf_describe["stages"][1]["executable"], applet_id)
-        #TODO: Workflow API changed; uncomment after replacing workflowInputSpec with inputs
-        # and workflowOutputSpec with outputs
-        # self.assertEqual(wf_describe["workflowInputSpec"], wf_input)
-        # self.assertEqual(wf_describe["workflowOutputSpec"], wf_output)
+        self.assertEqual(wf_describe["inputs"], wf_input)
+        self.assertEqual(wf_describe["outputs"], wf_output)
 
     def test_dx_build_workflow_with_destination(self):
         workflow_spec = {"name": "my_workflow"}
@@ -3755,7 +3749,6 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
                                               exit_code=3):
                 new_workflow = run("dx build --json {src_dir}".format(src_dir=workflow_dir))
 
-    @unittest.skip("Workflow API changed; unskip after replacing workflowInputSpec with inputs")
     def test_dx_build_get_build_workflow(self):
         # When building and getting a workflow multiple times we should
         # obtain functionally identical workflows, ie. identical dxworkflow.json specs.
@@ -3781,7 +3774,7 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
             "name": workflow_name,
             "outputFolder": "/",
             "stages": [stage0, stage1],
-            "workflowInputSpec": [{"name": "foo", "class": "int"}]
+            "inputs": [{"name": "foo", "class": "int"}]
         }
 
         # 1. Build
@@ -3821,8 +3814,8 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
             self.assertEqual(wf_describe_02["stages"][1]["id"], "stage_1")
             self.assertIsNone(wf_describe_02["stages"][1]["name"])
             self.assertEqual(wf_describe_02["stages"][1]["executable"], applet_id)
-            self.assertEqual(wf_describe_02["workflowInputSpec"], [{"name": "foo", "class": "int"}])
-            self.assertIsNone(wf_describe_02["workflowOutputSpec"])
+            self.assertEqual(wf_describe_02["inputs"], [{"name": "foo", "class": "int"}])
+            self.assertIsNone(wf_describe_02["outputs"])
 
     def test_build_worklow_malformed_dxworkflow_json(self):
         workflow_dir = self.write_workflow_directory("dxbuilt_workflow", "{")


### PR DESCRIPTION
This changes naming so that it is synced up with the apiserver.