### PR TITLE
DEVEX-1036 Add support for --ignore-reuse and --ignore-reuse-stage flags for workflows

### DIFF
--- a/src/python/dxpy/bindings/dxapp.py
+++ b/src/python/dxpy/bindings/dxapp.py
@@ -363,7 +363,6 @@ class DXApp(DXObject, DXExecutable):
                                           **kwargs)["id"])
 
     def _get_run_input(self, executable_input, **kwargs):
-        # May need to be changed when workflow apps are enabled
         return DXExecutable._get_run_input_fields_for_applet(executable_input, **kwargs)
 
     def _get_required_keys(self):

--- a/src/python/dxpy/bindings/dxapplet.py
+++ b/src/python/dxpy/bindings/dxapplet.py
@@ -82,6 +82,9 @@ class DXExecutable:
         if kwargs.get('debug') is not None:
             run_input["debug"] = kwargs['debug']
 
+        if kwargs.get('ignore_reuse') is not None:
+            run_input["ignoreReuse"] = kwargs['ignore_reuse']
+
         if kwargs.get('priority') is not None:
             run_input["priority"] = kwargs['priority']
 
@@ -105,13 +108,7 @@ class DXExecutable:
             if kwargs.get(unsupported_arg):
                 raise DXError(unsupported_arg + ' is not supported for applets (only workflows)')
 
