### PR TITLE
Support --phi flag for new projects

### DIFF
--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -4929,7 +4929,7 @@ parser_new_project.add_argument('--region', help='Region affinity of the new pro
 parser_new_project.add_argument('-s', '--select', help='Select the new project as current after creating',
                                 action='store_true')
 parser_new_project.add_argument('--bill-to', help='ID of the user or org to which the project will be billed. The default value is the billTo of the requesting user.')
-parser_new_project.add_argument('--phi', help='add PHI protection to project', default=False,
+parser_new_project.add_argument('--phi', help='Add PHI protection to project', default=False,
                                 action='store_true')
 parser_new_project.set_defaults(func=new_project)
 register_parser(parser_new_project, subparsers_action=subparsers_new, categories='fs')

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -1395,6 +1395,8 @@ def new_project(args):
         inputs["billTo"] = args.bill_to
     if args.region:
         inputs["region"] = args.region
+    if args.phi:
+        inputs["containsPHI"] = True
 
     try:
         resp = dxpy.api.project_new(inputs)
@@ -4927,6 +4929,8 @@ parser_new_project.add_argument('--region', help='Region affinity of the new pro
 parser_new_project.add_argument('-s', '--select', help='Select the new project as current after creating',
                                 action='store_true')
 parser_new_project.add_argument('--bill-to', help='ID of the user or org to which the project will be billed. The default value is the billTo of the requesting user.')
+parser_new_project.add_argument('--phi', help='add PHI protection to project', default=False,
+                                action='store_true')
 parser_new_project.set_defaults(func=new_project)
 register_parser(parser_new_project, subparsers_action=subparsers_new, categories='fs')
 

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -3133,22 +3133,6 @@ class TestApiWrappers(unittest.TestCase):
         assert 'messages' in greeting
 
 
-class TestCLI:
-    def test_new_project_phi(self, monkeypatch):
-        from dxpy.scripts import dx
-        monkeypatch.setattr(sys, 'argv', ['dx', 'new', 'project', '--phi', 'myproject'])
-        calls = {}
-
-        def recorder(*args, **kwargs):
-            calls.append((args, kwargs))
-
-        monkeypatch.setattr(dxpy.api, 'project_new', recorder)
-
-        dx.main()
-
-        assert calls == [((), {'name': 'myproject', 'containsPHI': True})]
-
-
 if __name__ == '__main__':
     if dxpy.AUTH_HELPER is None:
         sys.exit(1, 'Error: Need to be logged in to run these tests')

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -3133,6 +3133,22 @@ class TestApiWrappers(unittest.TestCase):
         assert 'messages' in greeting
 
 
+class TestCLI:
+    def test_new_project_phi(self, monkeypatch):
+        from dxpy.scripts import dx
+        monkeypatch.setattr(sys, 'argv', ['dx', 'new', 'project', '--phi', 'myproject'])
+        calls = {}
+
+        def recorder(*args, **kwargs):
+            calls.append((args, kwargs))
+
+        monkeypatch.setattr(dxpy.api, 'project_new', recorder)
+
+        dx.main()
+
+        assert calls == [((), {'name': 'myproject', 'containsPHI': True})]
+
+
 if __name__ == '__main__':
     if dxpy.AUTH_HELPER is None:
         sys.exit(1, 'Error: Need to be logged in to run these tests')


### PR DESCRIPTION
Right now I end up having users do:

```
dx api project new '{"name": "myname", "containsPHI": true}'
```

which is a little awkward to do.

Instead now you could do:

```
dx new project myname --phi
```

to have it include PHI.

Added a test case but wasn't sure how to run the tests.

In my hacky way of running it, got this to work:

```
$ pipenv install && pipenv run dx new project myname --phi
$ dx describe project-FV9Zvk80y1x2kzqP7Vy5Z89z
Result 1:
ID                  project-FV9Zvk80y1x2kzqP7Vy5Z89z
Class               project
Name                myname
Summary
Billed to           org-counsyl
Access level        ADMINISTER
Region              aws:us-east-1
Protected           false
Restricted          false
Contains PHI        true
Created             Thu Jan 31 11:37:09 2019
Created by          jtratner
Last modified       Thu Jan 31 11:37:09 2019
Data usage          0.00 GB
Sponsored data      0.00 GB
Storage cost        $0.000/month
Sponsored egress    0.00 GB used of 0.00 GB total
At spending limit?  false
Tags                -
Properties          -
downloadRestricted  false
defaultInstanceType "mem2_hdd2_x2"
```