### PR TITLE
Update dx-clone-asset

### DIFF
--- a/src/python/scripts/dx-clone-asset
+++ b/src/python/scripts/dx-clone-asset
@@ -38,6 +38,7 @@ def _parse_args():
     ap.add_argument('--regions',
                     help='Regions to clone asset into.  Permitted regions are:\n[{0}]'.format(', '.join(SUPPORTED_REGIONS)),
                     choices=SUPPORTED_REGIONS,
+                    default=SUPPORTED_REGIONS,
                     nargs='+',
                     metavar='',
                     required=False)
@@ -125,16 +126,17 @@ def clone_asset(record_id, regions, num_retries=0, priority=None):
     corresponding asset as the values.  If an asset is not able to be created in a given
     region, the value will be set to None.
     """
+    # Get the asset record
+    record = dxpy.DXRecord(record_id)
+    fid = record.get_details()['archiveFileId']['$dnanexus_link']
+    curr_region = dxpy.describe(record.project)['region']
+
     # Only run once per region
-    regions = set(regions)
+    regions = set(regions) - set([curr_region])
     app_supported_regions = set(CLONE_ASSET_APP.describe()['regionalOptions'].keys())
     if len(regions - app_supported_regions) > 0:
         print('Currently no support for the following region(s): [{0}]'.format(', '.join(regions - app_supported_regions)), file=sys.stderr)
         sys.exit(1)
-
-    # Get the asset record
-    record = dxpy.DXRecord(record_id)
-    fid = record.get_details()['archiveFileId']['$dnanexus_link']
 
     # Get information about the asset
     record_name = record.name


### PR DESCRIPTION
* Set the default regions to be all regions that user has access to
  (This way user doesn't have to specify regions if she wants to clone
   to all regions, which is the typical use case).
* When cloning, don't bother cloning to the region that the asset
  currently lives in.