### PR TITLE
Allow newer versions of python-dateutil to be used

### DIFF
--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -1,5 +1,5 @@
 ws4py==0.3.2
-python-dateutil==2.5
+python-dateutil>=2.5
 python-magic==0.4.6
 beautifulsoup4==4.4.1
 psutil==3.3.0


### PR DESCRIPTION
The version of python-dateutil is from 2016, which makes it hard to integrate with tools that require newer python-dateutil.

Similar to #373

Changelog here - https://dateutil.readthedocs.io/en/stable/changelog.html#version-2-5-0