### PR TITLE
Wait file list

### DIFF
--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -2409,6 +2409,12 @@ def close(args):
 
 def wait(args):
     had_error = False
+    # If only one path provided, check to see if it is a local file
+    # and if so gather actual paths on which to wait from the contents 
+    # of the file.
+    if len(args.path) == 1 and os.path.isfile(args.path[0]):
+        args.path = open(args.path[0]).read().strip().split('\n')
+
     for path in args.path:
         if is_job_id(path) or is_analysis_id(path):
             dxexecution = dxpy.get_handler(path)
@@ -4965,7 +4971,7 @@ register_parser(parser_close, categories=('data', 'metadata'))
 # wait
 #####################################
 parser_wait = subparsers.add_parser('wait', help='Wait for data object(s) to close or job(s) to finish',
-                                    description='Polls the state of specified data object(s) or job(s) until they are all in the desired state.  Waits until the "closed" state for a data object, and for any terminal state for a job ("terminated", "failed", or "done").  Exits with a non-zero code if a job reaches a terminal state that is not "done".',
+                                    description='Polls the state of specified data object(s) or job(s) until they are all in the desired state.  Waits until the "closed" state for a data object, and for any terminal state for a job ("terminated", "failed", or "done").  Exits with a non-zero code if a job reaches a terminal state that is not "done".  Can also provide a local file containing a list of data object(s) or job(s), one per line.',
                                     prog='dx wait',
                                     parents=[env_args])
 path_action = parser_wait.add_argument('path', help='Path to a data object or job ID to wait for', nargs='+')

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -2413,7 +2413,11 @@ def wait(args):
     # and if so gather actual paths on which to wait from the contents 
     # of the file.
     if len(args.path) == 1 and os.path.isfile(args.path[0]):
-        args.path = open(args.path[0]).read().strip().split('\n')
+        try:
+            args.path = open(args.path[0]).read().strip().split('\n')
+        except IOError as e:
+            raise DXCLIError(
+                'Could not open {}. The problem was: {}' % (args.path[0], e))
 
     for path in args.path:
         if is_job_id(path) or is_analysis_id(path):
@@ -4974,7 +4978,7 @@ parser_wait = subparsers.add_parser('wait', help='Wait for data object(s) to clo
                                     description='Polls the state of specified data object(s) or job(s) until they are all in the desired state.  Waits until the "closed" state for a data object, and for any terminal state for a job ("terminated", "failed", or "done").  Exits with a non-zero code if a job reaches a terminal state that is not "done".  Can also provide a local file containing a list of data object(s) or job(s), one per line.',
                                     prog='dx wait',
                                     parents=[env_args])
-path_action = parser_wait.add_argument('path', help='Path to a data object or job ID to wait for', nargs='+')
+path_action = parser_wait.add_argument('path', help='Path to a data object, job ID, or file with IDs to wait for', nargs='+')
 path_action.completer = DXPathCompleter()
 parser_wait.set_defaults(func=wait)
 register_parser(parser_wait, categories=('data', 'metadata', 'exec'))

--- a/src/python/scripts/dx-clone-asset
+++ b/src/python/scripts/dx-clone-asset
@@ -17,6 +17,7 @@ URL_DURATION = 60 * 60 * 24
 SLEEP_TIME = 5
 CLONE_ASSET_APP_NAME = '_clone_asset'
 CLONE_ASSET_APP = dxpy.find_one_app(zero_ok=False, more_ok=False, name=CLONE_ASSET_APP_NAME, return_handler=True)
+GLOBAL_ASSET_PROJECT_PREFIX = 'App and Applet Assets'
 
 # Get the set of supported regions
 SUPPORTED_REGIONS = set()
@@ -25,6 +26,18 @@ if user_description['billTo'].startswith('user-'):
     SUPPORTED_REGIONS = set(user_description['permittedRegions'])
 elif user_description['billTo'].startswith('org-'):
     SUPPORTED_REGIONS = set(dxpy.api.org_describe(user_description['billTo'])['permittedRegions'])
