### PR TITLE
Allow newer versions of psutil

### DIFF
--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -2,5 +2,5 @@ ws4py==0.3.2
 python-dateutil==2.5
 python-magic==0.4.6
 beautifulsoup4==4.4.1
-psutil==3.3.0
+psutil>=3.3.0
 requests==2.7.0


### PR DESCRIPTION
I think this is the last one! The version of psutil is from late 2015, which again is old enough that it hits version conflicts when attempting to install `dxpy` alongside other python packages.  Any possibility this could also be allowed to float versions?

(I've put these up in separate PRs in case you only want to accept some and not others, etc)

Changelog here - https://github.com/giampaolo/psutil/blob/master/HISTORY.rst