### PR TITLE
Fixing bug with asset in dxapp.json

### DIFF
--- a/src/python/dxpy/app_builder.py
+++ b/src/python/dxpy/app_builder.py
@@ -553,11 +553,15 @@ def upload_applet(src_dir, uploaded_resources, check_name_collisions=True, overw
         if "id" in asset:
             asset_record = dxpy.DXRecord(asset["id"]).describe(fields={'details'}, default_fields=True)
         elif "name" in asset and asset_project is not None and "version" in asset:
-            asset_record = dxpy.find_one_data_object(zero_ok=True, classname="record", typename="AssetBundle",
-                                                     name=asset["name"], properties=dict(version=asset["version"]),
-                                                     project=asset_project, folder=asset_folder,
-                                                     describe={"defaultFields": True, "fields": {"details": True}},
-                                                     state="closed")
+            try:
+                asset_record = dxpy.find_one_data_object(zero_ok=True, classname="record", typename="AssetBundle",
+                                                         name=asset["name"], properties=dict(version=asset["version"]),
+                                                         project=asset_project, folder=asset_folder, recurse=False,
+                                                         describe={"defaultFields": True, "fields": {"details": True}},
+                                                         state="closed", more_ok=False)
+            except DXSearchError:
+                msg = "Found more than one asset record that matches: name={0}, folder={1} in project={2}."
+                raise AppBuilderException(msg.format(asset["name"], asset_folder, asset_project)
         else:
             raise AppBuilderException("Each runSpec.assetDepends element must have either {'id'} or "
                                       "{'name', 'project' and 'version'} field(s).")

--- a/src/python/dxpy/app_builder.py
+++ b/src/python/dxpy/app_builder.py
@@ -559,9 +559,9 @@ def upload_applet(src_dir, uploaded_resources, check_name_collisions=True, overw
                                                          project=asset_project, folder=asset_folder, recurse=False,
                                                          describe={"defaultFields": True, "fields": {"details": True}},
                                                          state="closed", more_ok=False)
-            except DXSearchError:
+            except dxpy.exceptions.DXSearchError:
                 msg = "Found more than one asset record that matches: name={0}, folder={1} in project={2}."
-                raise AppBuilderException(msg.format(asset["name"], asset_folder, asset_project)
+                raise AppBuilderException(msg.format(asset["name"], asset_folder, asset_project))
         else:
             raise AppBuilderException("Each runSpec.assetDepends element must have either {'id'} or "
                                       "{'name', 'project' and 'version'} field(s).")


### PR DESCRIPTION
If an asset is specified in dxapp.json using a project and path, then we should require
1. That the asset exist in the exact path specified (i.e. not look in subfolders for the given path)
2. Insist that there be only a single asset that matches the description.

Currently, it could be that a user specifies an asset like
project=project-982uq3954732894324
folder=/foo
name=my_asset

Inside of project-982uq3954732894324 there could be an asset called my_asset in the /foo folder and
also an asset in the /foo/.archive folder.  The system may return the asset from the .archive folder
and the user would be none the wiser!  This seems bad.  If a user specifies the path to an asset,
we should require it be that exact path.