### PR TITLE
Fix for supporting dx-download-all-inputs --except [array:file variable]

### DIFF
--- a/src/python/dxpy/bindings/download_all_inputs.py
+++ b/src/python/dxpy/bindings/download_all_inputs.py
@@ -167,9 +167,11 @@ def download_all_inputs(exclude=None, parallel=False, max_threads=8):
         raise
 
     # Exclude directories
+    # dirs contain all folders (e.g. $HOME/in/FOO) and their sub folders (e.g. $HOME/in/FOO/1, $HOME/in/FOO/2, etc.)
+    # If the main folder is excluded, its sub-folder would also be excluded from dirs_to_create
     dirs_to_create = []
     for d in dirs:
-        if (exclude is None) or (d not in exclude):
+        if (exclude is None) or (d.split('/')[0] not in exclude):
             dirs_to_create.append(d)
 
     # Create the directory structure, in preparation for download.

--- a/src/python/dxpy/bindings/download_all_inputs.py
+++ b/src/python/dxpy/bindings/download_all_inputs.py
@@ -171,7 +171,11 @@ def download_all_inputs(exclude=None, parallel=False, max_threads=8):
     # If the main folder is excluded, its sub-folder would also be excluded from dirs_to_create
     dirs_to_create = []
     for d in dirs:
-        if (exclude is None) or (d.split('/')[0] not in exclude):
+        keep = True
+        if (exclude is not None) and (d is not None):
+            if (d.split('/')[0] in exclude):
+                keep = False
+        if keep:
             dirs_to_create.append(d)
 
     # Create the directory structure, in preparation for download.

--- a/src/python/test/file_load/basic_except/run.sh
+++ b/src/python/test/file_load/basic_except/run.sh
@@ -1,5 +1,5 @@
 main() {
-    dx-download-all-inputs --except seq1 --except seq2
+    dx-download-all-inputs --except seq1 --except seq2 --except ref
 
     # verify that seq1 and seq2 have not been downloaded
     if [ -e "in/seq1" ]
@@ -13,6 +13,13 @@ main() {
         exit 1
     fi
 
+    # verify that ref has not been downloaded
+    if [ -e "in/ref" ]
+    then
+        echo "Error: file:array ref has been downloaded, in spite of the --except flag"
+        exit 1
+    fi
+
     # Check file content
     dx download "$seq1" -o seq1
     dx download "$seq2" -o seq2
@@ -20,8 +27,13 @@ main() {
     mkdir -p out/result
     echo "hello world, $seq1, $seq2" > out/result/report.txt
 
+    # Check ref content
+    for i in ${!ref[@]}; do
+      dx download "${ref[$i]}" -o "${ref_path[$i]}"
+    done
     mkdir -p out/genes
     echo 'ls in/$ref' > out/genes/refs_ls.txt
+
     echo 'ls in/$reads' > out/genes/reads_ls.txt
 
     dx-upload-all-outputs --except genes


### PR DESCRIPTION
Fix to support `dx-download-all-inputs` with `--except` when the input variable is array:file.
Make `dirs_to_create` exclude all sub-folders (e.g. `$HOME/in/FOO/0`, `$HOME/in/FOO/1`, etc.), rather than just the major folder (e.g. `$HOME/in/FOO`)