### PR TITLE
Handle urllib3 NewConnectionError

### DIFF
--- a/src/python/dxpy/__init__.py
+++ b/src/python/dxpy/__init__.py
@@ -327,11 +327,13 @@ def _is_retryable_exception(e):
     have been established, we return False.
 
     """
-    if (isinstance(e, urllib3.exceptions.ProtocolError) or isinstance(e, urllib3.exceptions.NewConnectionError)):
+    if isinstance(e, urllib3.exceptions.ProtocolError):
         e = e.args[1]
     if isinstance(e, (socket.gaierror, socket.herror)):
         return True
     if isinstance(e, socket.error) and e.errno in _RETRYABLE_SOCKET_ERRORS:
+        return True
+    if isinstance(e, urllib3.exceptions.NewConnectionError):
         return True
     return False
 

--- a/src/python/dxpy/__init__.py
+++ b/src/python/dxpy/__init__.py
@@ -327,7 +327,7 @@ def _is_retryable_exception(e):
     have been established, we return False.
 
     """
-    if isinstance(e, urllib3.exceptions.ProtocolError):
+    if (isinstance(e, urllib3.exceptions.ProtocolError) or isinstance(e, urllib3.exceptions.NewConnectionError)):
         e = e.args[1]
     if isinstance(e, (socket.gaierror, socket.herror)):
         return True

--- a/src/python/dxpy/exceptions.py
+++ b/src/python/dxpy/exceptions.py
@@ -223,6 +223,7 @@ def exit_with_exc_info(code=1, message='', print_tb=False, exception=None):
     sys.exit(code)
 
 network_exceptions = (requests.packages.urllib3.exceptions.ProtocolError,
+                      requests.packages.urllib3.exceptions.NewConnectionError,
                       requests.packages.urllib3.exceptions.DecodeError,
                       requests.packages.urllib3.exceptions.ConnectTimeoutError,
                       requests.packages.urllib3.exceptions.ReadTimeoutError,

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -2403,7 +2403,14 @@ class TestHTTPResponses(unittest.TestCase):
     def test_bad_host(self):
         # Verify that the exception raised is one that dxpy would
         # consider to be retryable, but truncate the actual retry loop
-        with self.assertRaises(requests.packages.urllib3.exceptions.ProtocolError) as exception_cm:
+        try:
+            dxpy.DXHTTPRequest('http://doesnotresolve.dnanexus.com/', {}, prepend_srv=False, always_retry=False,
+                               max_retries=1)
+        except Exception as e:
+            print(type(e), file=sys.stderr)
+            print(e, file=sys.stderr)
+            print(e.args, file=sys.stderr)
+        with self.assertRaises(requests.packages.urllib3.exceptions.NewConnectionError) as exception_cm:
             dxpy.DXHTTPRequest('http://doesnotresolve.dnanexus.com/', {}, prepend_srv=False, always_retry=False,
                                max_retries=1)
         self.assertTrue(dxpy._is_retryable_exception(exception_cm.exception))
@@ -2411,7 +2418,7 @@ class TestHTTPResponses(unittest.TestCase):
     def test_connection_refused(self):
         # Verify that the exception raised is one that dxpy would
         # consider to be retryable, but truncate the actual retry loop
-        with self.assertRaises(requests.packages.urllib3.exceptions.ProtocolError) as exception_cm:
+        with self.assertRaises(requests.packages.urllib3.exceptions.NewConnectionError) as exception_cm:
             # Connecting to a port on which there is no server running
             dxpy.DXHTTPRequest('http://localhost:20406', {}, prepend_srv=False, always_retry=False, max_retries=1)
         self.assertTrue(dxpy._is_retryable_exception(exception_cm.exception))
@@ -2428,7 +2435,7 @@ class TestHTTPResponses(unittest.TestCase):
         with self.assertRaises(TypeError):
             dxpy.DXHTTPRequest("/system/whoami", {}, cert="nonexistent")
         if dxpy.APISERVER_PROTOCOL == "https":
-            with self.assertRaisesRegexp((TypeError,SSLError), "file|string"):
+            with self.assertRaisesRegexp((TypeError,SSLError, OpenSSL.SSL.Error), "file|string"):
                 dxpy.DXHTTPRequest("/system/whoami", {}, verify="nonexistent")
             with self.assertRaisesRegexp((SSLError, IOError, OpenSSL.SSL.Error), "file"):
                 dxpy.DXHTTPRequest("/system/whoami", {}, cert_file="nonexistent")

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -2403,13 +2403,6 @@ class TestHTTPResponses(unittest.TestCase):
     def test_bad_host(self):
         # Verify that the exception raised is one that dxpy would
         # consider to be retryable, but truncate the actual retry loop
-        try:
-            dxpy.DXHTTPRequest('http://doesnotresolve.dnanexus.com/', {}, prepend_srv=False, always_retry=False,
-                               max_retries=1)
-        except Exception as e:
-            print(type(e), file=sys.stderr)
-            print(e, file=sys.stderr)
-            print(e.args, file=sys.stderr)
         with self.assertRaises(requests.packages.urllib3.exceptions.NewConnectionError) as exception_cm:
             dxpy.DXHTTPRequest('http://doesnotresolve.dnanexus.com/', {}, prepend_srv=False, always_retry=False,
                                max_retries=1)


### PR DESCRIPTION
Handle `urllib3.exceptions.NewConnectionError` introduced in urllib3 version 1.12 https://pypi.org/project/urllib3/