### PR TITLE
Fix for 'No root certificates specified for verification of other-side certificates.'

### DIFF
--- a/src/python/dxpy/utils/job_log_client.py
+++ b/src/python/dxpy/utils/job_log_client.py
@@ -23,6 +23,7 @@ from __future__ import print_function, unicode_literals, division, absolute_impo
 
 import json
 import logging
+import ssl
 import time
 
 from websocket import WebSocketApp
@@ -77,7 +78,7 @@ class DXJobLogStreamClient:
                     on_error=self.errored,
                     on_message=self.received_message
                 )
-                self._app.run_forever()
+                self._app.run_forever(sslopt={"cert_reqs": ssl.CERT_NONE})
             except:
                 if not self.server_restarted():
                     raise

--- a/src/python/requirements_backports.txt
+++ b/src/python/requirements_backports.txt
@@ -1,1 +1,2 @@
 futures==3.0.4
+backports.ssl_match_hostname==3.5.0.1


### PR DESCRIPTION
This error occurred during a smoke test, related to the migration from ws4py to websockets-client. The fix is described here: https://github.com/kivy/python-for-android/issues/1107#issuecomment-326775043. I made this fix and re-ran the smoke tests, which passed: https://jenkins.internal.dnanexus.com/job/Smoke%20Test%20A%20Specific%20Nucleus%20Revision/534/