### PR TITLE
DEVEX-834 Upgrade Win installer to Python 2.7.15

### DIFF
--- a/build/pynsist_files/installer.cfg.template
+++ b/build/pynsist_files/installer.cfg.template
@@ -26,7 +26,7 @@ icon=dnanexus.ico
 #icon=foo.ico
 
 [Python]
-version=2.7.11
+version=2.7.15
 format=installer
 
 [Build]

--- a/src/Makefile
+++ b/src/Makefile
@@ -168,7 +168,7 @@ pynsist_installer: toolkit_version $(DNANEXUS_HOME)/bin/dx dx-verify-file jq
 	    sed s/TEMPLATE_STRING_DXPY_WHEEL_FILENAME/$${DXPY_WHEEL_FILENAME}/ "$(DNANEXUS_HOME)"/build/pynsist_files/pyapp_dnanexus.nsi.template > "$(DNANEXUS_HOME)"/build/pynsist_files/pyapp_dnanexus.nsi
 
 	# Install the pynsist package and use it to build a Windows installer
-	unset PYTHONPATH; source "$(DX_PY_ENV)/$(ACTIVATE)"; python -m pip install pynsist==1.7
+	unset PYTHONPATH; source "$(DX_PY_ENV)/$(ACTIVATE)"; python -m pip install pynsist==1.12
 	unset PYTHONPATH; source "$(DX_PY_ENV)/$(ACTIVATE)"; pynsist "$(DNANEXUS_HOME)"/build/pynsist_files/installer.cfg
 	# Copy .exe installer to dx-toolkit root once it's ready
 	cp "$(DNANEXUS_HOME)"/build/pynsist_files/build/nsis/DNAnexus_CLI_"$(GIT_TOOLKIT_VERSION_SHORT)".exe "$(DNANEXUS_HOME)"/dx-toolkit-"$(GIT_TOOLKIT_VERSION_SHORT)".exe


### PR DESCRIPTION
Bundling Python 2.7.15 for Windows upgrades setuptools, which allows us to `pip install cryptography<=2.2.2` on Windows.