### PR TITLE
DEVEX-1038 Fix missing argument test

### DIFF
--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -342,8 +342,7 @@ class TestDXClient(DXTestCase):
                 run(("dx uninvite "+query).format(p=self.project))
 
     def test_dx_add_missing_arguments(self):
-        with self.assertSubprocessFailure(stderr_text = "missing argument",
-                                          exit_code=3):
+        with self.assertSubprocessFailure():
             run("dx add")
 
     @pytest.mark.TRACEABILITY_MATRIX

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -342,7 +342,7 @@ class TestDXClient(DXTestCase):
                 run(("dx uninvite "+query).format(p=self.project))
 
     def test_dx_add_missing_arguments(self):
-        with self.assertSubprocessFailure():
+        with self.assertSubprocessFailure(exit_code=2):
             run("dx add")
 
     @pytest.mark.TRACEABILITY_MATRIX


### PR DESCRIPTION
The tests were failing due to exit code and error message mismatch, the expected ones are:

```
commandlinegirl@osboxes:~/repos/dx-toolkit$ dx add
usage: dx add [-h] list_type ...

(...)

dx add: error: too few arguments
commandlinegirl@osboxes:~/repos/dx-toolkit$ echo $?
2
```

