### PR TITLE
Replace ws4py with websocket-client library in job_log_client

### DIFF
--- a/src/python/dxpy/exceptions.py
+++ b/src/python/dxpy/exceptions.py
@@ -259,7 +259,7 @@ def err_exit(message='', code=None, expected_exceptions=default_expected_excepti
 
     exc = exception if exception is not None else sys.exc_info()[1]
     if isinstance(exc, SystemExit):
-        raise
+        raise exc
     elif isinstance(exc, expected_exceptions):
         exit_with_exc_info(EXPECTED_ERR_EXIT_STATUS, message, print_tb=dxpy._DEBUG > 0, exception=exception)
     elif ignore_sigpipe and isinstance(exc, IOError) and getattr(exc, 'errno', None) == errno.EPIPE:

--- a/src/python/dxpy/utils/job_log_client.py
+++ b/src/python/dxpy/utils/job_log_client.py
@@ -14,113 +14,154 @@
 #   License for the specific language governing permissions and limitations
 #   under the License.
 
-'''
+"""
 Utilities for client-side usage of the streaming log API
 (https://wiki.dnanexus.com/API-Specification-v1.0.0/Logging#API-method%3A-%2Fjob-xxxx%2FgetLog).
-'''
+"""
 
 from __future__ import print_function, unicode_literals, division, absolute_import
 
-import json, logging, time
+import json
+import logging
+import time
 
-#from ws4py.client.threadedclient import WebSocketClient
-from ws4py.client import WebSocketBaseClient
+from websocket import WebSocketApp
 
 import dxpy
 from .describe import get_find_executions_string
 from ..exceptions import err_exit
 
-logger = logging.getLogger('ws4py')
+logger = logging.getLogger('websocket')
 logger.setLevel(logging.WARN)
+
 
 class DXJobLogStreamingException(Exception):
     pass
 
-class DXJobLogStreamClient(WebSocketBaseClient):
-    def __init__(self, job_id, input_params=None, msg_output_format="{job} {level} {msg}", msg_callback=None,
-                 print_job_info=True):
+
+class DXJobLogStreamClient:
+    def __init__(
+        self, job_id, input_params=None, msg_output_format="{job} {level} {msg}",
+        msg_callback=None, print_job_info=True
+    ):
         self.job_id = job_id
-        self.seen_jobs = {}
         self.input_params = input_params
         self.msg_output_format = msg_output_format
         self.msg_callback = msg_callback
         self.print_job_info = print_job_info
-        self.closed_code, self.closed_reason = None, None
-        ws_proto = 'wss' if dxpy.APISERVER_PROTOCOL == 'https' else 'ws'
-        self.url = "{protocol}://{host}:{port}/{job_id}/getLog/websocket".format(protocol=ws_proto,
-                                                                                 host=dxpy.APISERVER_HOST,
-                                                                                 port=dxpy.APISERVER_PORT,
-                                                                                 job_id=job_id)
-        WebSocketBaseClient.__init__(self, self.url, protocols=None, extensions=None)
+        self.seen_jobs = {}
+        self.closed_code = None
+        self.closed_reason = None
+        self.url = "{protocol}://{host}:{port}/{job_id}/getLog/websocket".format(
+            protocol='wss' if dxpy.APISERVER_PROTOCOL == 'https' else 'ws',
+            host=dxpy.APISERVER_HOST,
+            port=dxpy.APISERVER_PORT,
+            job_id=job_id
+        )
+        self._app = None
 
-    def handshake_ok(self):
-        self.run()
+    def connect(self):
+        while True:
+            try:
+                self._app = WebSocketApp(
+                    self.url,
+                    on_open=self.opened,
+                    on_close=self.closed,
+                    on_message=self.received_message
+                )
+                self._app.run_forever()
+            except:
+                if not self.server_restarted():
+                    raise
+            finally:
+                self._app = None
+
+            if self.server_restarted():
+                # Instead of trying to reconnect in a retry loop with backoff, run an
+                # API call that will do the same and block while it retries.
+                logger.warn("Server restart, reconnecting...")
+                time.sleep(1)
+                dxpy.describe(self.job_id)
+            else:
+                break
+
+    def server_restarted(self):
+        return (
+            self.closed_code == 1001 and
+            self.closed_reason == "Server restart, please reconnect later"
+        )
 
     def opened(self):
-        args = {"access_token": dxpy.SECURITY_CONTEXT['auth_token'],
-                "token_type": dxpy.SECURITY_CONTEXT['auth_token_type']}
+        args = {
+            "access_token": dxpy.SECURITY_CONTEXT['auth_token'],
+            "token_type": dxpy.SECURITY_CONTEXT['auth_token_type']
+        }
         if self.input_params:
             args.update(self.input_params)
-        self.send(json.dumps(args))
+        self._app.send(json.dumps(args))
 
-    def reconnect(self):
-        # Instead of trying to reconnect in a retry loop with backoff, run an API call that will do the same
-        # and block while it retries.
-        time.sleep(1)
-        dxpy.describe(self.job_id)
-        WebSocketBaseClient.__init__(self, self.url, protocols=None, extensions=None)
-        self.connect()
+    def closed(self, code=None, reason=None):
+        if code is None:
+            code = 1006
+            reason = "Going away"
+        self.closed_code = code
+        self.closed_reason = reason
 
-    def terminate(self):
-        if self.stream and self.stream.closing and self.stream.closing.code == 1001 \
-           and self.stream.closing.reason == "Server restart, please reconnect later":
-            # Clean up state (this is a copy of WebSocket.terminate(), minus the part that calls closed())
-            try:
-                self.close_connection()
-                self.stream._cleanup()
-            except:
-                pass
-            self.stream = None
-            self.environ = None
-
-            logger.warn("Server restart, reconnecting...")
-            self.reconnect()
-        else:
-            WebSocketBaseClient.terminate(self)
-
-    def closed(self, code, reason):
-        self.closed_code, self.closed_reason = code, reason
-
-        if not (self.closed_code == 1000 or getattr(self.stream.closing, 'code', None) == 1000):
+        if self.closed_code != 1000:
             try:
                 error = json.loads(self.closed_reason)
-                raise DXJobLogStreamingException("Error while streaming job logs: {type}: {message}\n".format(**error))
+                raise DXJobLogStreamingException(
+                    "Error while streaming job logs: {type}: {message}\n".format(
+                        **error
+                    )
+                )
             except (KeyError, ValueError):
-                error = "Error while streaming job logs: {code} {reason}\n".format(code=self.closed_code,
-                                                                                   reason=self.closed_reason)
-                raise DXJobLogStreamingException(error)
+                raise DXJobLogStreamingException(
+                    "Error while streaming job logs: {code} {reason}\n".format(
+                        code=self.closed_code, reason=self.closed_reason
+                    )
+                )
         elif self.print_job_info:
             if self.job_id not in self.seen_jobs:
                 self.seen_jobs[self.job_id] = {}
             for job_id in self.seen_jobs.keys():
                 self.seen_jobs[job_id] = dxpy.describe(job_id)
-                print(get_find_executions_string(self.seen_jobs[job_id], has_children=False, show_outputs=True))
+                print(
+                    get_find_executions_string(
+                        self.seen_jobs[job_id],
+                        has_children=False,
+                        show_outputs=True
+                    )
+                )
         else:
             self.seen_jobs[self.job_id] = dxpy.describe(self.job_id)
 
-        if self.seen_jobs[self.job_id].get('state') in ['failed', 'terminated']:
+        if self.seen_jobs[self.job_id].get('state') in {'failed', 'terminated'}:
             err_exit(code=3)
 
     def received_message(self, message):
-        message = json.loads(message.__unicode__())
+        message_dict = json.loads(message.__unicode__())
 
-        if self.print_job_info and 'job' in message and message['job'] not in self.seen_jobs:
-            self.seen_jobs[message['job']] = dxpy.describe(message['job'])
-            print(get_find_executions_string(self.seen_jobs[message['job']], has_children=False, show_outputs=False))
+        if (
+            self.print_job_info and
+            'job' in message_dict and
+            message_dict['job'] not in self.seen_jobs
+        ):
+            self.seen_jobs[message_dict['job']] = dxpy.describe(message_dict['job'])
+            print(
+                get_find_executions_string(
+                    self.seen_jobs[message_dict['job']],
+                    has_children=False,
+                    show_outputs=False
+                )
+            )
 
-        if message.get('source') == 'SYSTEM' and message.get('msg') == 'END_LOG':
-            self.close()
+        if (
+            message_dict.get('source') == 'SYSTEM' and
+            message_dict.get('msg') == 'END_LOG'
+        ):
+            self._app.close()
         elif self.msg_callback:
-            self.msg_callback(message)
+            self.msg_callback(message_dict)
         else:
-            print(self.msg_output_format.format(**message))
+            print(self.msg_output_format.format(**message_dict))

--- a/src/python/dxpy/utils/job_log_client.py
+++ b/src/python/dxpy/utils/job_log_client.py
@@ -140,7 +140,7 @@ class DXJobLogStreamClient:
             err_exit(code=3)
 
     def received_message(self, message):
-        message_dict = json.loads(message.__unicode__())
+        message_dict = json.loads(message)
 
         if (
             self.print_job_info and

--- a/src/python/dxpy/utils/job_log_client.py
+++ b/src/python/dxpy/utils/job_log_client.py
@@ -111,6 +111,10 @@ class DXJobLogStreamClient:
     def errored(self, exception=None):
         self.error = True
         self.exception = exception
+        if exception:
+            import sys
+            import traceback
+            traceback.print_exception(*sys.exc_info())
 
     def closed(self, code=None, reason=None):
         if code:
@@ -133,7 +137,7 @@ class DXJobLogStreamClient:
                 )
             except (KeyError, ValueError):
                 raise DXJobLogStreamingException(
-                    "Error while streaming job logs: {code} {reason}\n".format(
+                    "Error while streaming job logs: {code}: {reason}\n".format(
                         code=self.closed_code, reason=self.closed_reason
                     )
                 )
@@ -176,7 +180,7 @@ class DXJobLogStreamClient:
             message_dict.get('source') == 'SYSTEM' and
             message_dict.get('msg') == 'END_LOG'
         ):
-            self._app.close()
+            self._app.keep_running = False
         elif self.msg_callback:
             self.msg_callback(message_dict)
         else:

--- a/src/python/dxpy/utils/job_log_client.py
+++ b/src/python/dxpy/utils/job_log_client.py
@@ -111,10 +111,6 @@ class DXJobLogStreamClient:
     def errored(self, exception=None):
         self.error = True
         self.exception = exception
-        if exception:
-            import sys
-            import traceback
-            traceback.print_exception(*sys.exc_info())
 
     def closed(self, code=None, reason=None):
         if code:

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -1,4 +1,4 @@
-ws4py==0.3.2
+websocket-client==0.53.0
 python-dateutil>=2.5
 python-magic==0.4.6
 beautifulsoup4==4.4.1


### PR DESCRIPTION
We received a request from Lilly to support proxies. The only place where this is an issue is job_log_client, which uses websockets to poll the log of a running job. Currently, we use ws4py, which does not have proxy support. This PR replaces ws4py with websocket-client, which does have proxy support.

Please code review. I would hold off on merging for now. I have provided Lilly with a build of this branch and they will test it for a while. 