### PR TITLE
Resolve project names in dx run --project flag

### DIFF
--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -3082,7 +3082,7 @@ def run(args):
             err_exit(exception=DXCLIError(
                 "Options --project and --folder/--destination cannot be specified together.\nIf specifying both a project and a folder, please include them in the --folder option."
             ))
-        dest_proj = args.project
+        dest_proj = resolve_container_id_or_name(args.project, is_error=True, multi=False)
 
     if args.folder is not None:
         dest_proj, dest_path, _none = try_call(resolve_existing_path,

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -3327,6 +3327,22 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
             run("dx run " + workflow_id + " -istage_0.number=32")
 
     @unittest.skipUnless(testutil.TEST_RUN_JOBS, 'skipping test that runs jobs')
+    def test_dx_run_specific_project(self):
+        dxpy.api.applet_new({
+            "project": self.project,
+            "name": "myapplet",
+            "dxapi": "1.0.0",
+            "inputSpec": [{"name": "number", "class": "int"}],
+            "outputSpec": [{"name": "number", "class": "int"}],
+            "runSpec": {"interpreter": "bash",
+                        "distribution": "Ubuntu",
+                        "release": "14.04",
+                        "code": "dx-jobutil-add-output number 32"}
+        })
+        project_name = dxpy.DXProject(self.project).name
+        run("dx run myapplet -inumber=5 --project %s" % project_name)
+
+    @unittest.skipUnless(testutil.TEST_RUN_JOBS, 'skipping test that runs jobs')
     def test_dx_run_clone_analysis(self):
         dxpy.api.applet_new({
             "project": self.project,


### PR DESCRIPTION
I think this should fix this error that some users have seen by resolving project names with dx run.

```
dx run myapp -iflowcell_barcode=abc --project mytestproject -y

InvalidInput: Expected key "project" of input to be a valid DNAnexus container ID, code 422. Request Time=1550725555.61, Request ID=1550725555642-54230
```

cc @yingw 
