### PR TITLE
A few Python 3 compatibility fixes.

### DIFF
--- a/src/python/dxpy/app_builder.py
+++ b/src/python/dxpy/app_builder.py
@@ -385,7 +385,7 @@ def upload_resources(src_dir, project=None, folder='/', ensure_upload=False, for
                 # compress the file by reading the tar file and passing
                 # it though a GzipFile object, writing the given
                 # block size (by default 8192 bytes) at a time
-                targz_gzf = gzip.GzipFile(fileobj=targz_fh, mode='w')
+                targz_gzf = gzip.GzipFile(fileobj=targz_fh, mode='wb')
                 tar_tmp_fh.seek(0)
                 dat = tar_tmp_fh.read(io.DEFAULT_BUFFER_SIZE)
                 while dat:

--- a/src/python/dxpy/app_builder.py
+++ b/src/python/dxpy/app_builder.py
@@ -385,7 +385,7 @@ def upload_resources(src_dir, project=None, folder='/', ensure_upload=False, for
                 # compress the file by reading the tar file and passing
                 # it though a GzipFile object, writing the given
                 # block size (by default 8192 bytes) at a time
-                targz_gzf = gzip.GzipFile(fileobj=targz_fh)
+                targz_gzf = gzip.GzipFile(fileobj=targz_fh, mode='w')
                 tar_tmp_fh.seek(0)
                 dat = tar_tmp_fh.read(io.DEFAULT_BUFFER_SIZE)
                 while dat:

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -2620,7 +2620,7 @@ def build(args):
             msg += " whether a dxapp.json or dxworkflow.json file is found in the source directory, respectively."
             build_parser.error(msg)
     except Exception as e:
-        print("Error: %s" % (e.message,), file=sys.stderr)
+        print("Error: {}".format(e), file=sys.stderr)
         err_exit()
 
 


### PR DESCRIPTION
cc @geetduggal @jtratner 

In this PR I've fixed a few Python3-related issues when using `dx build` from the command line:

```
Traceback (most recent call last):
  File "/Users/piotr/counsyl/dx-toolkit/src/python/dxpy/scripts/dx.py", line 2614, in build
    dx_build_app.build(args)
  File "/Users/piotr/counsyl/dx-toolkit/src/python/dxpy/scripts/dx_build_app.py", line 1002, in build
    json.loads(args.extra_args) if args.extra_args else {})
  File "/Users/piotr/counsyl/dx-toolkit/src/python/dxpy/scripts/dx_build_app.py", line 928, in _build_app
    **extra_args
  File "/Users/piotr/counsyl/dx-toolkit/src/python/dxpy/scripts/dx_build_app.py", line 794, in build_and_upload_locally
    force_symlinks=force_symlinks) if not dry_run else []
  File "/Users/piotr/counsyl/dx-toolkit/src/python/dxpy/app_builder.py", line 392, in upload_resources
    targz_gzf.write(dat)
  File "/Users/piotr/.pyenv/versions/3.6.5/lib/python3.6/gzip.py", line 251, in write
    raise OSError(errno.EBADF, "write() on read-only GzipFile object")
OSError: [Errno 9] write() on read-only GzipFile object

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/piotr/counsyl/dx-toolkit/src/python/dxpy/scripts/dx.py", line 5806, in main
    args.func(args)
  File "/Users/piotr/counsyl/dx-toolkit/src/python/dxpy/scripts/dx.py", line 2623, in build
    print("Error: %s" % (e.message,), file=sys.stderr)
AttributeError: 'OSError' object has no attribute 'message'
```

The problems were:

1. `OSError` in Python3 doesn't have the `message` attribute
2. Apparently the mechanism to autodetect the mode of the file object has changed between Python 2 and Python 3 and therefore in Python 3 it defaults to read-only whereas it used to allow writes in Python 2. I've changed it to explicitly open the file in `wb` mode.

I've tested this by successfully uploading files using `dx build` with those fixes in place.