### PR TITLE
Python 3: cleanup executable after download fix

### DIFF
--- a/src/python/dxpy/utils/executable_unbuilder.py
+++ b/src/python/dxpy/utils/executable_unbuilder.py
@@ -43,7 +43,7 @@ def _recursive_cleanup(foo):
     Aggressively cleans up things that look empty.
     """
     if isinstance(foo, dict):
-        for (key, val) in foo.items():
+        for (key, val) in list(foo.items()):
             if isinstance(val, dict):
                 _recursive_cleanup(val)
             if val == "" or val == [] or val == {}:


### PR DESCRIPTION
Before this PR:

```
›› dx get project-123:applet-123
Creating "./reorg-and-export-app" output directory
Downloading applet data
Traceback (most recent call last):
  File "/Users/jtratner/.pyenv/versions/3.6.4/lib/python3.6/site-packages/dxpy/utils/executable_unbuilder.py", line 347, in dump_executable
    _dump_app_or_applet(executable, omit_resources, describe_output)
  File "/Users/jtratner/.pyenv/versions/3.6.4/lib/python3.6/site-packages/dxpy/utils/executable_unbuilder.py", line 290, in _dump_app_or_applet
    _recursive_cleanup(dxapp_json['runSpec'])
  File "/Users/jtratner/.pyenv/versions/3.6.4/lib/python3.6/site-packages/dxpy/utils/executable_unbuilder.py", line 46, in _recursive_cleanup
    for (key, val) in foo.items():
RuntimeError: dictionary changed size during iteration
```

After: no error!