### PR TITLE
Attempt to correct aria2c output path

### DIFF
--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -191,7 +191,7 @@ def _download_symbolic_link(dxid, md5digest, project, dest_filename):
         # If '-d' arg not provided, aria2c uses current working directory
         cwd = os.getcwd()
         directory, filename = os.path.split(dest_filename)
-        directory = cwd if dirname in ["", cwd] else directory
+        directory = cwd if directory in ["", cwd] else directory
         cmd += ["-o", filename, "-d", directory, url]
 
     try:

--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -184,7 +184,9 @@ def _download_symbolic_link(dxid, md5digest, project, dest_filename):
         cmd += ["-O", dest_filename, url]
     else:
         print("aria2c found in path so using that instead of wget \n")
-        cmd = ["aria2c", "--check-certificate=false", "-s", str(multiprocessing.cpu_count()), "-x", str(multiprocessing.cpu_count())]
+        # aria2c does not allow more than 16 connections per server
+        max_connections = 16 if multiprocessing.cpu_count() > 16 else multiprocessing.cpu_count()
+        cmd = ["aria2c", "--check-certificate=false", "-s", str(max_connections), "-x", str(max_connections)]
         cmd += ["-o", dest_filename, url]
 
     try:

--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -192,7 +192,7 @@ def _download_symbolic_link(dxid, md5digest, project, dest_filename):
         cwd = os.getcwd()
         directory, filename = os.path.split(dest_filename)
         directory = cwd if directory in ["", cwd] else directory
-        cmd += ["-o", filename, "-d", directory, url]
+        cmd += ["-o", filename, "-d", os.path.abspath(directory), url]
 
     try:
         if aria2c_exe is not None:

--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -187,7 +187,12 @@ def _download_symbolic_link(dxid, md5digest, project, dest_filename):
         # aria2c does not allow more than 16 connections per server
         max_connections = 16 if multiprocessing.cpu_count() > 16 else multiprocessing.cpu_count()
         cmd = ["aria2c", "--check-certificate=false", "-s", str(max_connections), "-x", str(max_connections)]
-        cmd += ["-o", dest_filename, url]
+        # Split path properly for aria2c
+        # If '-d' arg not provided, aria2c uses current working directory
+        cwd = os.getcwd()
+        directory, filename = os.path.split(dest_filename)
+        directory = cwd if dirname in ["", cwd] else directory
+        cmd += ["-o", filename, "-d", directory, url]
 
     try:
         if aria2c_exe is not None:


### PR DESCRIPTION
Attempt to strip the path from the output filename for the call to aria2c when downloading symlinks.
```
root@kjdev:/dir0# dx download test.gz
# Generates a command with '-o'
aria2c -o /dir0/test13.gz
Download Results:
gid   |stat|avg speed  |path/URI
======+====+===========+=======================================================
9069c1|OK  |    60MiB/s|/dir0//dir0/test13.gz
```
The expected behavior would be to download test.gz to the current directory.
This seems fine but aria2c assumes `-d $(pwd)` if no directory argument is provided. 
```
root@kjdev:/dir0# aria2c -h |grep dir
 -d, --dir=DIR                The directory to store the downloaded file.
                              Possible Values: /path/to/directory
                              Default: /dir0
```
Thus the file is actually downloaded to `/dir0/dir0/test.gz`
```
root@kjdev:/dir0# tree /dir0/
/dir0/
└── dir0
    └── test.gz
```

After splitting the path and supplying both '-o' and '-d
```
root@kjdev:/dir0# dx download test.gz
Download Results:
gid   |stat|avg speed  |path/URI
======+====+===========+=======================================================
f7241b|OK  |    60MiB/s|/dir0/test.gz

# Now generates a command with '-o' and '-d' args
# aria2c -o test.gz -d /dir0

root@kjdev:/dir0# tree /dir0/
/dir0/
└── test.gz
```