### PR TITLE
Change download to skip folder if unnecessary

### DIFF
--- a/src/python/dxpy/cli/download.py
+++ b/src/python/dxpy/cli/download.py
@@ -169,7 +169,7 @@ def download(args):
 
         matching_folders = []
         # project may be none if path is an ID and there is no project context
-        if project is not None:
+        if project is not None and folderpath is not None:
             colon_pos = get_first_pos_of_char(":", path)
             if colon_pos >= 0:
                 path = path[colon_pos + 1:]


### PR DESCRIPTION
We would originally always do a check on subfolders for all paths passed in to download. This skips that check if we do not believe we are attempting to download a folder.