### PR TITLE
Fix cryptography version <= 2.2.2

### DIFF
--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -4,3 +4,4 @@ python-magic==0.4.6
 beautifulsoup4==4.4.1
 psutil>=3.3.0
 requests>=2.7.0
+cryptography<=2.2.2


### PR DESCRIPTION
Later versions log error messages and will be incompatible with Python 2.7.6, 14.04 default version.
```
"/share/dnanexus/lib/python2.7/site-packages/cryptography/hazmat/primitives/constant_time.py:26: CryptographyDeprecationWarning: Support for your Python version is deprecated. The next version of cryptography will remove support. Please upgrade to a 2.7.x release that supports hmac.compare_digest as soon as possible." 
```
Pulled from tag 2.3 here: https://github.com/pyca/cryptography/blob/2.3/src/cryptography/hazmat/primitives/constant_time.py
