### PR TITLE
DEVEX-941 session collision

### DIFF
--- a/src/python/dxpy/__init__.py
+++ b/src/python/dxpy/__init__.py
@@ -1030,14 +1030,6 @@ def append_underlying_workflow_describe(globalworkflow_desc):
 from .utils.config import DXConfig as _DXConfig
 config = _DXConfig()
 
-# This has the side effect of creating a new session directory in:
-#   ~/.dnanexus_config/sessions/<PID>
-# This ensures this session has a separate and distinct set of environment
-# variables. Otherwise, the variables are shared with the parent process.
-#
-# While you are at it, cleanup any old sessions, belonging to dead processes.
-config.save()
-
 from .bindings import *
 from .dxlog import DXLogHandler
 from .utils.exec_utils import run, entry_point

--- a/src/python/dxpy/__init__.py
+++ b/src/python/dxpy/__init__.py
@@ -1036,7 +1036,7 @@ config = _DXConfig()
 # variables. Otherwise, the variables are shared with the parent process.
 #
 # While you are at it, cleanup any old sessions, belonging to dead processes.
-config.save(True)
+config.save()
 
 from .bindings import *
 from .dxlog import DXLogHandler

--- a/src/python/dxpy/__init__.py
+++ b/src/python/dxpy/__init__.py
@@ -1029,6 +1029,12 @@ def append_underlying_workflow_describe(globalworkflow_desc):
 from .utils.config import DXConfig as _DXConfig
 config = _DXConfig()
 
+# This has the side effect of creating a new session directory in:
+#   ~/.dnanexus_config/sessions/<PID>
+# This ensures this session has a separate and distinct set of environment
+# variables. Otherwise, the variables are shared with the parent process.
+config.save()
+
 from .bindings import *
 from .dxlog import DXLogHandler
 from .utils.exec_utils import run, entry_point

--- a/src/python/dxpy/__init__.py
+++ b/src/python/dxpy/__init__.py
@@ -1026,6 +1026,7 @@ def append_underlying_workflow_describe(globalworkflow_desc):
     return globalworkflow_desc
 
 
+# Create a configuration structure
 from .utils.config import DXConfig as _DXConfig
 config = _DXConfig()
 
@@ -1033,7 +1034,9 @@ config = _DXConfig()
 #   ~/.dnanexus_config/sessions/<PID>
 # This ensures this session has a separate and distinct set of environment
 # variables. Otherwise, the variables are shared with the parent process.
-config.save()
+#
+# While you are at it, cleanup any old sessions, belonging to dead processes.
+config.save(True)
 
 from .bindings import *
 from .dxlog import DXLogHandler

--- a/src/python/dxpy/utils/config.py
+++ b/src/python/dxpy/utils/config.py
@@ -138,7 +138,7 @@ class DXConfig(MutableMapping):
         # create a fresh directory to store session state
         self._session_dir = self._get_ppid_session_conf_dir()
         self._sync_dxpy_state()
-        self.save()
+        self._write_conf_dir(self._session_dir)
 
     def _sync_dxpy_state(self):
         dxpy.set_api_server_info(host=environ.get("DX_APISERVER_HOST", None),

--- a/src/python/dxpy/utils/config.py
+++ b/src/python/dxpy/utils/config.py
@@ -271,9 +271,9 @@ class DXConfig(MutableMapping):
         self[item] = value
         self.save()
 
-    def save(self):
+    def save(self, cleanup=False):
         self._write_conf_dir(self._user_conf_dir)
-        self._write_conf_dir(self.get_session_conf_dir())
+        self._write_conf_dir(self.get_session_conf_dir(cleanup))
         self._write_unsetenv(self._user_conf_dir)
 
     def _write_unsetenv(self, conf_dir):

--- a/src/python/dxpy/utils/config.py
+++ b/src/python/dxpy/utils/config.py
@@ -271,9 +271,9 @@ class DXConfig(MutableMapping):
         self[item] = value
         self.save()
 
-    def save(self, cleanup=False):
+    def save(self):
         self._write_conf_dir(self._user_conf_dir)
-        self._write_conf_dir(self.get_session_conf_dir(cleanup))
+        self._write_conf_dir(self.get_session_conf_dir())
         self._write_unsetenv(self._user_conf_dir)
 
     def _write_unsetenv(self, conf_dir):

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -702,31 +702,31 @@ class TestDXClient(DXTestCase):
 
 
     def test_dxpy_session_isolation(self):
-        print("test_dxpy_session_isolation  project={}".format(self.project))
-
         def create_shell():
             child = pexpect.spawn("bash", **spawn_extra_args)
             child.setwinsize(20, 90)
             child.logfile = sys.stdout
             return child
 
-        def expect_dx_wd(shell, wd):
+        def expect_dx_wd(shell, proj_name, wd):
             shell.sendline("dx pwd")
-            shell.expect(self.project + ":/" + wd)
+            shell.expect(proj_name + ":/" + wd, timeout=5.0)
 
-        shell1 = create_shell()
-        shell1.sendline("dx select " + self.project)
-        shell1.sendline("dx mkdir /A")
-        shell1.sendline("dx cd /A")
-        expect_dx_wd(shell1, "A")
+        proj_name = 'test_proj1'
+        with temporary_project(proj_name, select=True) as proj:
+            shell1 = create_shell()
+            shell1.sendline("dx select " + proj_name)
+            shell1.sendline("dx mkdir /A")
+            shell1.sendline("dx cd /A")
+            expect_dx_wd(shell1, proj_name, "A")
 
-        shell2 = create_shell()
+            shell2 = create_shell()
 
-        shell1.sendline("dx mkdir /B")
-        shell1.sendline("dx cd /B")
+            shell1.sendline("dx mkdir /B")
+            shell1.sendline("dx cd /B")
 
-        expect_dx_wd(shell1, "B")
-        expect_dx_wd(shell2, "A")
+            expect_dx_wd(shell1, proj_name, "B")
+            expect_dx_wd(shell2, proj_name, "A")
 
     @unittest.skip('PTFM-16383 Disable flaky test')
     def test_dxpy_session_isolation_grandchildren(self):


### PR DESCRIPTION
Removing sharing between dx sessions, as this sharing includes mutable variables. Each session starts by making a fresh directory in `~/.dnanexus_config/sessions/<PID>` and stores its state there. 
