### PR TITLE
DEVEX-562 Add a note about dx publish when building apps or global workflows

### DIFF
--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -134,6 +134,9 @@ class ResultCounter():
         return ('\n' if self.counter > 1 else '') + UNDERLINE() + 'Result ' + \
             str(self.counter) + ':' + ENDC()
 
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
 def get_json_from_stdin():
     user_json_str = input('Type JSON here> ')
     user_json = None
@@ -2642,12 +2645,7 @@ def remove_users(args):
 
 def list_users(args):
     desc = try_call(resolve_global_executable, args.app)
-
-    #TODO: simplify when we add "authorizedUsers" to the describe output of global workflows
-    if desc['class'] == 'app':
-        users = desc['authorizedUsers']
-    else:
-        users = dxpy.api.global_workflow_list_authorized_users(desc['id'])['authorizedUsers']
+    users = desc['authorizedUsers']
 
     for user in users:
         print(user)
@@ -3636,8 +3634,6 @@ def upgrade(args):
         err_exit()
 
 def generate_batch_inputs(args):
-    def eprint(*args, **kwargs):
-        print(*args, file=sys.stderr, **kwargs)
 
     # Internally restricted maximum batch size for a TSV
     MAX_BATCH_SIZE = 500
@@ -3706,6 +3702,15 @@ def publish(args):
             dxpy.api.app_publish(desc['id'], input_params={"makeDefault": args.make_default})
         else:
             dxpy.api.global_workflow_publish(desc['id'], input_params={"makeDefault": args.make_default})
+
+        eprint("Published {} successfully".format(args.executable))
+
+        if desc['authorizedUsers']:
+            eprint("It is now available to the authorized users: {}".format(", ".join(desc['authorizedUsers'])))
+
+        eprint("You can add or remove users with:")
+        eprint("  dx add users {} user-xxxx".format(desc['name']))
+        eprint("  dx remove users {} user-yyyy".format(desc['name']))
     except:
         err_exit()
 

--- a/src/python/dxpy/scripts/dx_build_app.py
+++ b/src/python/dxpy/scripts/dx_build_app.py
@@ -876,7 +876,8 @@ def build_and_upload_locally(src_dir, mode, overwrite=False, archive=False, publ
             else:
                 print("Uploaded app %s/%s (%s) successfully" % (app_describe["name"], app_describe["version"], app_id), file=sys.stderr)
                 print("You can publish this app with:", file=sys.stderr)
-                print("  dx api app-%s/%s publish \"{\\\"makeDefault\\\": true}\"" % (app_describe["name"], app_describe["version"]), file=sys.stderr)
+                print("  dx publish {n}/{v} --make_default".format(n=app_describe["name"],
+                                                                   v=app_describe["version"]), file=sys.stderr)
 
             return app_describe if return_object_dump else {"id": app_id}
 


### PR DESCRIPTION
When an app was built we would print the message "To publish this app, use `dx api ....`. I replaced with `dx publish` and added a similar message to global workflow. I additionally cleaned the code a little bit. Thanks!