### PR TITLE
SCI-629 clone asset fix

### DIFF
--- a/src/python/scripts/dx-clone-asset
+++ b/src/python/scripts/dx-clone-asset
@@ -70,7 +70,7 @@ def _find_asset_project(region):
         projects = subprocess.check_output(cmd.format(project_name, region), shell=True).strip()
         if projects == '':
             cmd = 'dx new project --region "{0}" "{1}" --brief '
-            project = subprocess.check_output(cmd.format(region, project_name), shell=True).strip()
+            return subprocess.check_output(cmd.format(region, project_name), shell=True).strip()
         else:
             projects = projects.split('\n')
             return projects[0]

--- a/src/python/scripts/dx-clone-asset
+++ b/src/python/scripts/dx-clone-asset
@@ -2,7 +2,6 @@
 
 from __future__ import print_function
 import argparse
-import subprocess
 import multiprocessing
 import time
 import functools
@@ -10,6 +9,7 @@ import sys
 import json
 
 import dxpy
+from dxpy.exceptions import DXJobFailureError
 
 ASSET_PROJECT_PREFIX = 'DNAnexus Assets for'
 URL_DURATION = 60 * 60 * 24
@@ -49,35 +49,26 @@ def _parse_args():
                     required=False)
     ap.add_argument('--priority',
                     help='Priority with which to run the clone_asset app',
-                    choices = ['normal', 'high'],
+                    choices=['normal', 'high'],
                     required=False)
 
     return ap.parse_args()
 
 
 def _find_asset_project(region):
-    """
-    Returns the asset project for the given region, or None if a problem arrises.
+    """Returns the asset project for the given region, or None if a problem arises.
+
+    If multiple matches are found within a region, the first is returned
     """
     project_name = '{0} {1}'.format(ASSET_PROJECT_PREFIX, region)
 
-    # Try to find the asset project for the given region.
-    # If more than 1 project with the asset project name is found
-    # for the given region, or if no project is found and one
-    # can't be created, return None indicating there was a problem.
     try:
-        cmd = 'dx find projects --level CONTRIBUTE --name "{0}" --region "{1}" --brief '
-        projects = subprocess.check_output(cmd.format(project_name, region), shell=True).strip()
-        if projects == '':
-            cmd = 'dx new project --region "{0}" "{1}" --brief '
-            return subprocess.check_output(cmd.format(region, project_name), shell=True).strip()
-        else:
-            projects = projects.split('\n')
-            return projects[0]
-    except:
-        pass
-
-    return None
+        projects = dxpy.find_projects(name=project_name, region=region)
+        project = next(
+            projects, dxpy.api.project_new({'name': project_name, 'region': region}))
+        return project['id']
+    except Exception as e:
+        print(repr(e))
 
 
 def _clone_asset_into_region(region, record_name, asset_properties, asset_file_name, url, num_retries, q, priority):
@@ -89,30 +80,27 @@ def _clone_asset_into_region(region, record_name, asset_properties, asset_file_n
     The function will return the record_id of the new asset if successful, or None if it is not successful.
     """
     # Get the official asset project for the given region.
-    project = _find_asset_project(region)
+    project_id = _find_asset_project(region)
     # If no official asset project is found and one can't be created,
     # just return None.
-    if project is None:
+    if project_id is None:
         return {region: None}
 
     # Now try to run the CLONE_ASSET_APP num_retries + 1 times.
     curr_try = 0
     while curr_try <= num_retries:
-        cmd = ['dx', 'run', CLONE_ASSET_APP_NAME, '--project', project, '-iurl=' + url, '-irecord_name=' + record_name]
-        cmd += ['-iasset_file_name=' + asset_file_name, '-iasset_properties=' + json.dumps(asset_properties), '--brief']
-        job = subprocess.check_output(cmd).strip()
-        print('{0}: {1}'.format(region, job), file=sys.stderr)
+        job = CLONE_ASSET_APP.run(
+            executable_input={
+                'asset_properties': json.dumps(asset_properties), 'url': url,
+                'record_name': record_name, 'asset_file_name': asset_file_name},
+            project=project_id)
+        print('{0}: {1}'.format(region, job.get_id()), file=sys.stderr)
         try:
-            cmd = 'dx wait {0} '.format(job)
-            subprocess.check_output(cmd, shell=True)
-        except:
-            pass
-        cmd = 'dx describe {0} --json '.format(job)
-        job_desc = json.loads(subprocess.check_output(cmd, shell=True).strip())
-
-        if job_desc['state'] == 'done':
+            job.wait_on_done()
             q.put(region)
-            return {region: job_desc['output']['asset_bundle']}
+            return {region: job.describe()['output']['asset_bundle']}
+        except DXJobFailureError:
+            pass
 
         curr_try += 1
 


### PR DESCRIPTION
**Motivation**

`dx-clone-asset` script consistently fails when region specific projects don't exist. Expected behavior is the region specific projects are created then used for the asset clone.

**Changes**

* It was just a missing return statement in the `_find_asset_project` function.
* Also decided to remove `subprocess` usage since using subprocess to call `dxpy` functions isn't as readable.