### PR TITLE
DEVEX-889 Fix setting instance types on global workflow stages

### DIFF
--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -3325,7 +3325,7 @@ def run(args):
         if dest_path is None:
             dest_path = dxpy.config.get('DX_CLI_WD', '/')
 
-    process_instance_type_arg(args, is_workflow)
+    process_instance_type_arg(args, is_workflow or is_global_workflow)
     run_body(args, handler, dest_proj, dest_path)
 
 def terminate(args):


### PR DESCRIPTION
The command `dx run <global-workflow> --instance-type <stage_id>=<instance type>` was not processed correctly. This commit fixes it. 
