### PR TITLE
Updating jupyter notebook support

### DIFF
--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -19,7 +19,7 @@
 
 from __future__ import print_function, unicode_literals, division, absolute_import
 
-import os, sys, datetime, getpass, collections, re, json, argparse, copy, hashlib, io, time, subprocess, glob, logging
+import os, sys, datetime, getpass, collections, re, json, argparse, copy, hashlib, io, time, subprocess, glob, logging, functools
 import shlex # respects quoted substrings when splitting
 
 import requests
@@ -5084,16 +5084,17 @@ parser_notebook = subparsers.add_parser('notebook', help='Launch a web notebook 
                                         description='Launch a web notebook inside DNAnexus.',
                                         formatter_class=argparse.RawTextHelpFormatter,
                                         prog='dx notebook')
-parser_notebook.add_argument('notebook_type', help='Type of notebook to launch', choices=['jupyter'])
-parser_notebook.add_argument('notebook_files', help='Files to include on notebook instance', default=[], nargs=argparse.REMAINDER).completer = DXPathCompleter(classes=['file'])
+parser_notebook.add_argument('notebook_type', help='Type of notebook to launch', choices=['jupyter_lab', 'jupyter_notebook'])
+parser_notebook.add_argument('--notebook_files', help='Files to include on notebook instance', default=[], nargs='*').completer = DXPathCompleter(classes=['file'])
 parser_notebook.add_argument('--spark', help='Install spark infrastructure.', action='store_true', default=False)
 parser_notebook.add_argument('--port', help='local port to use to access the notebook.', default='2001')
 parser_notebook.add_argument('--snapshot', help='A snapshot file to reform on the server.').completer = DXPathCompleter(classes=['file'])
 parser_notebook.add_argument('--timeout', help='How long to keep the notebook open (smhwMy).', default='1h')
-parser_notebook.add_argument('--ds-packages', help='Install data science packages.', action='store_true')
 parser_notebook.add_argument('-q', '--quiet', help='Do not launch web browser.', action='store_false', dest='open_server')
+parser_notebook.add_argument('--version', help='What version of the notebook app to launch.', default=None)
 parser_notebook.add_argument('--instance-type', help='Instance type to run the notebook on.', default='mem1_ssd1_x4')
-parser_notebook.set_defaults(func=run_notebook)
+notebook_with_ssh_config_check = functools.partial(run_notebook, ssh_config_check=verify_ssh_config)
+parser_notebook.set_defaults(func=notebook_with_ssh_config_check)
 register_parser(parser_notebook, categories='data', add_help=False)
 
 from ..ssh_tunnel_app_support import run_loupe

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -5084,7 +5084,7 @@ parser_notebook = subparsers.add_parser('notebook', help='Launch a web notebook 
                                         description='Launch a web notebook inside DNAnexus.',
                                         formatter_class=argparse.RawTextHelpFormatter,
                                         prog='dx notebook')
-parser_notebook.add_argument('notebook_type', help='Type of notebook to launch', choices=['jupyter_lab', 'jupyter_notebook'])
+parser_notebook.add_argument('notebook_type', help='Type of notebook to launch', choices=['jupyter_lab', 'jupyter_notebook', 'jupyter'])
 parser_notebook.add_argument('--notebook_files', help='Files to include on notebook instance', default=[], nargs='*').completer = DXPathCompleter(classes=['file'])
 parser_notebook.add_argument('--spark', help='Install spark infrastructure.', action='store_true', default=False)
 parser_notebook.add_argument('--port', help='local port to use to access the notebook.', default='2001')

--- a/src/python/dxpy/ssh_tunnel_app_support.py
+++ b/src/python/dxpy/ssh_tunnel_app_support.py
@@ -105,7 +105,6 @@ def run_notebook(args, ssh_config_check):
             err_exit(msg)
     else:
         executable = 'app-{0}'.format(NOTEBOOK_APP)
-    executable = 'applet-F7Z21Pj0JzjgbFbXJ2BvBXGj'
     # Compose the command to launch the notebook
     cmd = ['dx', 'run', executable, '-inotebook_type={0}'.format(args.notebook_type)]
     cmd += ['-iinput_files={0}'.format(f) for f in args.notebook_files]

--- a/src/python/dxpy/ssh_tunnel_app_support.py
+++ b/src/python/dxpy/ssh_tunnel_app_support.py
@@ -117,7 +117,7 @@ def run_notebook(args, ssh_config_check):
 
     poll_for_server_running(job_id)
 
-    if args.notebook_type == 'jupyter':
+    if args.notebook_type in {'jupyter', 'jupyter_lab', 'jupyter_notebook'}:
         remote_port = 8888
 
     setup_ssh_tunnel(job_id, args.port, remote_port)


### PR DESCRIPTION
* Removing datascience package support (snapshots make this obsolete)
* Allows user to specify a specific version of the notebook app to use
* Checks that the user has ssh configured and throws an error if not
* Allows user to select the traditional jupyter notebook interface or jupyter lab interface
* Changes subprocess calls to use the preferred list notation rather than string with shell=True
* Some additional comments to document processing.