### PR TITLE
Better handling of quotes in dx-docker

### DIFF
--- a/src/python/scripts/dx-docker
+++ b/src/python/scripts/dx-docker
@@ -278,7 +278,7 @@ def run(args):
     with os.fdopen(tempsh_file_descriptor, 'w') as tmpsh:
         lines = ['#!/bin/sh']
         lines.extend(env[2:])
-        lines.append(' '.join(container_cmd))
+        lines.append(subprocess.list2cmdline(container_cmd))
         tmpsh.write('\n'.join(lines))
 
     os.chmod(tempsh_file_path, 0o777)

--- a/src/python/scripts/dx-docker
+++ b/src/python/scripts/dx-docker
@@ -258,20 +258,43 @@ def run(args):
     to_mount = [ '/etc/host.conf', '/etc/hosts', '/etc/mtab', '/etc/networks', '/etc/passwd',
                  '/etc/group', '/etc/nsswitch.conf', '/etc/resolv.conf', '/etc/localtime',
                  '/dev/', '/sys/', '/proc/', '/run/', '/var/run/dbus/system_bus_socket']
+
+    # TODO: rename this: 'bounded' is a bit confusing and they are not always dirs
     bounded_dirs = []
     for b in to_mount:
         bounded_dirs.append('-b')
         bounded_dirs.append(b)
 
     # TODO: implement some form of nested subprocesses to avoid quoting command array if possible
+    #proot_cmd =  ["proot", '-r', '{tmpdir}/rootfs'.format(tmpdir=tmpdir)] + \
+    #             bounded_dirs + \
+    #             volume + \
+    #             ["-w", workdir] + \
+    #             env + ["/bin/sh", "-c"] + \
+    #             [" ".join(("'"+x+"'" for x in container_cmd))]
+
+
+    tempsh_file_descriptor, tempsh_file_path = tempfile.mkstemp(suffix='.sh')
+    with os.fdopen(tempsh_file_descriptor, 'w') as tmpsh:
+        lines = ['#!/bin/sh']
+        lines.extend(env[2:])
+        lines.append(' '.join(container_cmd))
+        tmpsh.write('\n'.join(lines))
+
+    os.chmod(tempsh_file_path, 0o777)
+
+
+    # Note that we assume /dx-docker-runme.sh doesn't already exist in the container
+    bounded_dirs.extend(['-b', tempsh_file_path + ':/dx-docker-runme.sh'])
+
     proot_cmd =  ["proot", '-r', '{tmpdir}/rootfs'.format(tmpdir=tmpdir)] + \
                  bounded_dirs + \
                  volume + \
                  ["-w", workdir] + \
-                 env + ["/bin/sh", "-c"] + \
-                 [" ".join(("'"+x+"'" for x in container_cmd))]
+                 ['/dx-docker-runme.sh']
 
     shell(proot_cmd)
+    os.unlink(tempsh_file_path)
     if not args.rootfs:
         shutil.rmtree(tmpdir)
 parser_run.set_defaults(func=run)


### PR DESCRIPTION
This PR basically addresses the issue here https://github.com/dnanexus/dx-toolkit/issues/252 (thanks @mr-c !) so we can eventually run all conformance tests achieve https://github.com/common-workflow-language/cwltool/pull/542.

dx-docker tests and conformance tests all pass.  @commandlinegirl could you take a look please? thanks!