### PR TITLE
Windows build fixes

### DIFF
--- a/build/pynsist_files/installer.cfg.template
+++ b/build/pynsist_files/installer.cfg.template
@@ -52,15 +52,7 @@ nsi_template=pyapp_installpy_dnanexus.nsi
 files = dnanexus-shell.ps1
     cli-quickstart.url
     TEMPLATE_STRING_DXPY_WHEEL_FILENAME > $INSTDIR\\wheelfiles
-    beautifulsoup4-4.4.1-py2-none-any.whl > $INSTDIR\\wheelfiles
-    colorama-0.2.4-cp27-none-any.whl > $INSTDIR\\wheelfiles
-    futures-3.0.4-py2-none-any.whl > $INSTDIR\\wheelfiles
-    psutil-3.3.0-cp27-none-win32.whl > $INSTDIR\\wheelfiles
-    python_dateutil-2.5.0-py2.py3-none-any.whl > $INSTDIR\\wheelfiles
-    python_magic-0.4.6-cp27-none-any.whl > $INSTDIR\\wheelfiles
-    requests-2.7.0-py2.py3-none-any.whl > $INSTDIR\\wheelfiles
-    six-1.10.0-py2.py3-none-any.whl > $INSTDIR\\wheelfiles
-    ws4py-0.3.2-cp27-none-any.whl > $INSTDIR\\wheelfiles
+    wheelfile_depends
     ../../bin/dx-verify-file.exe > $INSTDIR\\bin
     ../../bin/jq.exe > $INSTDIR\\bin
     DLL_DEPS_FOLDERlibboost_atomic-mt.dll > $INSTDIR\\bin

--- a/build/pynsist_files/pyapp_dnanexus.nsi.template
+++ b/build/pynsist_files/pyapp_dnanexus.nsi.template
@@ -108,7 +108,7 @@ Section "!${PRODUCT_NAME}" sec_app
   DetailPrint "Installing dxpy..."
   ; Install dxpy, its dependencies, and console scripts in $INSTDIR\python27
   ; Use --no-index and a local wheelfiles dir so we don't need Inet access:
-  ExecWait '"C:\Python27\Scripts\pip.exe" install --root "$INSTDIR" --no-index --find-links="$INSTDIR\wheelfiles" "$INSTDIR\wheelfiles\TEMPLATE_STRING_DXPY_WHEEL_FILENAME"' $0
+  ExecWait '"C:\Python27\Scripts\pip.exe" install --root "$INSTDIR" --no-index --find-links="$INSTDIR\wheelfile_depends" "$INSTDIR\wheelfiles\TEMPLATE_STRING_DXPY_WHEEL_FILENAME"' $0
   StrCmp $0 0 pass error 
   pass:
     ;MessageBox MB_OK 'dxpy installed'

--- a/src/Makefile
+++ b/src/Makefile
@@ -157,7 +157,7 @@ pynsist_installer: toolkit_version $(DNANEXUS_HOME)/bin/dx dx-verify-file jq
 	    cp "$(DNANEXUS_HOME)"/src/python/dist/$${DXPY_WHEEL_FILENAME} "$(DNANEXUS_HOME)"/build/pynsist_files/
 
 	# Download the .whl files for each of dxpy's Python dependencies, to bundle with NSIS installer
-	unset PYTHONPATH; source "$(DX_PY_ENV)/$(ACTIVATE)"; python -m pip install --download "$(DNANEXUS_HOME)"/build/pynsist_files/wheelfile_depends -r python/requirements.txt -r python/requirements_windows.txt
+	unset PYTHONPATH; source "$(DX_PY_ENV)/$(ACTIVATE)"; mkdir -p "$(DNANEXUS_HOME)"/build/pynsist_files/wheelfile_depends; python -m pip install --download "$(DNANEXUS_HOME)"/build/pynsist_files/wheelfile_depends -r python/requirements.txt -r python/requirements_windows.txt
 
 	# Insert the wheel filename into installer.cfg
 	export DXPY_WHEEL_FILENAME=$$(basename $(DNANEXUS_HOME)/src/python/dist/dxpy-*.whl) ; \

--- a/src/Makefile
+++ b/src/Makefile
@@ -157,7 +157,7 @@ pynsist_installer: toolkit_version $(DNANEXUS_HOME)/bin/dx dx-verify-file jq
 	    cp "$(DNANEXUS_HOME)"/src/python/dist/$${DXPY_WHEEL_FILENAME} "$(DNANEXUS_HOME)"/build/pynsist_files/
 
 	# Download the .whl files for each of dxpy's Python dependencies, to bundle with NSIS installer
-	unset PYTHONPATH; source "$(DX_PY_ENV)/$(ACTIVATE)"; python -m pip install --download "$(DNANEXUS_HOME)"/build/pynsist_files -r python/requirements.txt -r python/requirements_windows.txt
+	unset PYTHONPATH; source "$(DX_PY_ENV)/$(ACTIVATE)"; python -m pip install --download "$(DNANEXUS_HOME)"/build/pynsist_files/wheelfile_depends -r python/requirements.txt -r python/requirements_windows.txt
 
 	# Insert the wheel filename into installer.cfg
 	export DXPY_WHEEL_FILENAME=$$(basename $(DNANEXUS_HOME)/src/python/dist/dxpy-*.whl) ; \

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -3,5 +3,5 @@ python-dateutil>=2.5
 python-magic==0.4.6
 beautifulsoup4==4.4.1
 psutil>=3.3.0
-requests>=2.7.0
+requests>=2.8.0
 cryptography<=2.2.2


### PR DESCRIPTION
Download wheelfiles to directory and copy instead of individually copying hardcoded versions.
Bump requests to >= 2.8.0 since it includes at least urllib3 1.12 with `NewConnectionError` exception, otherwise `dx` will error out.