### PR TITLE
DEVEX-745 Add default flag to dx publish by default

### DIFF
--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -5494,9 +5494,9 @@ parser_publish = subparsers.add_parser('publish', help='Publish an app or a glob
                                    prog='dx publish')
 parser_publish.add_argument('executable',
                             help='ID or name and version of an app/global workflow, e.g. myqc/1.0.0').completer = DXPathCompleter(classes=['app', 'globalworkflow'])
-parser_publish.add_argument('--make_default',
-                            help='Set a "default" alias on the published version',
-                            action='store_true', dest='make_default')
+parser_publish.add_argument('--no-default',
+                            help='Do not set a "default" alias on the published version',
+                            action='store_false', dest='make_default')
 parser_publish.set_defaults(func=publish)
 register_parser(parser_publish)
 

--- a/src/python/dxpy/scripts/dx_build_app.py
+++ b/src/python/dxpy/scripts/dx_build_app.py
@@ -876,8 +876,8 @@ def build_and_upload_locally(src_dir, mode, overwrite=False, archive=False, publ
             else:
                 print("Uploaded app %s/%s (%s) successfully" % (app_describe["name"], app_describe["version"], app_id), file=sys.stderr)
                 print("You can publish this app with:", file=sys.stderr)
-                print("  dx publish {n}/{v} --make_default".format(n=app_describe["name"],
-                                                                   v=app_describe["version"]), file=sys.stderr)
+                print("  dx publish {n}/{v}".format(n=app_describe["name"],
+                                                    v=app_describe["version"]), file=sys.stderr)
 
             return app_describe if return_object_dump else {"id": app_id}
 

--- a/src/python/dxpy/utils/resolver.py
+++ b/src/python/dxpy/utils/resolver.py
@@ -1234,7 +1234,7 @@ def resolve_global_executable(path, is_version_required=False):
     - named ID with alias (version or tag), e.g. "myapp/1.2.0", "myworkflow/1.2.0"
     - named ID with prefix and with alias (version or tag), e.g. "app-myapp/1.2.0", "globalworkflow-myworkflow/1.2.0"
     """
-    if is_version_required and "/" not in path:
+    if not is_hashid(path) and is_version_required and "/" not in path:
         raise ResolutionError('Version is required, e.g. "myexec/1.0.0"'.format())
 
     # First, check if the prefix is provided, then we don't have to resolve the name

--- a/src/python/dxpy/workflow_builder.py
+++ b/src/python/dxpy/workflow_builder.py
@@ -389,8 +389,8 @@ def _build_global_workflow(json_spec, args):
         logger.info("Uploaded global workflow {n}/{v} successfully".format(n=gwf_final_json["name"],
                                                                            v=gwf_final_json["version"]))
         logger.info("You can publish this workflow with:")
-        logger.info("  dx publish {n}/{v} --make_default".format(n=gwf_final_json["name"],
-                                                                 v=gwf_final_json["version"]))
+        logger.info("  dx publish {n}/{v}".format(n=gwf_final_json["name"],
+                                                  v=gwf_final_json["version"]))
     finally:
         # Clean up
         if projects_by_region:


### PR DESCRIPTION
Currently, you have to add the "--make-default" flag to "dx publish" to set the published version as default. But making it immediately default is going to be most often used operation so we should not force the user to add this flag each time they publish. It will also make it consistent with "dx build --app --publish", which publishes the app after building and immediately makes it the default version.