+
+
+def _get_public_asset_projects():
+    projects = dxpy.find_projects(name='^'+GLOBAL_ASSET_PROJECT_PREFIX, name_mode='regexp', public=True, return_handler=True)
+    project_by_region = {}
+    for project in projects:
+        # Note: if there is more than one project that matches the GLOBAL_ASSET_PROJECT_PREFIX in a given region
+        # we will be taking the last one here and ignoring the others.  We could consider raising a warning or
+        # error out, but my current feeling is that this is just too verbose and not to worry about it. (Famous last words).
+        project_by_region[project.region] = project.id
+
+    return project_by_region
 
 
 def _parse_args():
@@ -50,8 +63,12 @@ def _parse_args():
                     type=int,
                     required=False)
     ap.add_argument('--priority',
-                    help='Priority with which to run the clone_asset app',
+                    help='Priority with which to run the clone_asset app.',
                     choices=['normal', 'high'],
+                    required=False)
+    ap.add_argument('--publish',
+                    help='Move the assets to the public assets project upon completion.',
+                    action='store_true',
                     required=False)
 
     return ap.parse_args()
@@ -195,14 +212,45 @@ def clone_asset(record_id, regions, num_retries=0, priority=None):
     return record_ids
 
 
-def main(record, regions, num_retries=0, priority=None):
+def publish_assets(src_record, record_ids, publish):
+    public_asset_projects_by_region = _get_public_asset_projects()
+
+    # Add src_record to list of records to publish
+    dx_record = dxpy.DXRecord(src_record)
+    region = dxpy.describe(dx_record.project)['region']
+    record_ids[region] = dx_record.id
+
+    # Print a message if we're not actually going to publish the records
+    if not publish:
+        print('To publish your records at a later point in time, run:')
+
+    for region, record_id in record_ids.iteritems():
+        if region not in public_asset_projects_by_region:
+            print('Did not find public asset project for region {region}.'.format(region=region))
+            continue
+        dx_record = dxpy.DXRecord(record_id)
+        if publish:
+            dx_record.clone(public_asset_projects_by_region[region])
+            print('Published asset for region {region} in project {project}.'.format(region=region, 
+                project=public_asset_projects_by_region[region]))
+            dx_record.remove()
+        else:
+            msg = '  dx cp {src_project}:{record_id} {dest_project}:/'.format(src_project=dx_record.project,
+                record_id=record_id, dest_project=public_asset_projects_by_region[region])
+            print(msg)
+
+
+def main(record, regions, num_retries=0, priority=None, publish=False):
     record_ids = clone_asset(record, regions, num_retries, priority)
 
     for region in record_ids:
         record_id = 'Failed' if record_ids[region] is None else record_ids[region]
         print('{region}:\t{record_id}'.format(region=region, record_id=record_id))
 
+    all_record_ids = record_ids.copy()
+    publish_assets(record, record_ids, publish)
+
 
 if __name__ == '__main__':
     args = _parse_args()
-    main(args.record, args.regions, args.num_retries, args.priority)
+    main(args.record, args.regions, args.num_retries, args.priority, args.publish)

--- a/src/python/scripts/dx-clone-asset
+++ b/src/python/scripts/dx-clone-asset
@@ -29,7 +29,7 @@ elif user_description['billTo'].startswith('org-'):
 
 
 def _get_public_asset_projects():
-    projects = dxpy.find_projects(name='^'+GLOBAL_ASSET_PROJECT_PREFIX, name_mode='regexp', public=True, return_handler=True)
+    projects = dxpy.find_projects(name='^'+GLOBAL_ASSET_PROJECT_PREFIX, name_mode='regexp', public=True, return_handler=True, level='UPLOAD')
     project_by_region = {}
     for project in projects:
         # Note: if there is more than one project that matches the GLOBAL_ASSET_PROJECT_PREFIX in a given region

--- a/src/python/scripts/dx-clone-asset
+++ b/src/python/scripts/dx-clone-asset
@@ -17,7 +17,6 @@ URL_DURATION = 60 * 60 * 24
 SLEEP_TIME = 5
 CLONE_ASSET_APP_NAME = '_clone_asset'
 CLONE_ASSET_APP = dxpy.find_one_app(zero_ok=False, more_ok=False, name=CLONE_ASSET_APP_NAME, return_handler=True)
