### PR TITLE
TIP-415: extend DXHTTPRequest; allow overriding of httpclient to send client certificate in request.

### DIFF
--- a/src/java/src/main/java/com/dnanexus/DXHTTPRequest.java
+++ b/src/java/src/main/java/com/dnanexus/DXHTTPRequest.java
@@ -92,7 +92,7 @@ public class DXHTTPRequest {
 
     private final String apiserver;
 
-    private final HttpClient httpclient;
+    protected final HttpClient httpclient;
 
     private final boolean disableRetry;
 
@@ -154,6 +154,13 @@ public class DXHTTPRequest {
         //These timeouts prevent stuck of requests
         RequestConfig requestConfig = RequestConfig.custom().setConnectTimeout(env.getConnectionTimeout()).setSocketTimeout(env.getSocketTimeout()).build();
         this.httpclient = HttpClientBuilder.create().setUserAgent(USER_AGENT).setDefaultRequestConfig(requestConfig).build();
+    }
+
+    /**
+     * Allows custom DXHTTPRequest to setup overridden httpClient 
+     */
+    protected HttpClient getHttpClient() {
+        return this.httpclient;
     }
 
     /**
@@ -282,7 +289,7 @@ public class DXHTTPRequest {
                 // TODO: distinguish between errors during connection init and socket errors while
                 // sending or receiving data. The former can always be retried, but the latter can
                 // only be retried if the request is idempotent.
-                HttpResponse response = httpclient.execute(request);
+                HttpResponse response = getHttpClient().execute(request);
 
                 statusCode = response.getStatusLine().getStatusCode();
                 requestId = getHeader(response, "X-Request-ID");


### PR DESCRIPTION
required for TIP private routes for 'database-xxxx' operations. Changes in tip Apiserver client implementation overrides httpclient implementation with sslcontext. Keystore path, keystore password etc. passed as system property from hivemetastore and thriftserver.

@arunbhat @durae @geetduggal @wkoetke 