### PR TITLE
Test `dx find --all-projects` in isolated env

### DIFF
--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -4590,6 +4590,8 @@ class TestDXClientFind(DXTestCase):
                 run('dx find data --brief --folder ' + test_projectid + ':' + test_dirname + ' --path ' +
                     test_projectid + ':' + test_dirname)
 
+    @unittest.skipUnless(testutil.TEST_ISOLATED_ENV,
+                         'skipping test that takes a long time outside local environment')
     def test_dx_find_data_by_region(self):
         with temporary_project("p_azure", region="azure:westus") as p_azure:
             record_id = dxpy.new_dxrecord(project=p_azure.get_id(), close=True).get_id()

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -4591,7 +4591,7 @@ class TestDXClientFind(DXTestCase):
                     test_projectid + ':' + test_dirname)
 
     @unittest.skipUnless(testutil.TEST_ISOLATED_ENV,
-                         'skipping test that takes a long time outside local environment')
+                         'skipping test that can take a long time outside local environment')
     def test_dx_find_data_by_region(self):
         with temporary_project("p_azure", region="azure:westus") as p_azure:
             record_id = dxpy.new_dxrecord(project=p_azure.get_id(), close=True).get_id()


### PR DESCRIPTION
This test is running for ~50 minutes in staging. Only run it in an isolated environment where there is less data.