### PR TITLE
DEVEX-660 `dx watch  job-id` for reuse

### DIFF
--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -3409,6 +3409,11 @@ def watch(args):
     if not re.match("^job-[0-9a-zA-Z]{24}$", args.jobid):
         err_exit(args.jobid + " does not look like a DNAnexus job ID")
 
+    job_describe = dxpy.describe(args.jobid)
+    if 'outputReusedFrom' in job_describe and job_describe['outputReusedFrom'] is not None:
+      args.jobid = job_describe['outputReusedFrom']
+      print("Output reused from %s" %(args.jobid))
+
     log_client = DXJobLogStreamClient(args.jobid, input_params=input_params, msg_callback=msg_callback,
                                       msg_output_format=args.format, print_job_info=args.job_info)
 

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -3412,7 +3412,8 @@ def watch(args):
     job_describe = dxpy.describe(args.jobid)
     if 'outputReusedFrom' in job_describe and job_describe['outputReusedFrom'] is not None:
       args.jobid = job_describe['outputReusedFrom']
-      print("Output reused from %s" %(args.jobid))
+      if not args.quiet:
+        print("Output reused from %s" %(args.jobid))
 
     log_client = DXJobLogStreamClient(args.jobid, input_params=input_params, msg_callback=msg_callback,
                                       msg_output_format=args.format, print_job_info=args.job_info)


### PR DESCRIPTION
If a job is reused, when running `dx watch job-id`, instead stream the jobLog of the reused job.