### PR TITLE
Make dx tool (& dxpy imports) usable with python 3

### DIFF
--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -3805,7 +3805,7 @@ def generate_batch_inputs(args):
             if len(matches['ids']) > 1:
                 eprint("Input {iname} is associated with a file name that matches multiple IDs:".format(iname=input_name))
                 eprint("    {fname} => {ids}".format(fname=matches['name'], ids=", ".join(matches['ids'])))
-	eprint("")
+                eprint("")
 
     eprint("CREATED {num_batches} batch files each with at most {max} batch IDs.".format(num_batches=len(batches), max=MAX_BATCH_SIZE))
     if len(errors) > 0:

--- a/src/python/dxpy/ssh_tunnel_app_support.py
+++ b/src/python/dxpy/ssh_tunnel_app_support.py
@@ -127,8 +127,8 @@ def run_notebook(args, ssh_config_check):
 
     if args.open_server:
         multi_platform_open('http://localhost:{0}'.format(args.port))
-        print 'A web browser should have opened to connect you to your notebook.'
-    print 'If no browser appears, or if you need to reopen a browser at any point, you should be able to point your browser to http://localhost:{0}'.format(args.port)
+        print('A web browser should have opened to connect you to your notebook.')
+    print('If no browser appears, or if you need to reopen a browser at any point, you should be able to point your browser to http://localhost:{0}'.format(args.port))
 
 
 def run_loupe(args):
@@ -145,7 +145,7 @@ def run_loupe(args):
 
     if args.open_server:
         multi_platform_open('http://localhost:{0}'.format(args.port))
-        print 'A web browser should have opened to connect you to your notebook.'
-    print 'If no browser appears, or if you need to reopen a browser at any point, you should be able to point your browser to http://localhost:{0}'.format(args.port)
-    print 'Your Loupe session is scheduled to terminate in {0}.  If you wish to terminate before this, please run:'.format(args.timeout)
-    print 'dx terminate {0}'.format(job_id)
+        print('A web browser should have opened to connect you to your notebook.')
+    print('If no browser appears, or if you need to reopen a browser at any point, you should be able to point your browser to http://localhost:{0}'.format(args.port))
+    print('Your Loupe session is scheduled to terminate in {0}.  If you wish to terminate before this, please run:'.format(args.timeout))
+    print('dx terminate {0}'.format(job_id))


### PR DESCRIPTION
small fixes that allow `dx -h` to work in Python 3 and also a couple uses of the dxpy.api module as well.

Adding test cases or generation for Python 3 might be a little beyond me - but I figure this is a pretty straightforward change :)