### PR TITLE
PTFM 20348 invalid tls error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 
 ## Unreleased
 
+### Added
+
+* New InvalidTLSProtocol Exception raised when connection fails due to wrong TLS protocol.
+
 ## [236.0] - beta
 
 ### Added

--- a/src/python/dxpy/__init__.py
+++ b/src/python/dxpy/__init__.py
@@ -590,6 +590,11 @@ def DXHTTPRequest(resource, data, method='POST', headers=None, auth=True,
                 # If another thread closed the pool before the request was
                 # started, will throw ClosedPoolError
                 raise exceptions.UrllibInternalError("ClosedPoolError")
+            except urllib3.exceptions.ProtocolError:
+                # If the protocol error is 'connection reset by peer', most likely it is an
+                # error in the ssl handshake due to unsupported TLS protocol.
+                if 'Connection reset by peer' in exception_msg:
+                    raise exceptions.InvalidTLSProtocol(exception_msg)
 
             _raise_error_for_testing(try_index, method)
             req_id = response.headers.get("x-request-id", "unavailable")

--- a/src/python/dxpy/__init__.py
+++ b/src/python/dxpy/__init__.py
@@ -690,7 +690,7 @@ def DXHTTPRequest(resource, data, method='POST', headers=None, auth=True,
             _get_pool_manager(**pool_args).clear()
             success = False
             exception_msg = _extract_msg_from_last_exception()
-            if isinstance(e, _expected_exceptions) and not isinstance(e, exceptions.InvalidTLSProtocol):
+            if isinstance(e, _expected_exceptions):
                 # Total number of allowed tries is the initial try PLUS
                 # up to (max_retries) subsequent retries.
                 total_allowed_tries = max_retries + 1

--- a/src/python/dxpy/__init__.py
+++ b/src/python/dxpy/__init__.py
@@ -690,7 +690,7 @@ def DXHTTPRequest(resource, data, method='POST', headers=None, auth=True,
             _get_pool_manager(**pool_args).clear()
             success = False
             exception_msg = _extract_msg_from_last_exception()
-            if isinstance(e, _expected_exceptions):
+            if isinstance(e, _expected_exceptions) and not isinstance(e, exceptions.InvalidTLSProtocol):
                 # Total number of allowed tries is the initial try PLUS
                 # up to (max_retries) subsequent retries.
                 total_allowed_tries = max_retries + 1

--- a/src/python/dxpy/__init__.py
+++ b/src/python/dxpy/__init__.py
@@ -593,6 +593,7 @@ def DXHTTPRequest(resource, data, method='POST', headers=None, auth=True,
             except urllib3.exceptions.ProtocolError:
                 # If the protocol error is 'connection reset by peer', most likely it is an
                 # error in the ssl handshake due to unsupported TLS protocol.
+                exception_msg = _extract_msg_from_last_exception()
                 if 'Connection reset by peer' in exception_msg:
                     raise exceptions.InvalidTLSProtocol(exception_msg)
 

--- a/src/python/dxpy/exceptions.py
+++ b/src/python/dxpy/exceptions.py
@@ -169,12 +169,11 @@ class InvalidTLSProtocol(DXAPIError):
     Raised when the connection to the server was reset due to an ssl protocol not supported.
     Only connections with TLS v1.2 will be accepted.
     '''
-    def __init__(self, msg):
-        self.msg = msg
+    def __init__(self):
+        pass
 
     def error_message(self):
-        output = self.msg
-        output += "\nPlease refer to our blog post at https://goo.gl/zdc7MR regarding upgrading to TLS 1.2."
+        output = "Please refer to our blog post at https://blog.dnanexus.com/2017-09-23-upgrading-tls/ regarding upgrading to TLS 1.2."
         return output
 
     def __str__(self):

--- a/src/python/dxpy/exceptions.py
+++ b/src/python/dxpy/exceptions.py
@@ -164,6 +164,13 @@ class BadJSONInReply(ValueError):
     for this are the network connection breaking, or overload on the server.
     '''
 
+class InvalidTLSProtocol(DXError):
+    '''
+    Raised when the connection to the server was reset due to an ssl protocol not supported.
+    Only connections with TLS v1.2 will be accepted.
+    '''
+    def __init__(self, args):
+        self.message = "Invalid TLS protocol, please make sure your system supports TLS v1.2\n" + args
 
 class UrllibInternalError(AttributeError):
     '''

--- a/src/python/dxpy/exceptions.py
+++ b/src/python/dxpy/exceptions.py
@@ -164,13 +164,21 @@ class BadJSONInReply(ValueError):
     for this are the network connection breaking, or overload on the server.
     '''
 
-class InvalidTLSProtocol(DXError):
+class InvalidTLSProtocol(DXAPIError):
     '''
     Raised when the connection to the server was reset due to an ssl protocol not supported.
     Only connections with TLS v1.2 will be accepted.
     '''
-    def __init__(self, args):
-        self.message = "Invalid TLS protocol, please make sure your system supports TLS v1.2\n" + args
+    def __init__(self, msg):
+        self.msg = msg
+
+    def error_message(self):
+        output = self.msg
+        output += "\nPlease refer to our blog post at https://goo.gl/zdc7MR regarding upgrading to TLS 1.2."
+        return output
+
+    def __str__(self):
+        return self.error_message()
 
 class UrllibInternalError(AttributeError):
     '''


### PR DESCRIPTION
I added code to handle an exception that looks like this:
ProtocolError: ('Connection aborted.', error(54, 'Connection reset by peer'))
and throw a new exception with a custom message for the user to know that their TLS protocol is not supported.