### PR TITLE
python 3: use text mode for CSV reading

### DIFF
--- a/src/python/dxpy/utils/batch_utils.py
+++ b/src/python/dxpy/utils/batch_utils.py
@@ -133,7 +133,7 @@ def _search_column_id(col_name, header_line):
 def batch_launch_args(executable, input_json, batch_tsv_file):
     header_line = []
     lines = []
-    with open(batch_tsv_file, "rb") as f:
+    with open(batch_tsv_file, "r") as f:
         reader = csv.reader(f, delimiter=str(u'\t'))
         header_line = next(reader)
         lines = list(reader)


### PR DESCRIPTION
another small fix for python 3 (CSV reader complains about getting byte strings)