### PR TITLE
Fix test by creating a separate temporary project

### DIFF
--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -3327,22 +3327,6 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
             run("dx run " + workflow_id + " -istage_0.number=32")
 
     @unittest.skipUnless(testutil.TEST_RUN_JOBS, 'skipping test that runs jobs')
-    def test_dx_run_specific_project(self):
-        dxpy.api.applet_new({
-            "project": self.project,
-            "name": "myapplet",
-            "dxapi": "1.0.0",
-            "inputSpec": [{"name": "number", "class": "int"}],
-            "outputSpec": [{"name": "number", "class": "int"}],
-            "runSpec": {"interpreter": "bash",
-                        "distribution": "Ubuntu",
-                        "release": "14.04",
-                        "code": "dx-jobutil-add-output number 32"}
-        })
-        project_name = dxpy.DXProject(self.project).name
-        run("dx run myapplet -inumber=5 --project %s" % project_name)
-
-    @unittest.skipUnless(testutil.TEST_RUN_JOBS, 'skipping test that runs jobs')
     def test_dx_run_clone_analysis(self):
         dxpy.api.applet_new({
             "project": self.project,
@@ -10189,6 +10173,21 @@ class TestDXRun(DXTestCase):
         app_name = "app-dnanexus_smoke_test"
         run("dx run {} -isubjobs=1 --yes --wait --watch".format(app_name))
 
+    @unittest.skipUnless(testutil.TEST_RUN_JOBS, 'skipping test that runs jobs')
+    def test_dx_run_specific_project(self):
+        with temporary_project('tmp_project_for_run', select=True) as temp_project:
+            dxpy.api.applet_new({
+                "project": temp_project.get_id(),
+                "name": "myapplet",
+                "dxapi": "1.0.0",
+                "inputSpec": [{"name": "number", "class": "int"}],
+                "outputSpec": [{"name": "number", "class": "int"}],
+                "runSpec": {"interpreter": "bash",
+                            "distribution": "Ubuntu",
+                            "release": "16.04",
+                            "code": "dx-jobutil-add-output number 32"}
+            })
+            run("dx run myapplet -inumber=5 --project %s" % temp_project.name)
 
 class TestDXUpdateApp(DXTestCaseBuildApps):
     @unittest.skipUnless(testutil.TEST_ISOLATED_ENV,


### PR DESCRIPTION
When running the whole test suite the new test `test_dx_run_specific_project`
was breaking due to project name conflicts:

```
ResolutionError: Found multiple projects with name "dxclient_test_pr\xf6ject";
please use a project ID to specify the desired project
```

Fixed it and also moved it to the TestDXRun() class.
