### PR TITLE
DEVEX-853 cat argument too long

### DIFF
--- a/src/python/scripts/dx-print-bash-vars
+++ b/src/python/scripts/dx-print-bash-vars
@@ -39,5 +39,5 @@ for key, val in var_defs_hash.iteritems():
     if val_len <= (16 * 1024):
         print("export {}={}".format(key, val))
     else:
-        print("the variable {} is too long ({} bytes), omitting".format(key, val_len),
-              file=sys.stderr)
+        msg = "the variable {} is too long ({} bytes), omitting".format(key, val_len)
+        print("echo {}".format(msg))

--- a/src/python/scripts/dx-print-bash-vars
+++ b/src/python/scripts/dx-print-bash-vars
@@ -39,5 +39,5 @@ for key, val in var_defs_hash.iteritems():
     if val_len <= (16 * 1024):
         print("export {}={}".format(key, val))
     else:
-        msg = "the variable {} is too long ({} bytes), omitting".format(key, val_len)
+        msg = "\"the variable {} is too long ({} bytes), omitting\"".format(key, val_len)
         print("echo {}".format(msg))

--- a/src/python/scripts/dx-print-bash-vars
+++ b/src/python/scripts/dx-print-bash-vars
@@ -35,8 +35,8 @@ job_input_file = file_load_utils.get_input_json_file()
 
 var_defs_hash = file_load_utils.gen_bash_vars(job_input_file)
 for key, val in var_defs_hash.iteritems():
-    val_len = length(val)
-    if len <= (16 * 1024):
+    val_len = len(val)
+    if val_len <= (16 * 1024):
         print("export {}={}".format(key, val))
     else:
         print("the variable {} is too long ({} bytes), omitting".format(key, val_len),

--- a/src/python/scripts/dx-print-bash-vars
+++ b/src/python/scripts/dx-print-bash-vars
@@ -35,4 +35,9 @@ job_input_file = file_load_utils.get_input_json_file()
 
 var_defs_hash = file_load_utils.gen_bash_vars(job_input_file)
 for key, val in var_defs_hash.iteritems():
-    print("export {}={}".format(key, val))
+    val_len = length(val)
+    if len <= (16 * 1024):
+        print("export {}={}".format(key, val))
+    else:
+        print("the variable {} is too long ({} bytes), omitting".format(key, val_len),
+              file=sys.stderr)


### PR DESCRIPTION
A fix that created bash variables for each of a job's inputs, only if it isn't too long. The current limit is 16KB.