### PR TITLE
Devex 1034 cli parse error

### DIFF
--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -5548,6 +5548,11 @@ def main():
         set_cli_colors(args)
         set_delim(args)
         set_env_from_args(args)
+        if not hasattr(args, 'func'):
+            # Something was wrong in the command line. Print the help message for
+            # this particular combination of command line words.
+            parser.parse_args(args_list + ["--help"])
+            sys.exit(1)
         try:
             args.func(args)
             # Flush buffered data in stdout before interpreter shutdown to ignore broken pipes

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -341,6 +341,11 @@ class TestDXClient(DXTestCase):
             with self.assertSubprocessFailure(stderr_regexp="ResourceNotFound", exit_code=3):
                 run(("dx uninvite "+query).format(p=self.project))
 
+    def test_dx_add_missing_arguments(self):
+        with self.assertSubprocessFailure(stderr_text = "missing argument",
+                                          exit_code=3):
+            run("dx add")
+
     @pytest.mark.TRACEABILITY_MATRIX
     @testutil.update_traceability_matrix(["DNA_CLI_DATA_OBJ_ADD_TYPES", "DNA_CLI_DATA_OBJ_REMOVE_TYPES"])
     def test_dx_add_rm_types(self):


### PR DESCRIPTION
Fixing a python3 issue, where the command line parser behaves a little bit differently when there is a missing argument.