### PR TITLE
dx-docker allows `--quiet` option before run

### DIFF
--- a/src/python/scripts/dx-docker
+++ b/src/python/scripts/dx-docker
@@ -53,6 +53,8 @@ def makedirs(path):
         pass
 
 parser = argparse.ArgumentParser()
+parser.add_argument("-q", "--quiet", action='store_true', help="Suppress printing pull progress to stderr")
+
 subparsers = parser.add_subparsers()
 
 def get_aci_fname(image):


### PR DESCRIPTION
Re: https://github.com/dnanexus/dx-toolkit/issues/382 from @mr-c

Before landing I'll ensure all integration tests pass.  

I'll probably add some more code to ensure that quiet is passed through to all relevant subcommands in short order, but landing this would allow dx-docker to work with cwltool right away (see https://github.com/common-workflow-language/cwltool/blob/de509ba31bc4abebf44e9717952b1538ed539d64/cwltool/docker.py#L283)