### PR TITLE
PTFM-21231: inline cluster bootstrapScript

### DIFF
--- a/src/python/dxpy/app_builder.py
+++ b/src/python/dxpy/app_builder.py
@@ -541,11 +541,12 @@ def upload_applet(src_dir, uploaded_resources, check_name_collisions=True, overw
 
     # If this is a cluster applet, inline all provided bootstrapScript code
     # NOTE: assumes bootstrapScript is always provided as a filename
-    sys_reqs = applet_spec["runSpec"]["systemRequirements"]
-    for entry_point in sys_reqs:
-        if "clusterSpec" in sys_reqs[entry_point]:
-            with open(os.path.join(src_dir, sys_reqs[entry_point]["clusterSpec"]["bootstrapScript"])) as code_fh:
-                sys_reqs[entry_point]["clusterSpec"]["bootstrapScript"] = code_fh.read()
+    if "systemRequirements" in applet_spec["runSpec"]:
+        sys_reqs = applet_spec["runSpec"]["systemRequirements"]
+        for entry_point in sys_reqs:
+            if "clusterSpec" in sys_reqs[entry_point]:
+                with open(os.path.join(src_dir, sys_reqs[entry_point]["clusterSpec"]["bootstrapScript"])) as code_fh:
+                    sys_reqs[entry_point]["clusterSpec"]["bootstrapScript"] = code_fh.read()
 
     # Attach bundled resources to the app
     if uploaded_resources is not None:

--- a/src/python/dxpy/app_builder.py
+++ b/src/python/dxpy/app_builder.py
@@ -539,6 +539,14 @@ def upload_applet(src_dir, uploaded_resources, check_name_collisions=True, overw
             applet_spec["runSpec"]["code"] = code_fh.read()
             del applet_spec["runSpec"]["file"]
 
+    # If this is a cluster applet, inline all provided bootstrapScript code
+    # NOTE: assumes bootstrapScript is always provided as a filename
+    sys_reqs = applet_spec["runSpec"]["systemRequirements"]
+    for entry_point in sys_reqs:
+        if "clusterSpec" in sys_reqs[entry_point]:
+            with open(os.path.join(src_dir, sys_reqs[entry_point]["clusterSpec"]["bootstrapScript"])) as code_fh:
+                sys_reqs[entry_point]["clusterSpec"]["bootstrapScript"] = code_fh.read()
+
     # Attach bundled resources to the app
     if uploaded_resources is not None:
         applet_spec["runSpec"]["bundledDepends"].extend(uploaded_resources)


### PR DESCRIPTION
Users can provide a filename under `clusterSpec.bootstrapScript`, where the listed file contains code to run during each cluster worker's setup. The contents of this file need to be read and inlined in the applet doc at build time (just like we do when a user provides their applet's source code filename under `runSpec.file`)

**Question:** Do I need to make changes anywhere else besides `dxpy`?

Test plan: 
`nucleus$ export DXTEST_ISOLATED_ENV=1`
`nucleus$ run_integration_tests.sh --client_tests_only --tests test_dxclient.TestDXBuildApp.test_build_cluster_app_bootstrap_script_inlined`