-        applet_input_hash = DXExecutable._get_run_input_common_fields(executable_input, **kwargs)
-
-        # Add arguments which are specific to app(let)s but not to workflows
-        # so they are not included in DXExecutable._get_run_input_common_fields()
-        if kwargs.get('ignore_reuse') is not None:
-            applet_input_hash["ignoreReuse"] = kwargs['ignore_reuse']
-        return applet_input_hash
+        return DXExecutable._get_run_input_common_fields(executable_input, **kwargs)
 
     def _run_impl(self, run_input, **kwargs):
         """

--- a/src/python/dxpy/bindings/dxapplet.py
+++ b/src/python/dxpy/bindings/dxapplet.py
@@ -46,7 +46,7 @@ class DXExecutable:
         '''
         Takes the same arguments as the run method. Creates an input hash for the /executable-xxxx/run method,
         translating ONLY the fields that can be handled uniformly across all executables: project, folder, name, tags,
-        properties, details, depends_on, allow_ssh, debug, delay_workspace_destruction, and extra_args.
+        properties, details, depends_on, allow_ssh, debug, delay_workspace_destruction, ignore_reuse, and extra_args.
         '''
         project = kwargs.get('project') or dxpy.WORKSPACE_ID
 
@@ -82,11 +82,11 @@ class DXExecutable:
         if kwargs.get('debug') is not None:
             run_input["debug"] = kwargs['debug']
 
-        if kwargs.get('ignore_reuse') is not None:
-            run_input["ignoreReuse"] = kwargs['ignore_reuse']
-
         if kwargs.get('priority') is not None:
             run_input["priority"] = kwargs['priority']
+
+        if kwargs.get('ignore_reuse') is not None:
+            run_input["ignoreReuse"] = kwargs['ignore_reuse']
 
         if dxpy.JOB_ID is None:
             run_input["project"] = project

--- a/src/python/dxpy/bindings/dxworkflow.py
+++ b/src/python/dxpy/bindings/dxworkflow.py
@@ -486,6 +486,11 @@ class DXWorkflow(DXDataObject, DXExecutable):
                 for _stage in kwargs['rerun_stages']
             ]
 
+        if kwargs.get('ignore_reuse', False):
+            run_input['ignoreReuse'] = ['*']
+            #TODO: this needs to be temporarily added to prevent using caching on the server side
+            run_input['rerunStages'] = ['*']
+
         if kwargs.get('ignore_reuse_stages') is not None:
             run_input['ignoreReuse'] = [
                 _stage if _stage == '*' else self._get_stage_id(_stage)

--- a/src/python/dxpy/bindings/dxworkflow.py
+++ b/src/python/dxpy/bindings/dxworkflow.py
@@ -189,7 +189,7 @@ class DXWorkflow(DXDataObject, DXExecutable):
         # A stage with the provided ID can't be found in the workflow, so look for it as a name
         stage_ids_matching_name = [stg['id'] for stg in self.stages if stg.get('name') == stage]
         if len(stage_ids_matching_name) == 0:
-            raise DXError('DXWorkflow: the given stage identifier ' + stage + ' could not be found as a stage ID nor as a stage name ' + str(self.stages))
+            raise DXError('DXWorkflow: the given stage identifier ' + stage + ' could not be found as a stage ID nor as a stage name')
         elif len(stage_ids_matching_name) > 1:
             raise DXError('DXWorkflow: more than one workflow stage was found to have the name "' + stage + '"')
         else:
@@ -488,8 +488,6 @@ class DXWorkflow(DXDataObject, DXExecutable):
 
         if kwargs.get('ignore_reuse', False):
             run_input['ignoreReuse'] = ['*']
-            #TODO: this needs to be temporarily added to prevent using caching on the server side
-            run_input['rerunStages'] = ['*']
 
         if kwargs.get('ignore_reuse_stages') is not None:
             run_input['ignoreReuse'] = [

--- a/src/python/dxpy/bindings/dxworkflow.py
+++ b/src/python/dxpy/bindings/dxworkflow.py
@@ -189,7 +189,7 @@ class DXWorkflow(DXDataObject, DXExecutable):
         # A stage with the provided ID can't be found in the workflow, so look for it as a name
         stage_ids_matching_name = [stg['id'] for stg in self.stages if stg.get('name') == stage]
         if len(stage_ids_matching_name) == 0:
-            raise DXError('DXWorkflow: the given stage identifier could not be found as a stage ID nor as a stage name')
+            raise DXError('DXWorkflow: the given stage identifier ' + stage + ' could not be found as a stage ID nor as a stage name ' + str(self.stages))
         elif len(stage_ids_matching_name) > 1:
             raise DXError('DXWorkflow: more than one workflow stage was found to have the name "' + stage + '"')
         else:
@@ -486,6 +486,12 @@ class DXWorkflow(DXDataObject, DXExecutable):
                 for _stage in kwargs['rerun_stages']
             ]
 
+        if kwargs.get('ignore_reuse_stages') is not None:
+            run_input['ignoreReuse'] = [
+                _stage if _stage == '*' else self._get_stage_id(_stage)
+                for _stage in kwargs['ignore_reuse_stages']
+            ]
+
         return run_input
 
     def _run_impl(self, run_input, **kwargs):
@@ -503,6 +509,8 @@ class DXWorkflow(DXDataObject, DXExecutable):
         :type stage_folders: dict
         :param rerun_stages: A list of stage IDs, names, indices, and/or the string "*" to indicate which stages should be run even if there are cached executions available
         :type rerun_stages: list of strings
+        :param ignore_reuse_stages: Stages of a workflow (IDs, names, or indices) or "*" for which job reuse should be disabled
+        :type ignore_reuse_stages: list
         :returns: Object handler of the newly created analysis
         :rtype: :class:`~dxpy.bindings.dxanalysis.DXAnalysis`
 

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -4740,11 +4740,6 @@ parser_run.add_argument('--stage-relative-output-folder', metavar=('STAGE_ID', '
                         nargs=2,
                         action='append',
                         default=[])
-parser_run.add_argument('--rerun-stage', metavar='STAGE_ID', dest='rerun_stages',
-                        help=fill('A stage (using its ID, name, or index) to rerun, or "*" to ' +
-                                  'indicate all stages should be rerun; repeat as necessary',
-                                  width_adjustment=-24),
-                        action='append')
 parser_run.add_argument('--name', help=fill('Name for the job (default is the app or applet name)', width_adjustment=-24))
 parser_run.add_argument('--delay-workspace-destruction',
                         help=fill('Whether to keep the job\'s temporary workspace around for debugging purposes for 3 days after it succeeds or fails', width_adjustment=-24),
@@ -4778,11 +4773,15 @@ ignore_reuse.add_argument('--ignore-reuse',
                                   width_adjustment=-24),
                         action='store_true')
 ignore_reuse.add_argument('--ignore-reuse-stage', metavar='STAGE_ID', dest='ignore_reuse_stages',
-                        help=fill('A stage (using its ID, name, or index) for which job reuse should be ignored, ' +
-                                  'or "*" to indicate the job reuse for all stages should be ignored; if a stage points ' +
-                                  'to another (nested) workflow the ignore reuse option will be applied to the whole subworkflow. ' +
+                        help=fill('A stage (using its ID, name, or index) for which job reuse should be disabled, ' +
+                                  'if a stage points to another (nested) workflow the ignore reuse option will be applied to the whole subworkflow. ' +
                                   'This option overwrites any ignoreReuse fields set on app(let)s or the workflow during build time; ' +
                                   'repeat as necessary',
+                                  width_adjustment=-24),
+                        action='append')
+ignore_reuse.add_argument('--rerun-stage', metavar='STAGE_ID', dest='rerun_stages',
+                        help=fill('A stage (using its ID, name, or index) to rerun, or "*" to ' +
+                                  'indicate all stages should be rerun; repeat as necessary',
                                   width_adjustment=-24),
                         action='append')
 parser_run.add_argument('--batch-tsv', dest='batch_tsv', metavar="FILE",

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -3334,10 +3334,12 @@ def run(args):
         err_exit(exception=DXCLIError(
             "Option --ignore-reuse cannot be used when running workflows. Use ignore-reuse-stage instead"
         ))
-    if args.ignore_reuse_stages and args.rerun_stages:
-        err_exit(exception=DXCLIError(
-            "Options --ignore-reuse-stage and --rerun-stage cannot be specified together. --ignore-reuse-stage is preferred"
-        ))
+    # if rerun-stages is not used, the cached executions on the
+    # server side will be used and the reuse will not be ignored
+    # if args.ignore_reuse_stages and args.rerun_stages:
+    #     err_exit(exception=DXCLIError(
+    #         "Options --ignore-reuse-stage and --rerun-stage cannot be specified together. --ignore-reuse-stage is preferred"
+    #     ))
 
     run_body(args, handler, dest_proj, dest_path)
 

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -3332,11 +3332,11 @@ def run(args):
 
     if args.ignore_reuse and (is_workflow or is_global_workflow):
         err_exit(exception=DXCLIError(
-            "Option --ignore-reuse cannot be used when running workflows. Please, use ignore-reuse-stage"
+            "Option --ignore-reuse cannot be used when running workflows. Use ignore-reuse-stage instead"
         ))
     if args.ignore_reuse_stages and args.rerun_stages:
         err_exit(exception=DXCLIError(
-            "Options --ignore-reuse-stage and --rerun-stage cannot be specified together.\n--ignore-reuse-stages is preferred"
+            "Options --ignore-reuse-stage and --rerun-stage cannot be specified together. --ignore-reuse-stage is preferred"
         ))
 
     run_body(args, handler, dest_proj, dest_path)
@@ -4787,7 +4787,8 @@ parser_run.add_argument('--ignore-reuse',
 parser_run.add_argument('--ignore-reuse-stage', metavar='STAGE_ID', dest='ignore_reuse_stages',
                         help=fill('A stage (using its ID, name, or index) for which job reuse should be ignored, ' +
                                   'or "*" to indicate the job reuse for all stages should be ignored; if a stage points ' +
-                                  'to another workflow the ignore reuse option will be applied to the whole subworkflow; ' +
+                                  'to another (nested) workflow the ignore reuse option will be applied to the whole subworkflow. ' +
+                                  'This option overwrites any ignoreReuse fields set on app(let)s or the workflow during build time; ' +
                                   'repeat as necessary',
                                   width_adjustment=-24),
                         action='append')

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -3334,7 +3334,7 @@ def run(args):
         err_exit(exception=DXCLIError(
             "Option --ignore-reuse cannot be used when running workflows. Use ignore-reuse-stage instead"
         ))
-    # if rerun-stages is not used, the cached executions on the
+    # if rerun-stages "*" is not used, the cached executions on the
     # server side will be used and the reuse will not be ignored
     # if args.ignore_reuse_stages and args.rerun_stages:
     #     err_exit(exception=DXCLIError(

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -2897,6 +2897,7 @@ def run_body(args, executable, dest_proj, dest_path, preset_inputs=None, input_n
         "depends_on": args.depends_on or None,
         "allow_ssh": args.allow_ssh,
         "ignore_reuse": args.ignore_reuse or None,
+        "ignore_reuse_stages": args.ignore_reuse_stages or None,
         "debug": {"debugOn": args.debug_on} if args.debug_on else None,
         "delay_workspace_destruction": args.delay_workspace_destruction,
         "priority": ("high" if args.watch else args.priority),
@@ -3328,6 +3329,16 @@ def run(args):
             dest_path = dxpy.config.get('DX_CLI_WD', '/')
 
     process_instance_type_arg(args, is_workflow or is_global_workflow)
+
+    if args.ignore_reuse and (is_workflow or is_global_workflow):
+        err_exit(exception=DXCLIError(
+            "Option --ignore-reuse cannot be used when running workflows. Please, use ignore-reuse-stage"
+        ))
+    if args.ignore_reuse_stages and args.rerun_stages:
+        err_exit(exception=DXCLIError(
+            "Options --ignore-reuse-stage and --rerun-stage cannot be specified together.\n--ignore-reuse-stages is preferred"
+        ))
+
     run_body(args, handler, dest_proj, dest_path)
 
 def terminate(args):
@@ -4773,6 +4784,13 @@ parser_run.add_argument('--ignore-reuse',
                         help=fill("Disable job reuse for execution",
                                   width_adjustment=-24),
                         action='store_true')
+parser_run.add_argument('--ignore-reuse-stage', metavar='STAGE_ID', dest='ignore_reuse_stages',
+                        help=fill('A stage (using its ID, name, or index) for which job reuse should be ignored, ' +
+                                  'or "*" to indicate the job reuse for all stages should be ignored; if a stage points ' +
+                                  'to another workflow the ignore reuse option will be applied to the whole subworkflow; ' +
+                                  'repeat as necessary',
+                                  width_adjustment=-24),
+                        action='append')
 parser_run.add_argument('--batch-tsv', dest='batch_tsv', metavar="FILE",
                         help=fill('A file in tab separated value (tsv) format, with a subset ' +
                                   'of the executable input arguments. A job will be launched ' +

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -4779,7 +4779,7 @@ ignore_reuse.add_argument('--ignore-reuse-stage', metavar='STAGE_ID', dest='igno
                                   'repeat as necessary',
                                   width_adjustment=-24),
                         action='append')
-ignore_reuse.add_argument('--rerun-stage', metavar='STAGE_ID', dest='rerun_stages',
+parser_run.add_argument('--rerun-stage', metavar='STAGE_ID', dest='rerun_stages',
                         help=fill('A stage (using its ID, name, or index) to rerun, or "*" to ' +
                                   'indicate all stages should be rerun; repeat as necessary',
                                   width_adjustment=-24),

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -3330,17 +3330,6 @@ def run(args):
 
     process_instance_type_arg(args, is_workflow or is_global_workflow)
 
-    if args.ignore_reuse and (is_workflow or is_global_workflow):
-        err_exit(exception=DXCLIError(
-            "Option --ignore-reuse cannot be used when running workflows. Use ignore-reuse-stage instead"
-        ))
-    # if rerun-stages "*" is not used, the cached executions on the
-    # server side will be used and the reuse will not be ignored
-    # if args.ignore_reuse_stages and args.rerun_stages:
-    #     err_exit(exception=DXCLIError(
-    #         "Options --ignore-reuse-stage and --rerun-stage cannot be specified together. --ignore-reuse-stage is preferred"
-    #     ))
-
     run_body(args, handler, dest_proj, dest_path)
 
 def terminate(args):
@@ -4782,11 +4771,13 @@ parser_run.add_argument('--ssh-proxy', metavar=('<address>:<port>'),
 parser_run.add_argument('--debug-on', action='append', choices=['AppError', 'AppInternalError', 'ExecutionError', 'All'],
                         help=fill("Configure the job to hold for debugging when any of the listed errors occur",
                                   width_adjustment=-24))
-parser_run.add_argument('--ignore-reuse',
+
+ignore_reuse = parser_run.add_mutually_exclusive_group()
+ignore_reuse.add_argument('--ignore-reuse',
                         help=fill("Disable job reuse for execution",
                                   width_adjustment=-24),
                         action='store_true')
-parser_run.add_argument('--ignore-reuse-stage', metavar='STAGE_ID', dest='ignore_reuse_stages',
+ignore_reuse.add_argument('--ignore-reuse-stage', metavar='STAGE_ID', dest='ignore_reuse_stages',
                         help=fill('A stage (using its ID, name, or index) for which job reuse should be ignored, ' +
                                   'or "*" to indicate the job reuse for all stages should be ignored; if a stage points ' +
                                   'to another (nested) workflow the ignore reuse option will be applied to the whole subworkflow. ' +

--- a/src/python/test/dxpy_testutil.py
+++ b/src/python/test/dxpy_testutil.py
@@ -500,8 +500,8 @@ class DXTestCaseBuildWorkflows(DXTestCase):
             readme_file.write(readme_content)
         return os.path.join(self.temp_file_path, workflow_name)
 
-    def create_applet(self, project_id):
-        return dxpy.api.applet_new({"name": "my_first_applet",
+    def create_applet_spec(self, project_id):
+        return {"name": "my_first_applet",
                                     "project": project_id,
                                     "dxapi": "1.0.0",
                                     "inputSpec": [{"name": "number", "class": "int"}],
@@ -510,7 +510,10 @@ class DXTestCaseBuildWorkflows(DXTestCase):
                                                 "distribution": "Ubuntu",
                                                 "release": "14.04",
                                                 "code": "exit 0"}
-                                   })['id']
+                                   }
+
+    def create_applet(self, project_id):
+        return dxpy.api.applet_new(self.create_applet_spec(project_id))['id']
 
     def create_workflow_spec(self, project_id):
         workflow_spec = {"name": "my_workflow",

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -4057,6 +4057,8 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
         workflow_desc = dxpy.get_handler(workflow_id).describe()
         self.assertEqual(workflow_desc['ignoreReuse'], ["stage_0"])
 
+    @unittest.skipUnless(testutil.TEST_RUN_JOBS,
+                         "skipping test that would run jobs")
     def test_run_workflow_with_ignore_reuse(self):
         # Build the workflow (ignoreReuse is set on applet document)
         workflow_name = 'workflow_run_ignore_reuse'

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -4091,6 +4091,14 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
         analysis_desc = dxpy.describe(analysis_id)
         self.assertEqual(analysis_desc.get('ignoreReuse'), ["*"])
 
+        # Run the workflow with ignore-reuse
+        analysis_id = run('dx run ' + workflow_id + ' --ignore-reuse -y --brief').strip()
+        analysis_desc = dxpy.describe(analysis_id)
+        self.assertEqual(analysis_desc.get('ignoreReuse'), ["*"])
+
+        with self.assertSubprocessFailure(stderr_regexp='not allowed with argument', exit_code=2):
+            run('dx run ' + workflow_id + ' --ignore-reuse --ignore-reuse-stage "*" -y --brief').strip()
+
     def test_dx_build_get_build_workflow(self):
         # When building and getting a workflow multiple times we should
         # obtain functionally identical workflows, ie. identical dxworkflow.json specs.

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -4080,6 +4080,12 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
         analysis_desc = dxpy.describe(analysis_id)
         self.assertEqual(analysis_desc.get('ignoreReuse'), ["stage_1"])
 
+        # Run the workflow with multiple ignore-reuse-stage
+        analysis_id = run('dx run ' + workflow_id + ' --ignore-reuse-stage stage_0 --ignore-reuse-stage stage_1 -y --brief').strip()
+        analysis_desc = dxpy.describe(analysis_id)
+        self.assertIn("stage_0", analysis_desc.get('ignoreReuse'))
+        self.assertIn("stage_1", analysis_desc.get('ignoreReuse'))
+
         # Run the workflow with ignore-reuse-stage wildcard
         analysis_id = run('dx run ' + workflow_id + ' --ignore-reuse-stage "*" -y --brief').strip()
         analysis_desc = dxpy.describe(analysis_id)

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -4086,11 +4086,6 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
         self.assertIn("stage_0", analysis_desc.get('ignoreReuse'))
         self.assertIn("stage_1", analysis_desc.get('ignoreReuse'))
 
-        # Run the workflow with ignore-reuse-stage wildcard
-        analysis_id = run('dx run ' + workflow_id + ' --ignore-reuse-stage "*" -y --brief').strip()
-        analysis_desc = dxpy.describe(analysis_id)
-        self.assertEqual(analysis_desc.get('ignoreReuse'), ["*"])
-
         # Run the workflow with ignore-reuse
         analysis_id = run('dx run ' + workflow_id + ' --ignore-reuse -y --brief').strip()
         analysis_desc = dxpy.describe(analysis_id)

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -4072,24 +4072,18 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
 
         # Run the workflow without ignore-reuse-stage
         analysis_id = run("dx run " + workflow_id + " -y --brief").strip()
-        analysis_desc = json.loads(run("dx describe --json " + analysis_id))
+        analysis_desc = dxpy.describe(analysis_id)
         self.assertIsNone(analysis_desc.get('ignoreReuse'))
 
-        analysis_desc = json.loads(run("dx describe " + analysis_id + " --json"))
-        time.sleep(2) # May need to wait for job to be created in the system
-        job_desc = json.loads(run("dx describe --json " + analysis_desc["stages"][0]["execution"]["id"]))
-        self.assertEqual(job_desc.get('ignoreReuse'), True)
-        job_desc = json.loads(run("dx describe --json " + analysis_desc["stages"][1]["execution"]["id"]))
-        self.assertEqual(job_desc.get('ignoreReuse'), False)
-
         # Run the workflow with ignore-reuse-stage
-        analysis_id = run('dx run ' + workflow_id + ' --ignore-reuse-stage stage_0 --ignore-reuse-stage stage_1 -y --brief').strip()
-        analysis_desc = json.loads(run("dx describe --json " + analysis_id))
-        self.assertEqual(analysis_desc.get('ignoreReuse'), ["stage_0", "stage_1"])
-        # analysis_desc = json.loads(run("dx describe " + analysis_id + " --json"))
-        # time.sleep(2) # May need to wait for job to be created in the system
-        # job_desc = json.loads(run("dx describe --json " + analysis_desc["stages"][0]["execution"]["id"]))
-        # self.assertEqual(job_desc.get('ignoreReuse'), True)
+        analysis_id = run('dx run ' + workflow_id + ' --ignore-reuse-stage stage_1 -y --brief').strip()
+        analysis_desc = dxpy.describe(analysis_id)
+        self.assertEqual(analysis_desc.get('ignoreReuse'), ["stage_1"])
+
+        # Run the workflow with ignore-reuse-stage wildcard
+        analysis_id = run('dx run ' + workflow_id + ' --ignore-reuse-stage "*" -y --brief').strip()
+        analysis_desc = dxpy.describe(analysis_id)
+        self.assertEqual(analysis_desc.get('ignoreReuse'), ["*"])
 
     def test_dx_build_get_build_workflow(self):
         # When building and getting a workflow multiple times we should


### PR DESCRIPTION
This commit adds an ignoreReuse option for building and running workflows. 

I looked into the posssibility of reusing "--ignore-reuse" (that we have for apps now) but couldn't really use it without breaking customers' runs. There is an open [issue](https://bugs.python.org/issue9338) with using nargs (argparse optionals with nargs='?', '*' or '+' can't be followed by positionals) which means we cannot use one param that accepts 0 or more arguments.

If you had any other ideas on how we could do that I'd be happy to change it - thanks!





