### PR TITLE
Fetch c-ares 1.12.0 from c-ares.haxx.se

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -461,7 +461,7 @@ CARES_PV=1.13.0
 CARES_SHA=dde50284cc3d505fb2463ff6276e61d5531b1d68
 c-ares/stage/lib/libcares.la: shasum
 	mkdir -p c-ares
-	curl ${UBUNTU_MIRROR}/pool/main/c/c-ares/c-ares_${CARES_PV}.orig.tar.gz > c-ares-${CARES_PV}.tar.gz
+	curl https://c-ares.haxx.se/download/c-ares-${CARES_PV}.tar.gz > c-ares-${CARES_PV}.tar.gz
 	[[ $$(shasum c-ares-${CARES_PV}.tar.gz|cut -f 1 -d ' ') == $(CARES_SHA) ]]
 	tar -xzf c-ares-${CARES_PV}.tar.gz -C c-ares --strip-components=1
 	cd c-ares; ./configure --prefix=/


### PR DESCRIPTION
c-ares 1.13.0 has an issue preventing it from building on Windows (https://github.com/c-ares/c-ares/issues/119). Until the fix makes its way into a tagged release, we can keep using 1.12.0.