### PR TITLE
SCI-1087 add stages to asset depends

### DIFF
--- a/src/python/dxpy/app_builder.py
+++ b/src/python/dxpy/app_builder.py
@@ -566,6 +566,7 @@ def upload_applet(src_dir, uploaded_resources, check_name_collisions=True, overw
     for asset in asset_depends:
         asset_project = asset.get("project", None)
         asset_folder = asset.get("folder", '/')
+        asset_stages = asset.get("stages", None)
         if "id" in asset:
             asset_record = dxpy.DXRecord(asset["id"]).describe(fields={'details'}, default_fields=True)
         elif "name" in asset and asset_project is not None and "version" in asset:
@@ -597,6 +598,8 @@ def upload_applet(src_dir, uploaded_resources, check_name_collisions=True, overw
                 "name": archive_file_name,
                 "id": archive_file_id
             }
+            if asset_stages:
+                bundle_depends["stages"] = asset_stages
             applet_spec["runSpec"]["bundledDepends"].append(bundle_depends)
             # If the file is not found in the applet destination project, clone it from the asset project
             if (not dry_run and

--- a/src/python/dxpy/utils/executable_unbuilder.py
+++ b/src/python/dxpy/utils/executable_unbuilder.py
@@ -149,12 +149,15 @@ def _dump_app_or_applet(executable, omit_resources=False, describe_output={}):
                 asset_record = dxpy.DXRecord(asset_record_id)
                 if asset_record:
                     try:
-                        asset_depends.append({"name": asset_record.describe().get("name"),
+                        asset_json = {"name": asset_record.describe().get("name"),
                                               "project": asset_record.get_proj_id(),
                                               "folder": asset_record.describe().get("folder"),
                                               "version": asset_record.describe(fields={"properties": True}
                                                                                )["properties"]["version"]
-                                              })
+                                              }
+                        if dep.get("stages"):
+                            asset_json["stages"] = dep["stages"]
+                        asset_depends.append(asset_json)
                         deps_to_remove.append(dep)
                     except DXError:
                         print("Describe failed on the assetDepends record object with ID - " +

--- a/src/python/test/test_dxasset.py
+++ b/src/python/test/test_dxasset.py
@@ -277,7 +277,7 @@ class TestDXBuildAsset(DXTestCase):
                     stage_without_asset(){
                         if [[ -e file_inside_asset.txt ]]; then
                             echo "file should not be here"
-                            sys.exit(1)
+                            exit 1
                         fi
                     }
                     """

--- a/src/python/test/test_dxasset.py
+++ b/src/python/test/test_dxasset.py
@@ -115,7 +115,7 @@ class TestDXBuildAsset(DXTestCase):
             "description": "A detailed description about the asset",
             "version": "0.0.1",
             "distribution": "Ubuntu",
-            "release": "12.04",
+            "release": "14.04",
             "instanceType": "mem1_ssd1_x2",
             "execDepends": [{"name": "python-numpy"}]
         }
@@ -134,7 +134,7 @@ class TestDXBuildAsset(DXTestCase):
             "description": "A detailed description about the asset",
             "version": "0.0.1",
             "distribution": "Ubuntu",
-            "release": "12.04",
+            "release": "14.04",
             "execDepends": [{"name": "python-numpy"}]
         }
         asset_dir = self.write_asset_directory("asset_with_valid_destination", json.dumps(asset_spec))
@@ -155,7 +155,7 @@ class TestDXBuildAsset(DXTestCase):
             "description": "A detailed description about the asset",
             "version": "0.0.1",
             "distribution": "Ubuntu",
-            "release": "12.04"
+            "release": "14.04"
         }
         asset_dir = self.write_asset_directory("asset_with_invalid_destination", json.dumps(asset_spec))
         with self.assertSubprocessFailure(stderr_regexp='Could not find a project named', exit_code=3):
@@ -167,7 +167,7 @@ class TestDXBuildAsset(DXTestCase):
             "description": "A detailed description about the asset",
             "version": "0.0.1",
             "distribution": "Ubuntu",
-            "release": "12.04"
+            "release": "14.04"
         }
         asset_dir = self.write_asset_directory("asset_with_missing_fields", json.dumps(asset_spec))
         with self.assertSubprocessFailure(stderr_regexp='The asset configuration does not contain', exit_code=1):
@@ -181,7 +181,7 @@ class TestDXBuildAsset(DXTestCase):
             "description": "A detailed description about the asset",
             "version": "0.0.1",
             "distribution": "Ubuntu",
-            "release": "12.04"
+            "release": "14.04"
         }
         asset_dir = self.write_asset_directory("asset_with_resources", json.dumps(asset_spec), "resources")
         asset_bundle_id = json.loads(run('dx build_asset --json ' + asset_dir))['id']
@@ -196,7 +196,7 @@ class TestDXBuildAsset(DXTestCase):
             "description": "A detailed description about the asset",
             "version": "0.0.1",
             "distribution": "Ubuntu",
-            "release": "12.04"
+            "release": "14.04"
         }
         asset_dir = self.write_asset_directory("asset_with_invalid_makefile", json.dumps(asset_spec),
                                                None, "echo")
@@ -212,7 +212,7 @@ class TestDXBuildAsset(DXTestCase):
             "description": "A detailed description about the asset",
             "version": "0.0.1",
             "distribution": "Ubuntu",
-            "release": "12.04"
+            "release": "14.04"
         }
         asset_dir = self.write_asset_directory("build_and_use_asset", json.dumps(asset_spec), "resources")
 
@@ -256,7 +256,7 @@ class TestDXBuildAsset(DXTestCase):
             "description": "A detailed description about the asset",
             "version": "0.0.1",
             "distribution": "Ubuntu",
-            "release": "12.04",
+            "release": "14.04",
             "instanceType": "mem1_ssd1_x3"
         }
         asset_dir = self.write_asset_directory("build_asset_with_invalid_instance_type", json.dumps(asset_spec))
@@ -273,7 +273,7 @@ class TestDXBuildAsset(DXTestCase):
             "description": " A detailed description about the asset",
             "version": "0.0.1",
             "distribution": "Ubuntu",
-            "release": "12.04"
+            "release": "14.04"
         }
         asset_dir = self.write_asset_directory("test_build_asset_inside_job", json.dumps(asset_spec))
         asset_conf_file_id = run("dx upload " + os.path.join(asset_dir, "dxasset.json") + " --brief --wait").strip()
@@ -375,7 +375,7 @@ class TestDXBuildAsset(DXTestCase):
             "description": "A detailed description about the asset",
             "version": "0.0.1",
             "distribution": "Ubuntu",
-            "release": "12.04"
+            "release": "14.04"
         }
         asset_dir = self.write_asset_directory("set_tarball_property", json.dumps(asset_spec))
         asset_bundle_id = json.loads(run('dx build_asset --json ' + asset_dir))['id']


### PR DESCRIPTION
In bundledDepends, you can specify to only use the bundle in certain stages of an app by supplying the "stages" argument. However, this argument is not checked for when converting from an asset to a bundle, so assetDepends does not support this. 

I've updated the asset handling to support this and added a test.