### PR TITLE
Skip symlinks test in isolated environment

### DIFF
--- a/src/python/test/test_dx_symlink.py
+++ b/src/python/test/test_dx_symlink.py
@@ -122,6 +122,7 @@ class TestSymlink(unittest.TestCase):
         return dxpy.DXFile(dxid = result["id"],
                            project = self.proj_id)
 
+    @unittest.skipIf(testutil.TEST_ISOLATED_ENV, 'skipping test that fails inside local environment')
     def test_symlinks(self):
         dxfile1 = self.download_url_create_symlink("https://s3.amazonaws.com/1000genomes/CHANGELOG",
                                                    "sym1")

--- a/src/python/test/test_dx_symlink.py
+++ b/src/python/test/test_dx_symlink.py
@@ -29,7 +29,7 @@ import unittest
 import dxpy
 from dxpy.exceptions import err_exit
 from dxpy.utils import describe
-from dxpy_testutil import (chdir, run)
+from dxpy_testutil import (chdir, run, TEST_ISOLATED_ENV)
 
 def setUpTempProject(thing):
     thing.old_workspace_id = dxpy.WORKSPACE_ID
@@ -122,7 +122,7 @@ class TestSymlink(unittest.TestCase):
         return dxpy.DXFile(dxid = result["id"],
                            project = self.proj_id)
 
-    @unittest.skipIf(testutil.TEST_ISOLATED_ENV, 'skipping test that fails inside local environment')
+    @unittest.skipIf(TEST_ISOLATED_ENV, 'skipping test that fails inside local environment')
     def test_symlinks(self):
         dxfile1 = self.download_url_create_symlink("https://s3.amazonaws.com/1000genomes/CHANGELOG",
                                                    "sym1")


### PR DESCRIPTION
Skip `test_symlinks` in isolated environment. Failing the jenkins integration test.