### PR TITLE
Allow newer versions of requests to be used

### DIFF
--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -3,4 +3,4 @@ python-dateutil==2.5
 python-magic==0.4.6
 beautifulsoup4==4.4.1
 psutil==3.3.0
-requests==2.7.0
+requests>=2.7.0


### PR DESCRIPTION
Otherwise, hard to install this along with other packages since it uses version of requests from 2015 :(

Release notes here - http://docs.python-requests.org/en/master/community/updates/ - I assume it's safe to use (and clearly you can package it with your own locked version in the toolkit).

Alternate option would be to specify a *max* version - e.g. `requests>=2.7.0,<=2.19.1` and then redo testing when you want to expand it again.