### PR TITLE
DEVEX-917 Binary files on python3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 
 ### Added
 - Binary mode for opening dx:files.
-- A `--textual` flag for command line tools that need to handle unicode text files.
-  For example: `dx cat --textual file-xxxx`. This was added for `cat`, and `download`.
+- A `--unicode` flag for command line tools that need to handle unicode text files.
+  For example: `dx cat --unicode file-xxxx`. This was added for `cat`, and `download`.
 
 ## [275.0] - 2019.02.01 beta
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 
 * argcomplete eval in the worker when sourcing `environment`
 * Bug in downloading symlinks when using aria2c
+- Uploading binary data, such at compressed files, works in python3.
+
+### Added
+- Binary mode for opening dx:files.
+- A `--textual` flag for command line tools that need to handle unicode text files.
+  For example: `dx cat --textual file-xxxx`. This was added for `cat`, and `download`.
+
 
 ## [274.0] - 2019.01.24 beta
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 ## Unreleased
 
 ### Fixed
-
-* argcomplete eval in the worker when sourcing `environment`
-* Bug in downloading symlinks when using aria2c
 - Uploading binary data, such at compressed files, works in python3.
 
 ### Added
@@ -17,15 +14,21 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 - A `--textual` flag for command line tools that need to handle unicode text files.
   For example: `dx cat --textual file-xxxx`. This was added for `cat`, and `download`.
 
+## [275.0] - 2019.02.01 beta
 
-## [274.0] - 2019.01.24 beta
+### Fixed
+
+* argcomplete eval in the worker when sourcing `environment`
+* Bug in downloading symlinks when using aria2c
+
+## [274.0] - 2019.02.01 stable
 
 ### Fixed
 
 * Preserve `httpsApp` field in dxapp.json when calling `dx get`
 * The `--except [array:file variable]` option for `dx-download-all-inputs`
 
-## [273.0] - 2019.01.24 stable
+## [273.0] - 2019.01.24
 
 ### Fixed
 * upload issue using api proxy in Python 3

--- a/src/python/dxpy/bindings/dxfile.py
+++ b/src/python/dxpy/bindings/dxfile.py
@@ -959,6 +959,6 @@ class DXFile(DXDataObject):
         if USING_PYTHON2:
             return data
         # In python3, the underlying system methods use the 'bytes' type, not 'string'
-        if self._binary_mode:
+        if self._binary_mode is True:
             return data
         return data.decode("utf-8")

