### PR TITLE
DEVEX-851 - Fix python 3 dx upload issue

### DIFF
--- a/src/python/dxpy/__init__.py
+++ b/src/python/dxpy/__init__.py
@@ -609,6 +609,9 @@ def DXHTTPRequest(resource, data, method='POST', headers=None, auth=True,
                     return i
 
                 _headers = {ensure_ascii(k): ensure_ascii(v) for k, v in _headers.items()}
+                if (sys.version_info > (3, 0)): 
+                    _headers.pop(b'host', None)
+                    _headers.pop(b'content-length', None)
                 response = pool_manager.request(_method, _url, headers=_headers, body=body,
                                                 timeout=timeout, retries=False, **kwargs)
             except urllib3.exceptions.ClosedPoolError:


### PR DESCRIPTION
Looks like the `headers` and `content-length` fields were duplicated when testing for python 2 vs. 3.  These lines simply check for python 3 and delete those fields when passing into urllib3.  Thanks to @jtratner for alerting us to this