### PR TITLE
Fix import dxpy cli

### DIFF
--- a/src/python/dxpy/cli/__init__.py
+++ b/src/python/dxpy/cli/__init__.py
@@ -23,7 +23,7 @@ from __future__ import print_function, unicode_literals, division, absolute_impo
 
 import sys
 
-INTERACTIVE_CLI = True if sys.stdin.isatty() and sys.stdout.isatty() else False
+INTERACTIVE_CLI = sys.stdin and sys.stdin.isatty() and sys.stdout and sys.stdout.isatty()
 
 from ..exceptions import err_exit, default_expected_exceptions, DXError
 from ..compat import input

--- a/src/python/requirements_test.txt
+++ b/src/python/requirements_test.txt
@@ -2,3 +2,4 @@ pexpect==4.2
 coverage==3.7.1
 pyopenssl==16.2.0
 pytest==3.5.1
+mock==2.0.0

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -76,6 +76,14 @@ def list_folder(proj_id, path):
     return output
 
 
+def test_dxpy_import_stdin_none(monkeypatch):
+    """
+    Ensure that importing dxpy works even if stdin is None.
+    """
+    monkeypatch.setattr(sys, 'stdin', None)
+    del sys.modules['dxpy.cli']
+    from dxpy.cli import INTERACTIVE_CLI
+
 
 class TestDXTestUtils(DXTestCase):
     @pytest.mark.TRACEABILITY_MATRIX

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -76,13 +76,14 @@ def list_folder(proj_id, path):
     return output
 
 
-def test_dxpy_import_stdin_none(monkeypatch):
-    """
-    Ensure that importing dxpy works even if stdin is None.
-    """
-    monkeypatch.setattr(sys, 'stdin', None)
-    del sys.modules['dxpy.cli']
-    from dxpy.cli import INTERACTIVE_CLI
+class TestDXPYImport(object):
+    def test_dxpy_import_stdin_none(self, monkeypatch):
+        """
+        Ensure that importing dxpy works even if stdin is None.
+        """
+        monkeypatch.setattr(sys, 'stdin', None)
+        del sys.modules['dxpy.cli']
+        from dxpy.cli import INTERACTIVE_CLI
 
 
 class TestDXTestUtils(DXTestCase):

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -31,6 +31,7 @@ import pexpect
 import requests
 import textwrap
 import pytest
+from mock import patch
 
 import dxpy
 import dxpy.executable_builder
@@ -76,12 +77,12 @@ def list_folder(proj_id, path):
     return output
 
 
-class TestDXPYImport(object):
-    def test_dxpy_import_stdin_none(self, monkeypatch):
+class TestDXPYImport(unittest.TestCase):
+    @patch('sys.stdin', None)
+    def test_dxpy_import_stdin_none(self):
         """
         Ensure that importing dxpy works even if stdin is None.
         """
-        monkeypatch.setattr(sys, 'stdin', None)
         del sys.modules['dxpy.cli']
         from dxpy.cli import INTERACTIVE_CLI
 


### PR DESCRIPTION
I realize that Python 3 is not yet fully supported in dxpy, but there was a problem that seems to be fixed by this small PR.

Namely, the problem was the following error when using Python 3, dxpy and AWS Step Functions:

```
Traceback (most recent call last):
File "/var/task/basespace_sm/sequencing_handlers.py", line 7, in <module>
from dxpy import DXApplet
File "/var/task/dxpy/__init__.py", line 1002, in <module>
from .bindings import *
File "/var/task/dxpy/bindings/__init__.py", line 649, in <module>
from .dxfile import DXFile, DXFILE_HTTP_THREADS, DEFAULT_BUFFER_SIZE
File "/var/task/dxpy/bindings/dxfile.py", line 36, in <module>
from ..utils.resolver import object_exists_in_project
File "/var/task/dxpy/utils/resolver.py", line 34, in <module>
from ..cli import try_call, INTERACTIVE_CLI
File "/var/task/dxpy/cli/__init__.py", line 26, in <module>
INTERACTIVE_CLI = True if sys.stdin.isatty() and sys.stdout.isatty() else False
AttributeError: 'NoneType' object has no attribute 'isatty'
```

The problem is that according to the [docs](https://docs.python.org/3/library/sys.html#sys.__stdin__):

>nder some conditions stdin, stdout and stderr as well as the original values __stdin__, __stdout__ and __stderr__ can be None. It is usually the case for Windows GUI apps that aren’t connected to a console and Python apps started with pythonw.

Which I think is the case in AWS Step Functions too.

In this PR I first check that `sys.stdin` and `sys.stdout` are not None, before trying to use them. I've also added a unit test that fails without the fix from 6fdf569.