### PR TITLE
DEVEX-720 Add support for dx building a global workflow (with apps) in multiple regions

### DIFF
--- a/src/python/dxpy/app_builder.py
+++ b/src/python/dxpy/app_builder.py
@@ -915,20 +915,6 @@ def _create_app(applet_or_regional_options, app_name, src_dir, publish=False, se
     return app_id
 
 
-def assert_consistent_regions(from_app_spec, from_command_line):
-    """
-    :param from_app_spec: The regional options specified in dxapp.json.
-    :type from_app_spec: dict or None.
-    :param from_command_line: The regional options specified on the
-    command-line via --region.
-    :type from_command_line: list or None.
-    """
-    if from_app_spec is None or from_command_line is None:
-        return
-    if set(from_app_spec) != set(from_command_line):
-        raise dxpy.app_builder.AppBuilderException("--region and the 'regionalOptions' key in dxapp.json do not agree")
-
-
 def get_enabled_regions(app_spec, from_command_line):
     """Returns a list of the regions in which the app should be enabled.
 
@@ -971,7 +957,7 @@ def get_enabled_regions(app_spec, from_command_line):
                     raise dxpy.app_builder.AppBuilderException(
                         key + " cannot be given in both runSpec and in regional options for " + region)
 
-    assert_consistent_regions(from_app_spec, from_command_line)
+    dxpy.executable_builder.assert_consistent_regions(from_app_spec, from_command_line)
 
     enabled_regions = None
     if from_app_spec is not None:

--- a/src/python/dxpy/app_builder.py
+++ b/src/python/dxpy/app_builder.py
@@ -928,42 +928,7 @@ def get_enabled_regions(app_spec, from_command_line):
     :type from_command_line: list or None
 
     """
-    from_app_spec = app_spec.get('regionalOptions')
-
-    if from_app_spec is not None:
-        if not isinstance(from_app_spec, dict):
-            raise dxpy.app_builder.AppBuilderException("The field 'regionalOptions' in dxapp.json must be a mapping")
-        if not from_app_spec:
-            raise dxpy.app_builder.AppBuilderException(
-                "The field 'regionalOptions' in dxapp.json must be a non-empty mapping")
-        regional_options_list = list(from_app_spec.items())
-        for region, opts_for_region in regional_options_list:
-            if not isinstance(opts_for_region, dict):
-                raise dxpy.app_builder.AppBuilderException("The field 'regionalOptions['" + region +
-                                                           "']' in dxapp.json must be a mapping")
-            if set(opts_for_region.keys()) != set(regional_options_list[0][1].keys()):
-                if set(opts_for_region.keys()) - set(regional_options_list[0][1].keys()):
-                    with_key, without_key = region, regional_options_list[0][0]
-                    key_name = next(iter(set(opts_for_region.keys()) - set(regional_options_list[0][1].keys())))
-                else:
-                    with_key, without_key = regional_options_list[0][0], region
-                    key_name = next(iter(set(regional_options_list[0][1].keys()) - set(opts_for_region.keys())))
-                raise dxpy.app_builder.AppBuilderException(
-                    "All regions in regionalOptions must specify the same options; " +
-                    "%s was given for %s but not for %s" % (key_name, with_key, without_key)
-                )
-            for key in opts_for_region:
-                if key in app_spec.get('runSpec', {}):
-                    raise dxpy.app_builder.AppBuilderException(
-                        key + " cannot be given in both runSpec and in regional options for " + region)
-
-    dxpy.executable_builder.assert_consistent_regions(from_app_spec, from_command_line,dxpy.app_builder.AppBuilderException)
-
-    enabled_regions = None
-    if from_app_spec is not None:
-        enabled_regions = from_app_spec.keys()
-    elif from_command_line is not None:
-        enabled_regions = from_command_line
+    enabled_regions = dxpy.executable_builder.get_enabled_regions('app', app_spec, from_command_line, AppBuilderException)
 
     if enabled_regions is not None and len(enabled_regions) == 0:
         raise AssertionError("This app should be enabled in at least one region")

--- a/src/python/dxpy/app_builder.py
+++ b/src/python/dxpy/app_builder.py
@@ -957,7 +957,7 @@ def get_enabled_regions(app_spec, from_command_line):
                     raise dxpy.app_builder.AppBuilderException(
                         key + " cannot be given in both runSpec and in regional options for " + region)
 
-    dxpy.executable_builder.assert_consistent_regions(from_app_spec, from_command_line)
+    dxpy.executable_builder.assert_consistent_regions(from_app_spec, from_command_line,dxpy.app_builder.AppBuilderException)
 
     enabled_regions = None
     if from_app_spec is not None:

--- a/src/python/dxpy/executable_builder.py
+++ b/src/python/dxpy/executable_builder.py
@@ -152,7 +152,7 @@ def verify_developer_rights(prefixed_name):
     return FoundExecutable(name=name_without_prefix, version=version, id=executable_id)
 
 
-def assert_consistent_regions(from_spec, from_command_line):
+def assert_consistent_regions(from_spec, from_command_line, builder_exception):
     """
     :param from_spec: The regional options specified in dxapp.json or dxworkflow.json
     :type from_spec: dict or None.
@@ -162,5 +162,5 @@ def assert_consistent_regions(from_spec, from_command_line):
     if from_spec is None or from_command_line is None:
         return
     if set(from_spec) != set(from_command_line):
-        raise dxpy..AppBuilderException("--region and the 'regionalOptions' key in the JSON file do not agree")
+        raise builder_exception("--region and the 'regionalOptions' key in the JSON file do not agree")
 

--- a/src/python/dxpy/executable_builder.py
+++ b/src/python/dxpy/executable_builder.py
@@ -150,3 +150,17 @@ def verify_developer_rights(prefixed_name):
         raise exception_type('You are not a developer for {n}'.format(n=name_without_prefix))
 
     return FoundExecutable(name=name_without_prefix, version=version, id=executable_id)
+
+
+def assert_consistent_regions(from_spec, from_command_line):
+    """
+    :param from_spec: The regional options specified in dxapp.json or dxworkflow.json
+    :type from_spec: dict or None.
+    :param from_command_line: The regional options specified on the command-line via --region.
+    :type from_command_line: list or None.
+    """
+    if from_spec is None or from_command_line is None:
+        return
+    if set(from_spec) != set(from_command_line):
+        raise dxpy..AppBuilderException("--region and the 'regionalOptions' key in the JSON file do not agree")
+

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -5390,6 +5390,10 @@ parser_find_orgs_with_billable_activities.add_argument("--without-billable-activ
 parser_find_orgs.set_defaults(func=find_orgs, with_billable_activities=None)
 register_parser(parser_find_orgs, subparsers_action=subparsers_find, categories="org")
 
+#####################################
+# notebook
+#####################################
+
 from ..ssh_tunnel_app_support import run_notebook
 parser_notebook = subparsers.add_parser('notebook', help='Launch a web notebook inside DNAnexus.',
                                         description='Launch a web notebook inside DNAnexus.',

--- a/src/python/dxpy/workflow_builder.py
+++ b/src/python/dxpy/workflow_builder.py
@@ -317,41 +317,36 @@ def _get_validated_json_for_build_or_update(json_spec, args):
 
 
 def _assert_executable_regions_match(workflow_enabled_regions, workflow_spec):
+    """
+    Check if the global workflow regions and the regions of stages (apps) match.
+    If the workflow contains any applets, the workflow can be currently enabled
+    in only one region - the region in which the applets are stored.
+    """
     executables = [i.get("executable") for i in workflow_spec.get("stages")]
-    
+
     for exect in executables:
+
         if exect.startswith("applet-") and len(workflow_enabled_regions) > 1:
-            mesg = "Building a global workflow with applets in more than one region is not yet supported."
-            mesg += " The applets must be stored in the enabled region of the global workflow."
-            raise WorkflowBuilderException(mesg)
+            raise WorkflowBuilderException("Building a global workflow with applets in more than one region is not yet supported.")
+
         elif exect.startswith("app-"):
-            app_regional_options = dxpy.api.app_describe(exect,
-                                                         input_params={"fields": {"regionalOptions": True}})
+            app_regional_options = dxpy.api.app_describe(exect, input_params={"fields": {"regionalOptions": True}})
             app_regions = set(app_regional_options['regionalOptions'].keys())
             if not workflow_enabled_regions.issubset(app_regions):
-                mesg = "The app {} is enabled in regions {} while the workflow - in {}.".format(exect,
-                                                                                                app_regions,
-                                                                                                workflow_enabled_regions)
-                mesg += " If you are a developer of the app, please enable the app in {} to run the workflow in that region(s).".format(
+                mesg = "The app {} is enabled in regions {} while the global workflow - in {}.".format(
+                    exect, app_regions, workflow_enabled_regions)
+                mesg += " Please, enable the workflow in the app's region(s)."
+                mesg += " If you are a developer of the app, you can also enable the app in {} to run the workflow in that region(s).".format(
                     workflow_enabled_regions - app_regions)
                 logger.warn(mesg)
+
         elif exect.startswith("workflow-"):
              # We recurse to check the regions of the executables of the inner workflow
             inner_workflow_spec = dxpy.api.workflow_describe(exect)
             _assert_executable_regions_match(workflow_enabled_regions, inner_workflow_spec)
+
         elif exect.startswith("globalworkflow-"):
             raise WorkflowBuilderException("Building a global workflow with nested global workflows is not yet supported")
-            #TODO: uncomment when this option is supported by the API server
-            # We don't recurse to check the regions of the executables of the global workflow
-            # since it was checked when the inner global workflow was built
-            # gwf_regional_options = dxpy.api.global_workflow_describe(exect,
-            #                                                          input_params={"fields": {"regionalOptions": True}})                                        
-            # exec_regions = set(gwf_regional_options['regionalOptions'].keys())
-            # if not workflow_enabled_regions.issubset(exec_regions):
-            #     mesg = "The executable {} is enabled in more regions than the workflow that is being built.".format(exct)
-            #     mesg += " It will not be possible to run your new workflow in {}".format(
-            #         exec_regions - workflow_enabled_regions)
-            #     logger.warn(mesg)
 
 
 def _build_regular_workflow(json_spec):

--- a/src/python/dxpy/workflow_builder.py
+++ b/src/python/dxpy/workflow_builder.py
@@ -358,10 +358,11 @@ def _build_regular_workflow(json_spec):
     return workflow_id
 
 
-def _get_enabled_regions(json_spec, from_command_line):
+def _get_validated_enabled_regions(json_spec, from_command_line):
     """
     Returns a set of regions (region names) in which the global workflow
-    should be enabled.
+    should be enabled. Also validates and synchronizes the regions
+    passed via CLI argument and in the regionalOptions field.
     """
     enabled_regions = dxpy.executable_builder.get_enabled_regions('globalworkflow',
                                                                   json_spec,
@@ -446,7 +447,7 @@ def _build_global_workflow(json_spec, args):
     and builds a global workflow on the platform based on these workflows.
     """
     # First determine in which regions the global workflow needs to be available
-    enabled_regions = _get_enabled_regions(json_spec, args.region)
+    enabled_regions = _get_validated_enabled_regions(json_spec, args.region)
 
     # Verify all the stages are also enabled in these regions
     # TODO: Add support for dx building multi-region global workflows with applets

--- a/src/python/dxpy/workflow_builder.py
+++ b/src/python/dxpy/workflow_builder.py
@@ -36,9 +36,8 @@ from .exceptions import err_exit
 from . import logger
 
 UPDATABLE_GLOBALWF_FIELDS = {'title', 'summary', 'description', 'developerNotes', 'details'}
-GLOBALWF_SUPPORTED_KEYS = {"name", "version", "title", "summary", "description",
-                           "developerNotes", "regionalOptions", "categories", "billTo",
-                           "dxapi", "details"}
+GLOBALWF_SUPPORTED_KEYS = UPDATABLE_GLOBALWF_FIELDS.union({"name", "version", , "regionalOptions",
+                                                           "categories", "billTo", "dxapi"})
 SUPPORTED_KEYS = GLOBALWF_SUPPORTED_KEYS.union({"project", "folder", "outputFolder", "stages",
                                                 "inputs", "outputs"})
 
@@ -240,6 +239,13 @@ def _validate_json_for_global_workflow(json_spec, args):
         if not isinstance(json_spec['details'], dict):
             raise WorkflowBuilderException(
                 'The field "details" must be a dictionary')
+
+    if 'regionalOptions' in json_spec:
+        if not (isinstance(json_spec['regionalOptions'], dict)
+                and json_spec['regionalOptions']
+                and not all([isinstance(i, dict) for i in json_spec['regionalOptions'].values()]):
+            raise WorkflowBuilderException(
+                'The field "regionalOptions" must be a non-empty dictionary whose values are dictionaries')
 
     if args.bill_to:
         json_spec["billTo"] = args.bill_to

--- a/src/python/test/dxpy_testutil.py
+++ b/src/python/test/dxpy_testutil.py
@@ -442,6 +442,24 @@ class DXTestCase(DXTestCaseCompat):
             self.assertFalse(True, error_string)
 
 
+    def write_app_directory_in_dir(self, temp_file_path, app_name, dxapp_str, code_filename, code_content):
+        # Note: if called twice with the same app_name, will overwrite
+        # the dxapp.json and code file (if specified) but will not
+        # remove any other files that happened to be present
+        try:
+            os.mkdir(os.path.join(temp_file_path, app_name))
+        except OSError as e:
+            if e.errno != 17:  # directory already exists
+                raise e
+        if dxapp_str is not None:
+            with open(os.path.join(temp_file_path, app_name, 'dxapp.json'), 'wb') as manifest:
+                manifest.write(dxapp_str.encode())
+        if code_filename:
+            with open(os.path.join(temp_file_path, app_name, code_filename), 'w') as code_file:
+                code_file.write(code_content)
+        return os.path.join(temp_file_path, app_name)
+
+
 class DXTestCaseBuildWorkflows(DXTestCase):
     """
     This class adds methods to ``DXTestCase`` related to (global) workflow
@@ -557,6 +575,9 @@ class DXTestCaseBuildWorkflows(DXTestCase):
                             "executable": self.test_applet_id,
                             "input": {"number": {"$dnanexus_link": {"stage": "stage_0",
                                                                              "outputField": "number"}}}}]}
+
+    def write_app_directory(self, app_name, dxapp_str, code_filename=None, code_content="\n"):
+        return self.write_app_directory_in_dir(self.temp_file_path, app_name, dxapp_str, code_filename, code_content)
 
 
 class DXTestCaseBuildApps(DXTestCase):

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -6667,8 +6667,7 @@ class TestDXBuildWorkflow(DXTestCaseBuildWorkflows):
             for warning in expected_warnings:
                 self.assertIn(warning, err.stderr)
 
-    @unittest.skipUnless(testutil.TEST_ISOLATED_ENV,
-                         'skipping test that would create global workflows')
+
     def test_build_workflow_invalid_project_context(self):
         gwf_name = "invalid_project_context_{t}".format(t=int(time.time()))
         dxworkflow_json = dict(self.dxworkflow_spec, name=gwf_name)
@@ -6676,10 +6675,12 @@ class TestDXBuildWorkflow(DXTestCaseBuildWorkflows):
                                                      json.dumps(dxworkflow_json))
 
         # Set the project context to a nonexistent project. This
-        # shouldn't have any effect since building a global workflow
-        # is supposed to be hygienic.
+        # should result in an error since currently the workflow
+        # will be enabled in the region of the project context
+        # (if regionalOptions or --region are not set)
         env = override_environment(DX_PROJECT_CONTEXT_ID='project-B00000000000000000000000')
-        run("dx build --create-globalworkflow --json " + workflow_dir, env=env)
+        with self.assertRaisesRegexp(subprocess.CalledProcessError, "ResourceNotFound"):
+            run("dx build --create-globalworkflow --json " + workflow_dir, env=env)
 
     @unittest.skipUnless(testutil.TEST_ISOLATED_ENV,
                          'skipping test that would create global workflows')

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -37,6 +37,7 @@ from dxpy.exceptions import (DXAPIError, DXFileError, DXError, DXJobFailureError
 from dxpy.utils import pretty_print, warn, Nonce
 from dxpy.utils.resolver import resolve_path, resolve_existing_path, ResolutionError, is_project_explicit
 import dxpy.app_builder as app_builder
+import dxpy.executable_builder as executable_builder
 
 from dxpy.compat import USING_PYTHON2
 
@@ -3108,7 +3109,7 @@ class TestIdempotentRequests(unittest.TestCase):
 
 class TestAppBuilderUtils(unittest.TestCase):
     def test_assert_consistent_regions(self):
-        assert_consistent_regions = app_builder.assert_consistent_regions
+        assert_consistent_regions = executable_builder.assert_consistent_regions
 
         # These calls should not raise exceptions.
 

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -3113,14 +3113,14 @@ class TestAppBuilderUtils(unittest.TestCase):
 
         # These calls should not raise exceptions.
 
-        assert_consistent_regions(None, None)
-        assert_consistent_regions(None, ["aws:us-east-1"])
-        assert_consistent_regions({"aws:us-east-1": None}, None)
+        assert_consistent_regions(None, None, app_builder.AppBuilderException)
+        assert_consistent_regions(None, ["aws:us-east-1"], app_builder.AppBuilderException)
+        assert_consistent_regions({"aws:us-east-1": None}, None, app_builder.AppBuilderException)
         # The actual key-value pairs are irrelevant.
-        assert_consistent_regions({"aws:us-east-1": None}, ["aws:us-east-1"])
+        assert_consistent_regions({"aws:us-east-1": None}, ["aws:us-east-1"], app_builder.AppBuilderException)
 
         with self.assertRaises(app_builder.AppBuilderException):
-            assert_consistent_regions({"aws:us-east-1": None}, ["azure:westus"])
+            assert_consistent_regions({"aws:us-east-1": None}, ["azure:westus"], app_builder.AppBuilderException)
 
 
 class TestApiWrappers(unittest.TestCase):


### PR DESCRIPTION
This PR adds support for building a multi-region global workflow using `dx build`.
If the workflow contains applets, it is still only possible to build the workflow
in one region.