### PR TITLE
Update cran repository

### DIFF
--- a/src/python/dxpy/utils/exec_utils.py
+++ b/src/python/dxpy/utils/exec_utils.py
@@ -363,7 +363,7 @@ class DXExecDependencyInstaller(object):
         elif dep_type == "cpan":
             return "cpanm --notest " + make_pm_atoms(packages, version_separator="~")
         elif dep_type == "cran":
-            repo = "http://cran.us.r-project.org"
+            repo = "http://cloud.r-project.org"
             r_preamble = "die <- function() { q(status=1) }; options(error=die); options(warn=2);"
             r_preamble += 'r <- getOption("repos"); r["CRAN"] = "{repo}"; options(repos=r)'.format(repo=repo)
             r_cmd_template = "R -e '{preamble}; {cmd}'"


### PR DESCRIPTION
Execdepends cran packages failing to access the current repository `http://cran.us.r-project.org`.
Swapping to `http://cloud.r-project.org` per https://cran.cnr.berkeley.edu/mirrors.html