### PR TITLE
Long bash variables

### DIFF
--- a/src/python/scripts/dx-print-bash-vars
+++ b/src/python/scripts/dx-print-bash-vars
@@ -36,8 +36,12 @@ job_input_file = file_load_utils.get_input_json_file()
 var_defs_hash = file_load_utils.gen_bash_vars(job_input_file)
 for key, val in var_defs_hash.items():
     val_len = len(val)
-    if val_len <= (16 * 1024):
-        print("export {}={}".format(key, val))
-    else:
-        msg = "\"the variable {} is too long ({} bytes), omitting\"".format(key, val_len)
+
+    # If the bash variable is very long, this can cause problems down
+    # the road.
+    #
+    # https://groups.google.com/forum/#!topic/comp.unix.programmer/FwYX32Vsjv8
+    if val_len >= (16 * 1024):
+        msg = "\"warning: variable {} is long ({} bytes)\"".format(key, val_len)
         print("echo {}".format(msg))
+    print("export {}={}".format(key, val))


### PR DESCRIPTION
If a bash variable is long, print a warning, do not omit it.