### PR TITLE
Actually do not print project with dx-jobutil-parse-link --no-project

### DIFF
--- a/src/python/scripts/dx-jobutil-parse-link
+++ b/src/python/scripts/dx-jobutil-parse-link
@@ -31,6 +31,9 @@ except ValueError:
     parser.exit("Unable to parse link as JSON")
 
 if isinstance(link, dict):
-    print("{proj}:{obj}".format(proj=link['project'], obj=link['id']))
+    if args.no_project:
+        print(link['id'])
+    else:
+        print("{proj}:{obj}".format(proj=link['project'], obj=link['id']))
 else:
     print(link)


### PR DESCRIPTION
Not sure where you want to put tests for this, but currently dx-jobutil-parse-link always prints project.

Current:

```
bash -c 'dx-jobutil-parse-link --no-project "$(dx-jobutil-dxlink project-123:file-123)"'
project-123:file-123
```

Fixed:

```
bash -c 'dx-jobutil-parse-link --no-project "$(dx-jobutil-dxlink project-123:file-123)"'
file-123
```

cc @pkaleta who noted this bug.