--- a/src/python/dxpy/bindings/dxfile.py
+++ b/src/python/dxpy/bindings/dxfile.py
@@ -210,19 +210,17 @@ class DXFile(DXDataObject):
         """
         DXDataObject.__init__(self, dxid=dxid, project=project)
 
-        # By default, a file is create in text mode. This makes a difference
+        # By default, a file is created in text mode. This makes a difference
         # in python 3.
         self._binary_mode = False
         if mode is None:
             self._close_on_exit = True
-            self._mode = None
         else:
             if 'b' in mode:
                 self._binary_mode = True
                 mode = mode.replace("b", "")
             if mode not in ['r', 'w', 'a']:
                 raise ValueError("mode must be one of 'r', 'w', or 'a'. Character 'b' may be used in combination (e.g. 'wb').")
-            self._mode = mode
             self._close_on_exit = (mode == 'w')
         self._read_buf = BytesIO()
         self._write_buf = BytesIO()
@@ -961,6 +959,6 @@ class DXFile(DXDataObject):
         if USING_PYTHON2:
             return data
         # In python3, the underlying system methods use the 'bytes' type, not 'string'
-        if self._binary_mode is True:
+        if self._binary_mode:
             return data
         return data.decode("utf-8")

--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -40,7 +40,7 @@ from ..exceptions import DXFileError, DXPartLengthMismatchError, DXChecksumMisma
 from ..utils import response_iterator
 import subprocess
 
-def open_dxfile(dxid, project=None, read_buffer_size=dxfile.DEFAULT_BUFFER_SIZE):
+def open_dxfile(dxid, project=None, mode=None, read_buffer_size=dxfile.DEFAULT_BUFFER_SIZE):
     '''
     :param dxid: file ID
     :type dxid: string
@@ -60,7 +60,7 @@ def open_dxfile(dxid, project=None, read_buffer_size=dxfile.DEFAULT_BUFFER_SIZE)
       DXFile(dxid)
 
     '''
-    return DXFile(dxid, project=project, read_buffer_size=read_buffer_size)
+    return DXFile(dxid, project=project, mode=mode, read_buffer_size=read_buffer_size)
 
 
 def new_dxfile(mode=None, write_buffer_size=dxfile.DEFAULT_BUFFER_SIZE, expected_file_size=None, file_is_mmapd=False,

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -1930,7 +1930,7 @@ def cat(args):
 
         # We assume the file is binary, unless specified otherwise
         mode = "rb"
-        if args.textual is True:
+        if args.unicode_text is True:
             mode = "r"
         try:
             dxfile = dxpy.DXFile(entity_result['id'], mode=mode)
@@ -1951,7 +1951,7 @@ def cat(args):
 def download_or_cat(args):
     if args.output == '-':
         cat_args = parser.parse_args(['cat'] + args.paths)
-        cat_args.textual = args.textual
+        cat_args.unicode_text = args.unicode_text
         cat(cat_args)
         return
     download(args)
@@ -4226,8 +4226,8 @@ parser_download.add_argument('-a', '--all', help='If multiple objects match the 
                              action='store_true')
 parser_download.add_argument('--no-progress', help='Do not show a progress bar', dest='show_progress',
                              action='store_false', default=sys.stderr.isatty())
-parser_download.add_argument('--textual', help='Display the characters as text/unicode when writing to stdout',
-                             action='store_true')
+parser_download.add_argument('--unicode', help='Display the characters as text/unicode when writing to stdout',
+                             dest="unicode_text", action='store_true')
 parser_download.set_defaults(func=download_or_cat)
 register_parser(parser_download, categories='data')
 
@@ -4251,8 +4251,8 @@ parser_cat = subparsers.add_parser('cat', help='Print file(s) to stdout', prog='
                                    parents=[env_args])
 cat_path_action = parser_cat.add_argument('path', help='File ID or name(s) to print to stdout', nargs='+')
 cat_path_action.completer = DXPathCompleter(classes=['file'])
-parser_cat.add_argument('--textual', help='Display the characters as text/unicode when writing to stdout',
-                        action='store_true')
+parser_cat.add_argument('--unicode', help='Display the characters as text/unicode when writing to stdout',
+                        dest="unicode_text", action='store_true')
 parser_cat.set_defaults(func=cat)
 register_parser(parser_cat, categories='data')
 

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -1804,6 +1804,24 @@ dxpy.run()
             buf = run("dx head test.tar.gz")
             self.assertEqual("File contains binary data", buf)
 
+    def test_download_unicode_to_stdout(self):
+        # example unicode text in Thai.
+        sentence = "ผบช.สตม.แจง ปมไทยกักตัว ให้ทางเอกอัครราชทูตออสเตรเลียรับทราบแล้ว"
+
+        with temporary_project('test_proj', select=True) as temp_project:
+            proj_id = temp_project.get_id()
+
+            # create a file with 'dx upload'
+            cmd = "echo {} | dx upload - --path Thai.txt --brief --wait".format(sentence)
+            file_id = run(cmd.strip())
+            self.assertTrue(file_id.startswith('file-'))
+
+            # download the file with 'dx cat'
+            buf = run("dx cat Thai.txt").strip()
+
+            # check that the content is the same
+            self.assertEqual(buf, sentence)
+
     def test_dx_download_resume_and_checksum(self):
         def assert_md5_checksum(filename, hasher):
             with open(filename, "rb") as fh:

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -1753,7 +1753,10 @@ dxpy.run()
 
         def gen_file_gzip(fname, proj_id):
             with gzip.open(fname, 'wb') as f:
-                f.write(data)
+                if USING_PYTHON2:
+                    f.write(data)
+                else:
+                    f.write(data.encode('utf-8'))
 
             dxfile = dxpy.upload_local_file(fname, name=fname, project=proj_id,
                                             media_type="application/gzip", wait_on_close=True)
@@ -1796,6 +1799,10 @@ dxpy.run()
             gen_file_tar("test-file", "test.tar.gz", proj_id)
             buf = run("dx cat test.tar.gz | tar zvxf -")
             self.assertTrue(os.path.exists('test-file'))
+
+            # test head on a binary file
+            buf = run("dx head test.tar.gz")
+            self.assertEqual("File contains binary data", buf)
 
     def test_dx_download_resume_and_checksum(self):
         def assert_md5_checksum(filename, hasher):

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -575,6 +575,32 @@ class TestDXFile(testutil.DXTestCaseCompat):
             buf = same_dxfile.read()
             self.assertEqual(self.foo_str[-1:], buf)
 
+    def test_write_read_binary_dxfile(self):
+        dxid = ""
+        data = "ไนความจริงสิ่งคาด"  # unicode characters
+
+        # Writing Unicode text
+        with dxpy.new_dxfile(mode = "w") as self.dxfile:
+            dxid = self.dxfile.get_id()
+            self.dxfile.write(data)
+        with dxpy.open_dxfile(dxid, mode="r") as same_dxfile:
+            same_dxfile.wait_on_close()
+            self.assertTrue(same_dxfile.closed())
+            buf = same_dxfile.read()
+            self.assertEqual(data, buf)
+
+        # Writing binary data
+        binary = data.encode("utf-8")
+        with dxpy.new_dxfile(mode = "wb") as self.dxfile:
+            dxid = self.dxfile.get_id()
+            self.dxfile.write(binary)
+        with dxpy.open_dxfile(dxid, mode="rb") as same_dxfile:
+            same_dxfile.wait_on_close()
+            self.assertTrue(same_dxfile.closed())
+            buf = same_dxfile.read()
+            self.assertEqual(binary, buf)
+
+
     def test_download_project_selection(self):
         with testutil.temporary_project() as p, testutil.temporary_project() as p2:
             # Same file is available in both projects

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -576,6 +576,10 @@ class TestDXFile(testutil.DXTestCaseCompat):
             self.assertEqual(self.foo_str[-1:], buf)
 
     def test_write_read_binary_dxfile(self):
+        # This test is run ONLY for python-3.
+        # It fails on python-2.
+        if USING_PYTHON2:
+            return
         dxid = ""
         data = "ไนความจริงสิ่งคาด"  # unicode characters
 
@@ -600,6 +604,22 @@ class TestDXFile(testutil.DXTestCaseCompat):
             buf = same_dxfile.read()
             self.assertEqual(binary, buf)
 
+    def test_write_read_unicode_dxfile(self):
+        # Not expected to work for python-2
+        if USING_PYTHON2:
+            return
+        data = "ไนความจริงสิ่งคาด"  # unicode characters
+
+        # using upload_string to upload unicode
+        self.dxfile = dxpy.upload_string(data)
+        self.dxfile.wait_on_close()
+        self.assertTrue(self.dxfile.closed())
+
+        # download and check the data remained the same
+        dxpy.download_dxfile(self.dxfile.get_id(), self.new_file.name)
+        with open(self.new_file.name, 'r') as fd:
+            data2 = fd.read().strip()
+        self.assertEqual(data2, data)
 
     def test_download_project_selection(self):
         with testutil.temporary_project() as p, testutil.temporary_project() as p2:


### PR DESCRIPTION
Address issue https://github.com/dnanexus/dx-toolkit/issues/426. 

1. Support binary mode in file open. 
2. Update the CLI to make use of binary mode on python3. By default, we assume files are binary. This will work for ASCII inputs, and gzip/tar files, which we assume are the majority. If you need to use unicode, the `--textual` flag is provided.
3. Additional tests.  