-GLOBAL_ASSET_PROJECT_PREFIX = 'App and Applet Assets'
 
 # Get the set of supported regions
 SUPPORTED_REGIONS = set()
@@ -26,18 +25,6 @@ if user_description['billTo'].startswith('user-'):
     SUPPORTED_REGIONS = set(user_description['permittedRegions'])
 elif user_description['billTo'].startswith('org-'):
     SUPPORTED_REGIONS = set(dxpy.api.org_describe(user_description['billTo'])['permittedRegions'])
-
-
-def _get_public_asset_projects():
-    projects = dxpy.find_projects(name='^'+GLOBAL_ASSET_PROJECT_PREFIX, name_mode='regexp', public=True, return_handler=True, level='UPLOAD')
-    project_by_region = {}
-    for project in projects:
-        # Note: if there is more than one project that matches the GLOBAL_ASSET_PROJECT_PREFIX in a given region
-        # we will be taking the last one here and ignoring the others.  We could consider raising a warning or
-        # error out, but my current feeling is that this is just too verbose and not to worry about it. (Famous last words).
-        project_by_region[project.region] = project.id
-
-    return project_by_region
 
 
 def _parse_args():
@@ -63,12 +50,8 @@ def _parse_args():
                     type=int,
                     required=False)
     ap.add_argument('--priority',
-                    help='Priority with which to run the clone_asset app.',
+                    help='Priority with which to run the clone_asset app',
                     choices=['normal', 'high'],
-                    required=False)
-    ap.add_argument('--publish',
-                    help='Move the assets to the public assets project upon completion.',
-                    action='store_true',
                     required=False)
 
     return ap.parse_args()
@@ -212,45 +195,14 @@ def clone_asset(record_id, regions, num_retries=0, priority=None):
     return record_ids
 
 
-def publish_assets(src_record, record_ids, publish):
-    public_asset_projects_by_region = _get_public_asset_projects()
-
-    # Add src_record to list of records to publish
-    dx_record = dxpy.DXRecord(src_record)
-    region = dxpy.describe(dx_record.project)['region']
-    record_ids[region] = dx_record.id
-
-    # Print a message if we're not actually going to publish the records
-    if not publish:
-        print('To publish your records at a later point in time, run:')
-
-    for region, record_id in record_ids.iteritems():
-        if region not in public_asset_projects_by_region:
-            print('Did not find public asset project for region {region}.'.format(region=region))
-            continue
-        dx_record = dxpy.DXRecord(record_id)
-        if publish:
-            dx_record.clone(public_asset_projects_by_region[region])
-            print('Published asset for region {region} in project {project}.'.format(region=region, 
-                project=public_asset_projects_by_region[region]))
-            dx_record.remove()
-        else:
-            msg = '  dx cp {src_project}:{record_id} {dest_project}:/'.format(src_project=dx_record.project,
-                record_id=record_id, dest_project=public_asset_projects_by_region[region])
-            print(msg)
-
-
-def main(record, regions, num_retries=0, priority=None, publish=False):
+def main(record, regions, num_retries=0, priority=None):
     record_ids = clone_asset(record, regions, num_retries, priority)
 
     for region in record_ids:
         record_id = 'Failed' if record_ids[region] is None else record_ids[region]
         print('{region}:\t{record_id}'.format(region=region, record_id=record_id))
 
-    all_record_ids = record_ids.copy()
-    publish_assets(record, record_ids, publish)
-
 
 if __name__ == '__main__':
     args = _parse_args()
-    main(args.record, args.regions, args.num_retries, args.priority, args.publish)
+    main(args.record, args.regions, args.num_retries, args.priority)


### PR DESCRIPTION
Adding ability to provide a file which contains a list of jobs or data objects upon which to wait.  

We ran into instances where we wanted to wait on a number of objects and hit bash limits on the number of characters that could be provided at the command line.  This new feature will allow us to get around that by simply specifying the longer list of jobs or data objects in a file instead of as command line arguments.