### PR TITLE
SCI-1323, SCI-1324: Add sugar transfer and processing modules

### DIFF
--- a/src/python/dxpy/compat.py
+++ b/src/python/dxpy/compat.py
@@ -32,8 +32,10 @@ _stdio_wrapped = False
 
 if USING_PYTHON2:
     from cStringIO import StringIO
+    import errno
     from httplib import BadStatusLine
     from repr import Repr
+    import pipes
     BytesIO = StringIO
     builtin_str = str
     bytes = str
@@ -42,6 +44,7 @@ if USING_PYTHON2:
     builtin_int = int
     int = long
     open = io.open
+    quote = pipes.quote
     THREAD_TIMEOUT_MAX = sys.maxint
     def input(prompt=None):
         encoded_prompt = prompt.encode(sys_encoding)
@@ -73,6 +76,14 @@ if USING_PYTHON2:
             userhome = pwent.pw_dir
         userhome = userhome.rstrip('/')
         return (userhome + path[i:]) or '/'
+    def makedirs(path, mode=0o777, exist_ok=False):
+        try:
+            os.makedirs(path, mode)
+        except OSError as exc:  # Python >2.5
+            if exist_ok and exc.errno == errno.EEXIST and os.path.isdir(path):
+                pass
+            else:
+                raise
     if os.name == 'nt':
         # The POSIX os.path.expanduser doesn't work on NT, so just leave it be
         expanduser = os.path.expanduser
@@ -94,6 +105,8 @@ else:
     builtin_int = int
     int = int
     open = open
+    quote = shlex.quote
+    makedirs = os.makedirs
     expanduser = os.path.expanduser
     THREAD_TIMEOUT_MAX = threading.TIMEOUT_MAX
 

--- a/src/python/dxpy/sugar/__init__.py
+++ b/src/python/dxpy/sugar/__init__.py
@@ -18,6 +18,6 @@ from transfers import (
     Uploader,
     Downloader,
     upload_file,
-    archive_and_upload_files,
+    tar_and_upload_files,
     download_file,
 )

--- a/src/python/dxpy/sugar/__init__.py
+++ b/src/python/dxpy/sugar/__init__.py
@@ -1,0 +1,23 @@
+# Copyright (C) 2013-2019 DNAnexus, Inc.
+#
+# This file is part of dx-toolkit (DNAnexus platform client libraries).
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#   use this file except in compliance with the License. You may obtain a copy
+#   of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+from processing import run_cmd, chain_cmds
+from transfers import (
+    Uploader,
+    Downloader,
+    upload_file,
+    archive_and_upload_files,
+    download_file,
+)

--- a/src/python/dxpy/sugar/processing.py
+++ b/src/python/dxpy/sugar/processing.py
@@ -69,13 +69,12 @@ class Processes:
         """
         The max return code of all the commands in the chain.
         """
+        if not self.was_run:
+            raise RuntimeError("Must call run() before returncode can be requested")
         if self._returncode is None:
-            returncodes = [
-                proc.returncode for proc in self._processes if proc.poll() is not None
-            ]
-            if returncodes:
-                # TODO: Is setting to max the right behavior?
-                self._returncode = max(returncodes)
+            # Set `self._returncode` to the returncode of the last process,
+            # to mimic behavior of `set -o pipefail`.
+            self._returncode = self._processes[-1].poll()
         return self._returncode
 
     def _init_stdout(self):

--- a/src/python/dxpy/sugar/processing.py
+++ b/src/python/dxpy/sugar/processing.py
@@ -1,7 +1,6 @@
 from __future__ import print_function, unicode_literals, division, absolute_import
 import copy
 import logging
-import os
 import shlex
 import subprocess
 import tempfile
@@ -507,24 +506,3 @@ def command_lists_to_strings(cmds):
         quote_args(cmd) if not isinstance(cmd, compat.basestring) else cmd
         for cmd in cmds
     ]
-
-
-def read_stream(stream, default=""):
-    """
-    Read from a stream and handle any errors.
-
-    Args:
-        stream: Stream to read from.
-        default: Default value to return if there is an error reading from the stream.
-
-    Returns:
-        String output of the stream, or `default` if there was an error.
-    """
-    try:
-        s = stream.read()
-        if s:
-            s = s.strip()
-        return s
-    except:
-        LOG.exception("Error reading from stream")
-        return default

--- a/src/python/dxpy/sugar/processing.py
+++ b/src/python/dxpy/sugar/processing.py
@@ -1,0 +1,530 @@
+from __future__ import print_function, unicode_literals, division, absolute_import
+import copy
+import logging
+import os
+import shlex
+import subprocess
+import tempfile
+
+from dxpy import compat
+
+
+LOG = logging.getLogger()
+
+
+# stdout/stderr types
+_PIPE = 0
+_FILE = 1
+_BUFFER = 2
+_OTHER = 3
+
+
+class Processes:
+    """
+    Encapsulates one or more commands, runs those commands using the
+    `subprocess` module, and provides access to the results.
+
+    Args:
+        cmds (sequence): Command strings or sequences of command arguments to
+            be chained together.
+        stdout: How to capture stdout of the final process in the chain; can be
+            a string (filename) or file object, in which case the output is written
+            to that file; None, in which case `subprocess.PIPE` is used; True,
+            in which case output is captured to a buffer; or False, in which case
+            stdout is discarded. If a file, any existing file with the same name is
+            overwritten.
+        stderr: How to capture stderr of the final process in the chain (see
+            `stdout` for details).
+        capture_stderr: Whether to capture the contents of stderr of processes
+            other than the final process.
+        echo: Whether to echo commands to the logger before running the commands.
+            Can be overridden by the `run()` method's `echo` parameter.
+        popen_kwargs: Keyword arguments to pass to Popen constructors.
+
+    Todo:
+        Add ability to send input to stdin of first process.
+    """
+    def __init__(
+        self, cmds, stdout=None, stderr=None, capture_stderr=True, echo=None,
+        **popen_kwargs
+    ):
+        self.cmds = cmds
+        self._stdout = stdout
+        self._stdout_type = None
+        self._stderr = stderr
+        self._stderr_type = None
+        self.capture_stderr = capture_stderr
+        self._stderr_buffers = [] if capture_stderr else None
+        self._closed = False
+        self.echo = echo
+        self.popen_kwargs = popen_kwargs
+        self._processes = None
+        self._output_handle = None
+        self._returncode = None
+        # These will hold
+        self.out = None
+        self.err = None
+
+    @property
+    def returncode(self):
+        """
+        The max return code of all the commands in the chain.
+        """
+        if self._returncode is None:
+            returncodes = [
+                proc.returncode for proc in self._processes if proc.poll() is not None
+            ]
+            if returncodes:
+                # TODO: Is setting to max the right behavior?
+                self._returncode = max(returncodes)
+        return self._returncode
+
+    def _init_stdout(self):
+        self._stdout, self._stdout_type, retval = self._init_std(self._stdout)
+        return retval
+
+    def _init_stderr(self):
+        self._stderr, self._stderr_type, retval = self._init_std(self._stderr)
+        return retval
+
+    @staticmethod
+    def _init_std(value):
+        if value is None:
+            return None, _PIPE, subprocess.PIPE
+
+        std_type = _OTHER
+        if value is False:
+            value = None
+        elif value is True:
+            value = Processes._create_temp_outfile()
+            std_type = _BUFFER
+        elif isinstance(value, compat.basestring):
+            value = open(value, "w")
+            std_type = _FILE
+        return value, std_type, value
+
+    def _get_stderr_buffer(self):
+        """
+        Creates a temporary file to use for storing a stderr stream.
+
+        Returns:
+            The opened file object.
+        """
+        if self.capture_stderr:
+            handle = self._create_temp_outfile()
+            self._stderr_buffers.append(handle)
+            return handle
+
+    @staticmethod
+    def _create_temp_outfile():
+        """
+        Creates and returns a temporary output file object.
+        """
+        return open(tempfile.mkstemp()[1], "w")
+
+    @property
+    def stdout(self):
+        """
+        The `stdout` stream of the last process in the chain.
+        """
+        if not self.was_run:
+            raise RuntimeError("Cannot access 'stdout' until after calling 'run'.")
+        return self._stdout or self._processes[-1].stdout
+
+    @property
+    def stderr(self):
+        """
+        The `stderr` stream of the last process in the chain.
+        """
+        if not self.was_run:
+            raise RuntimeError("Cannot access 'stderr' until after calling 'run'.")
+        return self._stderr or self._processes[-1].stderr
+
+    def get_all_stderr(self):
+        """
+        Get the contents of all stderr streams. Stderr streams of all but the final
+        process are only available if `self.capture_stderr is True`. Stderr stream
+        of the final process is only available if `self._stderr_type in
+        (_BUFFER, _PIPE)`.
+
+        Returns:
+            A list of strings, where each string is the captured stderr stream of a
+            process.
+        """
+        if not self.closed:
+            raise RuntimeError(
+                "Cannot access 'stderr' contents until all processes have completed "
+                "and file handles have been closed."
+            )
+        stderr = []
+        if self.capture_stderr:
+            stderr.extend(self._stderr_buffers)
+        if self._stderr_type in (_BUFFER, _PIPE):
+            stderr.append(self.err)
+        return stderr
+
+    @property
+    def was_run(self):
+        """
+        Whether the `run()` method was called.
+        """
+        return bool(self._processes)
+
+    @property
+    def done(self):
+        """
+        Whether the commands have finished running.
+        """
+        return self.returncode is not None
+
+    @property
+    def ok(self):
+        """
+        Whether the commands completed successfully, i.e. all had `returncode == 0`.
+        """
+        return self.returncode == 0
+
+    @property
+    def closed(self):
+        """
+        Whether `self.close()` has been called.
+        """
+        return self._closed
+
+    def run(self, echo=None, **kwargs):
+        """
+        Run the commands.
+
+        Args:
+            echo: Whether to echo the commands to the log. Overrides the value of
+                `self.echo`.
+            kwargs: Keyword arguments to pass to Popen. Overrides any values specified
+                in `self.popen_kwargs`.
+        """
+        if self.was_run:
+            raise RuntimeError("Cannot call run() more than once.")
+
+        if echo is None:
+            echo = self.echo
+        if echo is not False:
+            LOG.info(str(self))
+
+        num_commands = len(self.cmds)
+        procs = []
+
+        for i, cmd in enumerate(self.cmds, 1):
+            popen_kwargs = copy.copy(self.popen_kwargs)
+            popen_kwargs.update(kwargs)
+            if procs:
+                popen_kwargs["stdin"] = procs[-1].stdout
+            if i == num_commands:
+                popen_kwargs["stdout"] = self._init_stdout()
+                popen_kwargs["stderr"] = self._init_stderr()
+            else:
+                popen_kwargs["stdout"] = subprocess.PIPE
+                popen_kwargs["stderr"] = self._get_stderr_buffer()
+            proc = subprocess.Popen(cmd, **popen_kwargs)
+            if procs:
+                procs[-1].stdout.close()
+            procs.append(proc)
+
+        self._processes = procs
+
+    def block(self, close=True, raise_on_error=True):
+        """
+        Wait for all commands to finish.
+
+        Args:
+            close: Whether to call `self.close()` after the processes complete.
+            raise_on_error: Whether to raise a :class:`subprocess.CalledProcessError`
+                if the returncode was not 0.
+        """
+        last_proc = self._processes[-1]
+        try:
+            out, err = (
+                "" if std is None else std.strip()
+                for std in last_proc.communicate()
+            )
+            if self._stdout_type == _PIPE:
+                self.out = out
+            if self._stderr_type == _PIPE:
+                self.err = err
+        except ValueError:
+            LOG.error("Error reading from stdout/stderr")
+            pass
+
+        if close:
+            self.close()
+
+        if raise_on_error:
+            self.raise_if_error()
+
+    def kill(self):
+        """
+        Kill the running commands. It is recommended to call `close()` if this
+        returns `True`.
+
+        Returns:
+            True if processes were killed, else False.
+        """
+        if self.was_run:
+            if not self.done:
+                for i, proc in enumerate(self._processes):
+                    try:
+                        proc.kill()
+                    except:
+                        LOG.exception(
+                            "Error killing running process command %s", self.cmds[i]
+                        )
+                return True
+
+        return False
+
+    def close(self):
+        """
+        For each of stdout, stderr of the final process, if it is a file close it,
+        or if it is a buffer, set its value to `self.out/self.err`.
+        """
+        if not (self.was_run and self.done):
+            raise RuntimeError("Can only call close() after 'done' is True.")
+
+        if not self._closed:
+            def close_file(handle):
+                try:
+                    handle.close()
+                except IOError:
+                    LOG.exception("Error closing output file %s", handle.name)
+
+            def close_buffer(handle):
+                close_file(handle)
+                with open(handle.name, "rt") as inp:
+                    return inp.read()
+
+            if self._stdout_type == _FILE:
+                close_file(self._stdout)
+            elif self._stdout_type == _BUFFER:
+                self.out = close_buffer(self._stdout)
+
+            if self._stderr_type == _FILE:
+                close_file(self._stderr)
+            elif self._stderr_type == _BUFFER:
+                self.err = close_buffer(self._stderr)
+
+            if self.capture_stderr:
+                self._stderr_buffers = [
+                    close_buffer(buf) for buf in self._stderr_buffers
+                ]
+
+            self._closed = True
+
+    def raise_if_error(self):
+        """
+        Raise an exception if the processes are finished running and the
+        return code is not 0.
+
+        Raises:
+            CalledProcessError
+        """
+        if self.done and not self.ok:
+            msg = "stderr from executed commands: {}".format(
+                "\n".join(self.get_all_stderr())
+            )
+            raise subprocess.CalledProcessError(
+                self.returncode, str(self), output=msg
+            )
+
+    def __str__(self):
+        cmd_str = " | ".join(command_lists_to_strings(self.cmds))
+        if self._stdout_type == _FILE:
+            cmd_str += " > {}".format(self._stdout.name)
+        return cmd_str
+
+    def __enter__(self):
+        if not self.was_run:
+            self.run()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type or (self.was_run and not self.done):
+            # Kill the processes if exiting the context manager with an error
+            # or before the processes finish running.
+            self.kill()
+        self.close()
+
+
+def run_cmd(cmd, **kwargs):
+    """
+    Run a single command as a subprocess.
+
+    This is simply a convenience method for `chain([cmd], **kwargs)`.
+
+    Args:
+        cmd (str or sequence): The command string, or command arguments as a list.
+        **kwargs: Additional keyword arguments to pass to `chain_cmds`.
+
+    Returns:
+        A :class:`dxpy.sugar.processing.Processes` object.
+    """
+    return chain_cmds([cmd], **kwargs)
+
+
+def chain_cmds(cmds, stdout=None, shell=False, block=True, **kwargs):
+    """
+    Function to run several commands that pipe to each other in a python-aware way.
+
+    Args:
+        cmds (iterable): Any number of commands (lists or strings) to pipe together.
+            Input of type 'list' is recommended. When input is of type 'string',
+            command is executed using the default shell (i.e. `shell` is set to `None`
+            if it is `False`).
+        stdout (str): What to do with stdout of the last process in the chain. Can be a
+            string (filename) or file object, in which case the output is written to
+            that file; None, in which case `subprocess.PIPE` is used; True, in which
+            case output is captured to a buffer; or False, in which case stdout is
+            discarded.
+        shell (bool or str): Can be a boolean specifying whether to execute the command
+            using the shell, or a string value specifying the shell executable to use
+            (which also implies shell=True). If None, the command is executed via the
+            default shell (which, according to the subprocess docs, is /bin/sh).
+        block (bool): Whether to block until all processes have completed.
+        kwargs: Additional keyword arguments to pass to :class:`Processes`
+            constructor.
+
+    Returns:
+        A :class:`dxpy.sugar.processing.Processes` object.
+
+    Raises:
+        subprocess.CalledProcessError: if any subprocess in pipe returns exit
+            code not 0.
+
+    Examples:
+        Usage 1: Pipe multiple commands together and print output to file
+            example_cmd1 = ['dx', 'download', 'file-xxxx']
+            example_cmd2 = ['gunzip']
+            out_f = "somefilename.fasta"
+            chain_cmd([example_cmd1, example_cmd2], output_filename=out_f)
+
+            This function will print and execute the following command:
+            'dx download file-xxxx | gunzip > somefilename.fasta'
+
+        Usage 2: Pipe multiple commands together and return output
+            example_cmd1 = ['gzip', 'file.txt']
+            example_cmd2 = ['dx', 'upload', '-', '--brief']
+            file_id = chain_cmd([example_cmd1, example_cmd2], block=True).out
+
+            This function will print and execute the following command:
+            'gzip file.txt | dx upload - --brief '
+            and return the output.
+
+        Usage 3: Run a single command with output to file
+            run_cmd('echo "hello world"', output_filename='test2.txt')
+            Note: This calls the run function instead of chain.
+
+        Usage 4: A command failing mid-pipe should return CalledProcessedError
+            chain_cmd(
+                [['echo', 'hi:bye'], ['grep', 'blah'], ['cut', '-d', ':', '-f', '1']]
+            )
+            Traceback (most recent call last):
+                  ...
+            CalledProcessError: Command '['grep', 'blah']' returned non-zero
+                exit status 1
+    """
+    if shell is True:
+        executable = "/bin/bash"
+    elif isinstance(shell, compat.basestring):
+        executable = shell
+    else:
+        executable = None
+
+    if shell is False:
+        cmds = command_strings_to_lists(cmds)
+    else:
+        cmds = command_lists_to_strings(cmds)
+
+    processes = Processes(
+        cmds,
+        stdout=stdout,
+        shell=(shell is not False),
+        executable=executable,
+        **kwargs
+    )
+
+    if block:
+        with processes as procs:
+            procs.block()
+    else:
+        processes.run()
+
+    return processes
+
+
+# Note: command argument quoting only supported for POSIX-compatible shells.
+# If Windows needs to be supported, uncomment the next three lines and indent
+# the `quote_args` function definition.
+# if sys.platform == "win32":
+#     quote_args = subprocess.list2cmdline
+# else:
+def quote_args(seq):
+    """
+    Quote command line arguments.
+
+    Args:
+        seq (sequence): Command line arguments.
+
+    Returns:
+        Sequence of quoted command line arguments.
+    """
+    return " ".join(compat.quote(str(arg)) for arg in seq)
+
+
+def command_strings_to_lists(cmds):
+    """
+    Convert any command strings in `cmds` to lists.
+
+    Args:
+        cmds (sequence): Commands - either strings or lists of arguments.
+
+    Returns:
+        A sequence of command strings.
+    """
+    return [
+        shlex.split(cmd)if isinstance(cmd, compat.basestring) else cmd
+        for cmd in cmds
+    ]
+
+
+def command_lists_to_strings(cmds):
+    """
+    Convert any command lists in `cmds` to strings.
+
+    Args:
+        cmds (sequence): Commands - either strings or lists of arguments.
+
+    Returns:
+        A sequence of command argument sequences.
+    """
+    return [
+        quote_args(cmd) if not isinstance(cmd, compat.basestring) else cmd
+        for cmd in cmds
+    ]
+
+
+def read_stream(stream, default=""):
+    """
+    Read from a stream and handle any errors.
+
+    Args:
+        stream: Stream to read from.
+        default: Default value to return if there is an error reading from the stream.
+
+    Returns:
+        String output of the stream, or `default` if there was an error.
+    """
+    try:
+        s = stream.read()
+        if s:
+            s = s.strip()
+        return s
+    except:
+        LOG.exception("Error reading from stream")
+        return default

--- a/src/python/dxpy/sugar/transfers.py
+++ b/src/python/dxpy/sugar/transfers.py
@@ -1,0 +1,952 @@
+"""
+This module contains utilities for file upload and download. File downloads can be
+done in blocking or non-blocking mode.
+
+This module also provides the Uploader and Downloader classes for managing multiple
+concurrent up/downloads. Individual files, lists of files, and dicts of files can
+be queued for up/download with different settings. Each enqueue event is associated
+with a name. Calling the `wait()` method blocks until all up/downloads have completed
+and returns a dict mapping names to either local paths (for Downloader) or dxlinks
+(for Uploader).
+
+```
+with Downloader() as downloader:
+  downloader.enqueue_file("reference_tgz", "file-XXX")
+  downloader.enqueue_list("fastqs", ["file-YYY", "file-ZZZ"], skip_decompress=True)
+  local_files = downloader.wait()
+
+subprocess.call(
+    "bwa mem {reference_tgz} {fastqs}".format(**local_files),
+    output_filename="output.bam"
+)
+
+with Uploader() as uploader:
+  uploader.enqueue_file("output_bam", "output.bam", skip_compress=True)
+  uploader.enqueue_file("output_bai", "output.bam.bai", skip_compress=True)
+  return uploader.wait()
+```
+
+TODO: switch to using dxpy vs calls to dx whenever possible
+"""
+
+# Copyright (C) 2013-2019 DNAnexus, Inc.
+#
+# This file is part of dx-toolkit (DNAnexus platform client libraries).
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#   use this file except in compliance with the License. You may obtain a copy
+#   of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+from __future__ import print_function, unicode_literals, division, absolute_import
+import concurrent.futures
+import contextlib
+import copy
+import logging
+import multiprocessing
+import os
+import re
+import sys
+
+import dxpy
+from dxpy.compat import basestring, makedirs
+from dxpy.utils.resolver import data_obj_pattern
+from dxpy.sugar import processing as proc
+
+
+# Helpers - these belong in other modules
+
+import tempfile
+
+
+@contextlib.contextmanager
+def tmpfile(*args, **kwargs):
+    """
+    Create a temporary file, yield it, and delete it before returning.
+
+    Yields:
+        A path to a temporary file.
+
+    Notes:
+        This method is needed distinct from :class:`tempfile.TemporaryFile` in the
+        case where python needs to write to the file and then a subprocess needs
+        to read from the file.
+    """
+    path = tempfile.mkstemp(*args, **kwargs)[1]
+    try:
+        yield path
+    finally:
+        if os.path.exists(path):
+            os.remove(path)
+
+# End helpers
+
+
+LOG = logging.getLogger()
+SPECIAL_RE = re.compile(r"[^\w.]")
+MAX_READ_SIZE = (1024 * 1024 * 1024 * 2) - 1
+"""Maximum number of bytes that can be read from a file at once. The limit here is
+due to a known bug in some versions of python on macOS:
+https://bugs.python.org/issue24658.
+"""
+
+
+def upload_file(filename, skip_compress=False, **kwargs):
+    """
+    Upload a file, optionally compressing it.
+
+    Args:
+        filename (str): The file to upload.
+        skip_compress (bool): Whether to skip gzip compression.
+        kwargs: Additional kwargs to the upload function.
+
+    Returns:
+        A dxlink or DXFile.
+    """
+    if skip_compress:
+        return simple_upload_file(filename, **kwargs)
+    else:
+        return compress_and_upload_file(filename, **kwargs)
+
+
+def simple_upload_file(
+    filename,
+    remote_filename=None,
+    remote_folder="/",
+    return_handler=False,
+    project=None,
+    wait_on_close=False,
+):
+    """
+    Upload a file and return a link.
+
+    Args:
+        filename (str): Local filename.
+        remote_filename (str): Optional, remote filename to upload file to.
+        remote_folder (str): Optional, remote folder to upload file to.
+        return_handler (bool): Whether to return a DXFile handler.
+        project (str): The project ID to upload to, if not the currently selected
+            project.
+        wait_on_close (bool): Whether to block until the file has closed.
+
+    Returns:
+        DNAnexus link or DXFile pointing to the uploaded file (depending on
+        the value of `return_handler`).
+    """
+    kwargs = {"wait_on_close": wait_on_close}
+
+    if remote_filename:
+        kwargs["name"] = remote_filename
+    if not remote_folder:
+        remote_folder = "/"
+    elif not remote_folder.startswith("/"):
+        remote_folder = "/{}".format(remote_folder)
+    kwargs["folder"] = remote_folder
+    if project:
+        kwargs["project"] = project
+    LOG.info("Uploading file %s to %s", filename, remote_filename or filename)
+    handler = dxpy.upload_local_file(filename, **kwargs)
+    if return_handler:
+        return handler
+    else:
+        return dxpy.dxlink(handler.get_id(), handler.describe()["project"])
+
+
+def compress_and_upload_file(
+    filename,
+    remote_filename=None,
+    remote_folder="/",
+    compression_level=1,
+    return_handler=False,
+    project=None,
+    wait_on_close=False,
+    method="gz",
+    max_part_size=None
+):
+    """
+    Gzip and upload a local file.
+
+    Shorthand for running 'gzip' and 'dx upload' using a subprocess on a given
+    local file.
+
+    Args:
+        filename (str): Local filename.
+        remote_filename (str): Optional, remote filename to upload file to.
+        remote_folder (str): Optional, remote folder to upload file to.
+        compression_level (int): Level of compression between 1 and 9 to compress
+            file to. Specify 1 for gzip --fast and 9 for gzip --best. If not
+            specified, --fast is assumed.
+        return_handler (bool): Whether to return a DXFile handler.
+        project (str): The project ID to upload to, if not the currently selected
+            project.
+        wait_on_close (bool): Whether to block until the file has closed.
+        method (str): Compression method; one of 'gz', 'bz2'.
+        max_part_size (int): Optional, maximum file part size, defaults to project
+            value.
+
+    Returns:
+        DNAnexus link or DXFile pointing to the uploaded file (depending on
+        the value of `return_handler`).
+
+    Raises:
+        ValueError: if compression_level not between 1 and 9
+        CalledProcessError: propogated from run_pipe if called command fails
+    """
+    ext = ".{}".format(method)
+    if remote_filename is None:
+        remote_filename = os.path.basename(filename)
+    if not remote_filename.endswith(ext):
+        remote_filename += ext
+
+    if not remote_folder:
+        remote_folder = "/"
+    elif not remote_folder.startswith("/"):
+        remote_folder = "/{}".format(remote_folder)
+
+    remote_path = "{}/{}".format(remote_folder, remote_filename)
+    if project:
+        remote_path = "{}:{}".format(project, remote_path)
+
+    # check that compression level is valid
+    if compression_level < 1 or compression_level > 9:
+        raise ValueError("Compression level must be between 1 and 9")
+
+    if not max_part_size or max_part_size <= 0:
+        max_part_size = _get_max_part_size(project)
+
+    if filename.endswith(ext):
+        cmd = [
+            "dx", "upload", "--brief", "--buffer-size", str(max_part_size),
+            "--path", remote_filename, filename
+        ]
+        file_id = proc.run_cmd(cmd).out
+    else:
+        exe = "bzip2" if method == "bz2" else "gzip"
+        zip_cmd = [exe, "-{0}".format(compression_level), "-c", filename]
+        upload_cmd = [
+            "dx", "upload", "--brief", "--buffer-size", str(max_part_size),
+            "--path", remote_path
+        ]
+        if wait_on_close:
+            upload_cmd.append("--wait")
+        upload_cmd.append("-")
+        file_id = proc.chain_cmds([zip_cmd, upload_cmd], shell=True).out
+
+    return _wrap_file_id(file_id, return_handler)
+
+
+def archive_and_upload_files(
+    filenames,
+    remote_prefix=None,
+    remote_folder="/",
+    compression_level=1,
+    chdir=None,
+    return_handler=False,
+    project=None,
+    wait_on_close=False,
+    method="gz",
+    max_part_size=None
+):
+    """
+    Archive and upload one or more files.
+
+    Shorthand for running 'tar', 'gzip', and 'dx upload' using subprocess on a
+    list of local files/directories.
+
+    Args:
+        filenames (str or list of str): = Local filenames or directories.
+        remote_prefix (str) = Name to give to output tar archive. Must be provided
+            unless `filenames` is of length 1, in which case the prefix will be
+            the same as that of the single filename.
+        remote_folder (str): Optional, remote folder to upload file to.
+        compression_level (int) = Level of compression between 1 and 9 to
+            compress tar to. Specify 1 for gzip --fast and 9 for gzip --best.
+            If not specified, --fast is assumed. If None, no compression is
+            performed, i.e. the output is a .tar file.
+        chdir (bool): If a path, change to this directory; if None and filenames is
+            a directory, will cd to that directory; if True and filenames is
+            a directory, same behavior as None, otherwise an error is raised;
+            if False, no cd. (tar -C option).
+        return_handler (bool): Whether to return a DXFile handler.
+        project (str): The project ID to upload to, if not the currently selected
+            project.
+        wait_on_close (bool): Whether to block until the file has closed.
+        method (str): Compression method; one of 'gz', 'bz2'.
+        max_part_size (int): Optional, maximum file part size, defaults to project
+            value.
+
+    Returns:
+        DNAnexus link or DXFile pointing to the uploaded tar archive (depending on
+        the value of `return_handler`).
+
+    Raises:
+        ValueError: if compression_level not between 1 and 9
+        CalledProcessError: propogated from run_pipe if called command fails
+    """
+    is_dir = False
+    if isinstance(filenames, basestring):
+        is_dir = os.path.isdir(filenames)
+        filenames = [filenames]
+
+    if remote_prefix is None:
+        if len(filenames) == 1:
+            remote_prefix = os.path.basename(filenames[0])
+        else:
+            raise ValueError("'prefix' must be specified with multiple filenames")
+
+    if not remote_folder:
+        remote_folder = "/"
+    elif not remote_folder.startswith("/"):
+        remote_folder = "/{}".format(remote_folder)
+
+    if compression_level is not None and (
+        compression_level < 1 or compression_level > 9
+    ):
+        raise ValueError("Compression level must be between 1 and 9")
+
+    if compression_level:
+        zip_ext = ".{}".format(method)
+        ext = "tar" + zip_ext
+    else:
+        ext = "tar"
+
+    remote_path = "{}/{}.{}".format(remote_folder, remote_prefix, ext)
+    if project:
+        remote_path = "{}:{}".format(project, remote_path)
+
+    if not max_part_size or max_part_size <= 0:
+        max_part_size = _get_max_part_size(project)
+
+    with tmpfile() as names_file:
+        with open(names_file, "wt") as out:
+            out.write("\n".join(filenames))
+
+        tar_cmd = ["tar"]
+        if chdir is not False and not isinstance(chdir, str):
+            if is_dir:
+                chdir = filenames[0]
+            elif chdir is True:
+                raise ValueError(
+                    "chdir is True but {} is not a directory".format(filenames[0])
+                )
+            else:
+                chdir = None
+        if chdir:
+            tar_cmd.extend(["-C", chdir])
+        tar_cmd.extend(["cvf", "-", "--files-from", names_file])
+        cmds = [tar_cmd]
+
+        if compression_level:
+            exe = "bzip2" if method == "bz2" else "gzip"
+            cmds.append([exe, "-{}".format(compression_level)])
+
+        upload_cmd = [
+            "dx", "upload", "--brief", "--buffer-size", max_part_size,
+            "--path", remote_path
+        ]
+        if wait_on_close:
+            upload_cmd.append("--wait")
+        upload_cmd.append("-")
+        cmds.append(upload_cmd)
+
+        file_id = proc.chain_cmds(cmds, shell=True).out
+
+    return _wrap_file_id(file_id, return_handler)
+
+
+def _get_max_part_size(project_id=None):
+    if not project_id:
+        project_id = dxpy.PROJECT_CONTEXT_ID
+    project = dxpy.DXProject(project_id)
+    desc = project.describe(input_params={"fields": {"fileUploadParameters": True}})
+    return min(
+        desc["fileUploadParameters"]["maximumPartSize"],
+        MAX_READ_SIZE
+    )
+
+
+def _wrap_file_id(file_id, return_handler, project=None):
+    """
+    Given a file ID, create either a link or a `dxpy.DXFile` object, depending
+    on the value of `return_handler`.
+
+    Args:
+        file_id (str): The file ID to wrap.
+        return_handler (bool): Whether to return a `dxpy.DXFile` object.
+        project (str): The project ID (defaults to currently selected project).
+
+    Returns:
+        A `dxpy.DXFile` object, depending on the value of `return_handler`.
+    """
+    try:
+        dxpy.verify_string_dxid(file_id, "file")
+    except:
+        # dxpy prints warnings (e.g. about readline support) even when '--brief'
+        # is used, so we may need to parse out the file ID from stdout.
+        match = data_obj_pattern.search(file_id)
+        if match:
+            file_id = match.group()
+        else:
+            raise ValueError("Invalid file ID: {}".format(file_id))
+
+    dxlink = dxpy.dxlink(file_id, project_id=project)
+
+    if return_handler:
+        return dxpy.DXFile(dxlink)
+    else:
+        return dxlink
+
+
+def download_file(
+    remote_file,
+    skip_decompress=False,
+    skip_unpack=False,
+    remote_filename=None,
+    local_filename=None,
+    output_dir=None,
+    project=None,
+    block=True,
+):
+    """
+    Download and unzip a gzip file.
+
+    Shorthand for running dx download on a given input_file dx file link.
+    Additionally use subprocess to decompress and/or untar the file
+    automatically based on the name suffix of the file provided.
+
+    Args:
+        remote_file (dict or str): DNAnexus link or file-id of file to download
+        remote_filename (str): Name to use for the input filename, if different than
+            the name of the input_file. If not provided, platform filename is used.
+        skip_decompress (bool): Whether to skip decompressing files of type *.gz
+        skip_unpack (bool): Whether to skip unpacking archive files (.tar.*)
+        local_filename (str): Local file where the data is to be saved.
+        output_dir (str): Download file to a specific directory (default is the current
+            directory).
+        project (str): The ID of the project that contains the file, if it is not the
+            currently selected project and is not specified in the remote file
+            object/link.
+        block (bool): Wait for the download to complete before returning.
+
+    Notes:
+        Supported filetypes: *.tar.gz, *.tgz, *.tar, *.tar.bz2, *.tbz2, *.gz, *.bz2.
+
+        The arg skip_unpack only impacts tar files, and the arg skip_decompress only
+        impacts non-tar files of type *.gz.
+
+    Returns:
+        str: filename or local named pipe which file was downloaded to. If `block`
+        is False, also returns the Popen for the process running in the background.
+    """
+    remote_file = _as_dxfile(remote_file, project)
+
+    if remote_filename is None:
+        remote_filename = remote_file.describe()["name"]
+
+    if output_dir:
+        makedirs(output_dir, exist_ok=True)
+    else:
+        output_dir = os.getcwd()
+
+    is_tar = (
+        ".tar" in remote_filename
+        or remote_filename.endswith(".tgz")
+        or remote_filename.endswith(".tbz2")
+    )
+    unpack = is_tar and not skip_unpack
+    unzip = (
+        not skip_decompress
+        and not is_tar
+        and (remote_filename.endswith(".gz") or remote_filename.endswith(".bz2"))
+    )
+
+    if not any((unpack, unzip)):
+        return simple_download_file(remote_file, local_filename, output_dir, block)
+
+    dl_func = download_and_unpack_archive if unpack else download_and_decompress_file
+    return dl_func(remote_file, remote_filename, local_filename, output_dir, block)
+
+
+def simple_download_file(
+    remote_file,
+    local_filename=None,
+    output_dir=None,
+    project=None,
+    block=True,
+    **kwargs
+):
+    """
+    Download a file.
+
+    Args:
+        remote_file (dxpy.DXFile or dxlink): The file to download.
+        local_filename (str): The local_filename, or None to use the input filename.
+        output_dir (str): The output directory, or None to use the current directory.
+        project (str): The ID of the project that contains the file, if it is not the
+            currently selected project and is not specified in the remote file
+            object/link.
+        block (bool): Wait for the download to complete before returning. Ignored if
+            create_named_pipe=True.
+        kwargs: Additional arguments passed to `dxpy.sugar.processing.run_cmd()`.
+
+    Returns:
+        The output filename, if `block is True`, otherwise a
+        :class:`dxpy.sugar.processing.Processes` object.
+    """
+    remote_file = _as_dxfile(remote_file, project)
+
+    if local_filename is None:
+        local_filename = SPECIAL_RE.sub("", remote_file.name)
+    if output_dir:
+        local_filename = os.path.join(output_dir, local_filename)
+
+    LOG.info("Downloading file %s to %s", remote_file.get_id(), local_filename)
+
+    cmd = ["dx", "download", remote_file.get_id(), "-o", local_filename]
+
+    result = proc.run_cmd(cmd, block=block, **kwargs)
+
+    if block:
+        LOG.info(
+            "Completed downloading file %s to %s", remote_file.get_id(), local_filename
+        )
+        return local_filename
+    else:
+        return result
+
+
+def download_and_unpack_archive(
+    remote_file,
+    input_filename=None,
+    local_filename=None,
+    output_dir=None,
+    project=None,
+    block=True,
+):
+    """
+    Download and unpack a tar file, which may optionally be gzip-compressed.
+
+    Args:
+        remote_file (dxpy.DXFile): DNAnexus link or file-id of file to download
+        input_filename (str): Name to use for the input filename, if different than
+            the name of the input_file. If not provided, platform filename is used.
+        local_filename (str): Local filename/dirname. If not None, this file/directory
+            must exist after unpacking the archive or an error is raised.
+        output_dir (str): Download file to a specific directory (default is the current
+            directory).
+        project (str): The ID of the project that contains the file, if it is not the
+            currently selected project and is not specified in the remote file
+            object/link.
+        block (bool): Wait for the download to complete before returning.
+
+    Returns:
+        The list of unpacked filenames, if `block is True`, otherwise
+        a :class:`dxpy.sugar.processing.Processes` object.
+
+        If `local_filename` is provided and `block is False`, the list of unpacked
+        filenames has a single element, which is the `local_filename`, converted to
+        an absolute path if necessary.
+    """
+    remote_file = _as_dxfile(remote_file, project)
+
+    if input_filename is None:
+        input_filename = remote_file.describe()["name"]
+    if not output_dir:
+        output_dir = os.getcwd()
+    elif not os.path.isabs(output_dir):
+        output_dir = os.path.abspath(output_dir)
+
+    tar_cmd = ["tar", "--no-same-owner", "-C", output_dir]
+    if input_filename.endswith(".tar.gz"):
+        tar_cmd.append("-z")
+        ext_len = 7
+    elif input_filename.endswith(".tgz"):
+        tar_cmd.append("-z")
+        ext_len = 4
+    elif input_filename.endswith(".tar.bz2"):
+        tar_cmd.append("-j")
+        ext_len = 8
+    elif input_filename.endswith(".tbz2"):
+        tar_cmd.append("-j")
+        ext_len = 5
+    elif input_filename.endswith(".tar"):
+        ext_len = 4
+    else:
+        raise ValueError("Unsupported file type: {}".format(input_filename))
+    tar_cmd.extend(["-x", "-v", "-f", "-"])
+
+    if local_filename:
+        suffix = os.path.basename(local_filename)
+    else:
+        suffix = SPECIAL_RE.sub("", input_filename[:-ext_len])
+    file_list_filename = "tar_output_{}".format(suffix)
+
+    cmds = [["dx", "download", remote_file.get_id(), "-o", "-"], tar_cmd]
+
+    LOG.info(
+        "Downloading file %s using command %s and saving command stdout to "
+        "intermediate file %s", remote_file.get_id(), cmds, file_list_filename
+    )
+
+    result = proc.chain_cmds(cmds, stdout=file_list_filename, block=block)
+
+    if not block:
+        return result
+
+    LOG.info("Completed downloading file %s", remote_file.get_id())
+
+    if local_filename:
+        # If a local_filename was provided, make sure it exists
+        if not os.path.isabs(local_filename):
+            local_filename = os.path.join(output_dir, local_filename)
+        if not os.path.exists(local_filename):
+            raise ValueError(
+                "Expected file {} does not exist after untarring file {}",
+                local_filename, remote_file.get_id()
+            )
+        return [local_filename]
+    else:
+        # Otherwise return the list of files that were unpacked from the tar file
+        with open(file_list_filename, "rt") as inp:
+            return [os.path.join(output_dir, filename.rstrip()) for filename in inp]
+
+
+def download_and_decompress_file(
+    remote_file,
+    input_filename=None,
+    local_filename=None,
+    output_dir=None,
+    project=None,
+    block=True,
+):
+    """
+    Download and decompress a gzipped file.
+
+    Args:
+        remote_file (dxpy.DXFile or dxlink): DNAnexus link or file-id of file to
+            download.
+        input_filename (str): Name to use for the input filename, if different than
+            the name of the input_file. If not provided, platform filename is used.
+        local_filename (str): Local filename/dirname. If not None, this file/directory
+            must exist after unpacking the archive or an error is raised.
+        output_dir (str): Download file to a specific directory (default is the current
+            directory).
+        project (str): The ID of the project that contains the file, if it is not the
+            currently selected project and is not specified in the remote file
+            object/link.
+        block (bool): Wait for the download to complete before returning.
+
+    Returns:
+        The path of the decompressed file, if `block is True`, otherwise
+        a :class:`dxpy.sugar.processing.Processes` object.
+    """
+    remote_file = _as_dxfile(remote_file, project)
+
+    if input_filename is None:
+        input_filename = remote_file.describe()["name"]
+
+    if input_filename.endswith(".gz"):
+        exe = "gunzip"
+        ext_len = 3
+    elif input_filename.endswith(".bz2"):
+        exe = "bunzip2"
+        ext_len = 4
+    else:
+        raise ValueError(
+            "Unsupported compression method for file {}".format(input_filename)
+        )
+
+    if local_filename is None:
+        local_filename = input_filename[:-ext_len]
+    if output_dir:
+        local_filename = os.path.join(output_dir, local_filename)
+
+    cmds = [
+        ["dx", "download", remote_file.get_id(), "-o", "-"],
+        [exe],
+    ]
+
+    LOG.info(
+        "Downloading file %s to %s using command %s",
+        remote_file.get_id(),
+        local_filename,
+        cmds,
+    )
+
+    result = proc.chain_cmds(cmds, stdout=local_filename, block=block)
+
+    if block:
+        LOG.info(
+            "Completed downloading file %s to %s", remote_file.get_id(), local_filename
+        )
+        return local_filename
+    else:
+        return result
+
+
+def _as_dxfile(fileobj, project=None):
+    """
+    Convert a link to a `dxpy.DXFile` object.
+
+    Args:
+        fileobj (dict or `dxpy.DXFile): Link to convert; if already a `dxpy.DXFile`
+            it is returned without modification.
+        project (str): The ID of the project containing the file.
+
+    Returns:
+        A `dxpy.DXFile` object.
+    """
+    if dxpy.is_dxlink(fileobj):
+        project_id = None
+        if (
+            isinstance(fileobj["$dnanexus_link"], dict)
+            and "project" in fileobj["$dnanexus_link"]
+        ):
+            project_id = fileobj["$dnanexus_link"]["project"]
+        elif project:
+            project_id = project
+        return dxpy.DXFile(fileobj, project=project_id)
+    if not isinstance(fileobj, dxpy.DXFile):
+        raise ValueError("Not a link or DXFile object: {}".format(fileobj))
+    return fileobj
+
+
+class DataTransferExecutor(concurrent.futures.ThreadPoolExecutor):
+    """
+    Abstract subclass of :class:`concurrent.futures.ThreadPoolExecutor` that manages
+    processing files in a multithreaded manner.
+
+    Args:
+        io_function (Callable): Function to call to perform the data transefer.
+        max_parallel (int): Maximum number of parallel threads.
+        default_kwargs: Keyword arguments to pass to every enqueue call.
+    """
+
+    def __init__(self, io_function, max_parallel=None, **default_kwargs):
+        super(DataTransferExecutor, self).__init__(
+            # TODO: A question for discussion: often times clients just make API calls
+            #  and use bandwidth. A lot of the work performed is Network I/O bound. In
+            #  practice, people use a heuristic of 2 * num_cores when dealing with
+            #  network I/O bound task. For this scenario, uploading/downloading data,
+            #  what are good heuristics for ThreadPoolExecutor worker count?
+            max_workers=min(multiprocessing.cpu_count(), max_parallel)
+        )
+        self._io_function = io_function
+        self._default_kwargs = default_kwargs
+        self._queue = None
+
+    def enqueue_file(self, param_name, filespec, **kwargs):
+        """
+        Add a file to the queue associated with `name`.
+
+        Args:
+            param_name (str): Name associated with file.
+            filespec (str): File to upload/download.
+            **kwargs: Additional kwargs to pass to `self._io_function`.
+        """
+        self._enqueue(param_name, [filespec], _is_list=False, **kwargs)
+
+    def enqueue_list(self, param_name, files, **kwargs):
+        """
+        Add a list of files to the queue associated with `name`.
+
+        Args:
+            param_name (str): Name associated with the file list.
+            files (list): List of files.
+            **kwargs: Additional kwargs to pass to `self._io_function`.
+        """
+        self._enqueue(param_name, files, _is_list=True, **kwargs)
+
+    def enqueue_dict(self, files, **kwargs):
+        """
+        Add a dict of files to the queue.
+
+        Args:
+            files (dict): Dict with file values.
+            **kwargs: Additional kwargs to pass to `self._io_function`.
+        """
+        for param_name, _files in files.items():
+            is_list = type(_files) in {tuple, list}
+            if not is_list:
+                _files = [_files]
+            self._enqueue(param_name, _files, is_list, **kwargs)
+
+    def _enqueue(self, param_name, files, _is_list, **kwargs):
+        if self._queue is None:
+            self._queue = {}
+        if param_name in self._queue:
+            futures = self._queue[param_name][0]
+            new_futures, _ = self._submit(
+                files, _is_list, _start_index=len(futures), **kwargs
+            )
+            if len(new_futures) != len(files):
+                raise RuntimeError(
+                    "Number of futures returned differs from number of files "
+                    "submitted; {} != {}".format(len(new_futures), len(files))
+                )
+            futures.update(new_futures)
+            self._queue[param_name] = (futures, True)
+        else:
+            self._queue[param_name] = self._submit(files, _is_list, **kwargs)
+
+    def _submit(self, files, _is_list, _start_index=0, **kwargs):
+        """
+        Submit one or more files to be uploaded/downloaded.
+
+        Args:
+            files (list): List of files to download.
+            _is_list (bool): Whether `files` represents a list of files.
+            _start_index int): The starting index, if `files` is being appended
+                to an existing list of files.
+            **kwargs: Additional kwargs to pass to `download_file`.
+
+        Returns:
+            A tuple:
+            * dict with Future keys and values of tuple (file index, file).
+            * boolean, whether the result should be considered a list
+        """
+        return (
+            {
+                self.submit(
+                    self._io_function, _file, **self._get_submit_kwargs(kwargs)
+                ): (i, _file)
+                for i, _file in enumerate(files, _start_index)
+            },
+            _is_list,
+        )
+
+    def _get_submit_kwargs(self, kwargs):
+        """
+        Merge default and call-specific kwargs.
+
+        Args:
+            kwargs (dict): Call-specific kwargs.
+
+        Returns:
+            dict that is the merger between default and call-specific kwargs.
+        """
+        submit_kwargs = copy.copy(self._default_kwargs)
+        submit_kwargs.update(kwargs)
+        return submit_kwargs
+
+    def __call__(self, *files, **kwargs):
+        """Convenience method to enqueue files and wait for results.
+
+        Args:
+            files (list or dict): Files to process. Can be a sequence of files, or
+                dict with file values.
+            kwargs: Keyword arguments to pass to the worker function.
+
+        Returns:
+            A list or dict of results, depending on the input type.
+        """
+        try:
+            if len(files) == 1 and isinstance(files[0], dict):
+                self.enqueue_dict(files[0], **kwargs)
+                return self.wait()
+            else:
+                self.enqueue_list("default", files, **kwargs)
+                return self.wait()["default"]
+        except KeyboardInterrupt:
+            # Call os._exit() in case of KeyboardInterrupt. Otherwise, the atexit
+            # registered handler in concurrent.futures.thread will run, and issue
+            # blocking join() on all worker threads, requiring us to listen to
+            # events in worker threads in order to enable timely exit in response
+            # to Ctrl-C.
+            LOG.info("Interrupted by user")
+            os._exit(os.EX_IOERR)
+
+    def wait(self):
+        """
+        Wait for all downloads to complete.
+
+        Returns:
+            A dict mapping name to files.
+        """
+        _queue = self._queue
+        results = {}
+        if _queue is None:
+            return results
+        else:
+            self._queue = None
+
+        for name, (futures, is_list) in _queue.items():
+            if not futures:
+                raise RuntimeError("No futures for {}".format(name))
+
+            future_results = [None] * len(futures)
+
+            for future in concurrent.futures.as_completed(futures, timeout=sys.maxint):
+                i, _file = futures[future]
+                try:
+                    future_results[i] = future.result()
+                except Exception:
+                    LOG.exception("%s generated an exception", _file)
+                    raise
+
+            results[name] = future_results if is_list else future_results[0]
+
+        return results
+
+
+class Uploader(DataTransferExecutor):
+    """
+    Upload manager.
+
+    Args:
+        kwargs: Keyword args to pass to DataTransferExecutor.__init__.
+            max_num_parallel_transfers
+    """
+
+    def __init__(self, **kwargs):
+        super(Uploader, self).__init__(upload_file, **kwargs)
+
+    def _submit(
+        self,
+        files,
+        _is_list,
+        _start_index=0,
+        skip_compress=False,
+        archive=False,
+        **kwargs
+    ):
+        if archive:
+            compression_level = None if skip_compress else 1
+            return (
+                {
+                    self.submit(
+                        archive_and_upload_files,
+                        files,
+                        compression_level=compression_level,
+                        **self._get_submit_kwargs(kwargs)
+                    ): (0, ",".join(files))
+                },
+                False,
+            )
+        else:
+            return super(Uploader, self)._submit(
+                files,
+                _is_list,
+                _start_index=_start_index,
+                skip_compress=skip_compress,
+                **kwargs
+            )
+
+
+class Downloader(DataTransferExecutor):
+    """
+    Download manager.
+
+    Args:
+        kwargs: Keyword args to pass to DataTransferExecutor.__init__.
+            max_num_parallel_transfers
+    """
+
+    def __init__(self, **kwargs):
+        super(Downloader, self).__init__(download_file, **kwargs)

--- a/src/python/dxpy/sugar/transfers.py
+++ b/src/python/dxpy/sugar/transfers.py
@@ -285,10 +285,7 @@ def tar_and_upload_files(
             compress tar to. Specify 1 for gzip --fast and 9 for gzip --best.
             If not specified, --fast is assumed. If None or 0, no compression is
             performed, i.e. the output is a .tar file.
-        chdir (bool): If a path, change to this directory; if None and filenames is
-            a directory, will cd to that directory; if True and filenames is
-            a directory, same behavior as None, otherwise an error is raised;
-            if False, no cd. (tar -C option).
+        chdir (str): Change to this directory before tarring files (tar -C option).
         return_handler (bool): Whether to return a DXFile handler.
         project (str): The project ID to upload to, if not the currently selected
             project.
@@ -347,15 +344,6 @@ def tar_and_upload_files(
             out.write("\n".join(local_paths))
 
         tar_cmd = ["tar"]
-        if chdir is not False and not isinstance(chdir, str):
-            if is_dir:
-                chdir = local_paths[0]
-            elif chdir is True:
-                raise ValueError(
-                    "chdir is True but {} is not a directory".format(local_paths[0])
-                )
-            else:
-                chdir = None
         if chdir:
             tar_cmd.extend(["-C", chdir])
         tar_cmd.extend(["cvf", "-", "--files-from", names_file])

--- a/src/python/test/sugar/test_processing.py
+++ b/src/python/test/sugar/test_processing.py
@@ -1,0 +1,58 @@
+from __future__ import print_function, unicode_literals, division, absolute_import
+import contextlib
+import os
+import shutil
+import tempfile
+import unittest
+
+from dxpy.sugar import processing as proc
+
+import logging
+logging.basicConfig(level="INFO")
+
+
+@contextlib.contextmanager
+def temp_dir(*args, **kwargs):
+    dname = tempfile.mkdtemp(*args, **kwargs)
+    try:
+        yield dname
+    finally:
+        shutil.rmtree(dname)
+
+
+@contextlib.contextmanager
+def isolated_dir():
+    with temp_dir() as d:
+        curdir = os.getcwd()
+        os.chdir(d)
+        try:
+            yield d
+        finally:
+            os.chdir(curdir)
+
+
+class TestProc(unittest.TestCase):
+    def test_run(self):
+        with isolated_dir():
+            proc.run_cmd(
+                "echo -n 'foo'",
+                stdout="foo.txt",
+                echo=True,
+                block=True
+            )
+            self.assertTrue(os.path.exists("foo.txt"))
+            self.assertEqual(
+                "foo",
+                proc.run_cmd("cat foo.txt", block=True).out
+            )
+
+    def test_chain(self):
+        with isolated_dir():
+            proc.chain_cmds(
+                ["echo -n 'foo'", "gzip"], stdout="foo.txt.gz", block=True
+            )
+            self.assertEqual(
+                "foo", proc.chain_cmds(
+                    ["gunzip -c foo.txt.gz", "cat"], block=True
+                ).out
+            )

--- a/src/python/test/sugar/test_processing.py
+++ b/src/python/test/sugar/test_processing.py
@@ -43,7 +43,7 @@ class TestProc(unittest.TestCase):
             self.assertTrue(os.path.exists("foo.txt"))
             self.assertEqual(
                 "foo",
-                proc.run_cmd("cat foo.txt", block=True).out
+                proc.run_cmd("cat foo.txt", block=True).output
             )
 
     def test_chain(self):
@@ -54,5 +54,5 @@ class TestProc(unittest.TestCase):
             self.assertEqual(
                 "foo", proc.chain_cmds(
                     ["gunzip -c foo.txt.gz", "cat"], block=True
-                ).out
+                ).output
             )

--- a/src/python/test/sugar/test_transfers.py
+++ b/src/python/test/sugar/test_transfers.py
@@ -1,0 +1,327 @@
+from __future__ import print_function, unicode_literals, division, absolute_import
+import contextlib
+import gzip
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from uuid import uuid4
+
+import dxpy
+from dxpy.sugar import transfers as xfer
+
+import logging
+logging.basicConfig(level="INFO")
+
+
+def random_name(fmt_str=None):
+    rndstr = str(uuid4())
+    if fmt_str:
+        return fmt_str.format(rndstr)
+    else:
+        return rndstr
+
+
+def make_random_files(n, fmt_str=None):
+    filenames = []
+    for i in range(n):
+        fname = random_name(fmt_str)
+        filenames.append(fname)
+        with open(fname, "wt") as out:
+            out.write("test{}".format(i))
+    return filenames
+
+
+@contextlib.contextmanager
+def temp_dir(*args, **kwargs):
+    dname = tempfile.mkdtemp(*args, **kwargs)
+    try:
+        yield dname
+    finally:
+        shutil.rmtree(dname)
+
+
+@contextlib.contextmanager
+def isolated_dir():
+    with temp_dir() as d:
+        curdir = os.getcwd()
+        os.chdir(d)
+        try:
+            yield d
+        finally:
+            os.chdir(curdir)
+
+
+def run(cmd):
+    subprocess.check_call(cmd, shell=True)
+
+
+class TestUpload(unittest.TestCase):
+    project = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.project = dxpy.DXProject()
+        cls.project.new(name=random_name())
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.project.destroy()
+
+    def setUp(self):
+        self.folder = random_name("/{}")
+        self.project.new_folder(self.folder)
+
+    def tearDown(self):
+        self.project.remove_folder(self.folder, recurse=True)
+
+    def _assert_zip_equal(self, handler, expected_value="test0"):
+        with isolated_dir():
+            local_name = random_name("{}.txt.gz")
+            dxpy.download_dxfile(handler, local_name)
+            with gzip.open(local_name, "rt") as inp:
+                self.assertEqual(expected_value, inp.read())
+
+    def _assert_tar_equal(self, handler, filenames):
+        """
+        Download a tar file and untar it, check that it contains the expected
+        files with the expected contents.
+
+        Args:
+            handler: File handler of the tarfile to download.
+            filenames: Names of files that are expected to match the files in the tar.
+        """
+        with isolated_dir():
+            local_name = random_name("{}.tar.gz")
+            dxpy.download_dxfile(handler, local_name)
+
+            run("tar -xzf {}".format(local_name))
+            run("rm {}".format(local_name))
+
+            untarred_files = os.listdir(".")
+            self.assertEqual(len(filenames), len(untarred_files))
+
+            for i, fname in enumerate(filenames):
+                self.assertTrue(os.path.exists(fname))
+                with open(fname, "rt") as inp:
+                    self.assertEqual("test{}".format(i), inp.read())
+
+    def test_simple_upload_file(self):
+        with isolated_dir():
+            filename = make_random_files(1, "{}.txt")[0]
+            remote_filename = random_name("{}.txt")
+
+            handler = xfer.simple_upload_file(
+                filename,
+                remote_filename=remote_filename,
+                remote_folder=self.folder,
+                project=self.project.get_id(),
+                return_handler=True,
+                wait_on_close=True
+            )
+
+            self.assertIsInstance(handler, dxpy.DXFile)
+            self.assertEqual(remote_filename, handler.describe()["name"])
+            self.assertEqual(self.folder, handler.describe()["folder"])
+            self.assertEqual("test0", handler.read())
+
+    def test_compress_and_upload(self):
+        with isolated_dir():
+            filename = make_random_files(1, "{}.txt")[0]
+            remote_filename = random_name("{}.txt.gz")
+            try:
+                handler = xfer.compress_and_upload_file(
+                    filename,
+                    remote_filename=remote_filename,
+                    remote_folder=self.folder,
+                    project=self.project.get_id(),
+                    return_handler=True,
+                    wait_on_close=True
+                )
+            except subprocess.CalledProcessError as cpe:
+                print(cpe.output)
+                raise
+
+            self.assertIsInstance(handler, dxpy.DXFile)
+            self.assertEqual(remote_filename, handler.describe()["name"])
+            self.assertEqual(self.folder, handler.describe()["folder"])
+            self._assert_zip_equal(handler)
+
+    def test_archive_and_upload(self):
+        with isolated_dir():
+            filenames = make_random_files(2)
+            remote_prefix = random_name()
+            remote_filename = "{}.tar.gz".format(remote_prefix)
+
+            handler = xfer.archive_and_upload_files(
+                filenames,
+                remote_prefix=remote_prefix,
+                remote_folder=self.folder,
+                return_handler=True,
+                project=self.project.get_id(),
+                wait_on_close=True
+            )
+
+            self.assertIsInstance(handler, dxpy.DXFile)
+            self.assertEqual(
+                os.path.basename(remote_filename), handler.describe()["name"]
+            )
+            self.assertEqual(self.folder, handler.describe()["folder"])
+
+        self._assert_tar_equal(handler, filenames)
+
+    def test_uploader(self):
+        with isolated_dir():
+            plain_file = make_random_files(1)[0]
+            to_zip_file = make_random_files(1)[0]
+            to_tar_filenames = make_random_files(2)
+            dict_files = dict(zip(
+                ("dict_file_{}".format(i) for i in range(2)),
+                make_random_files(2)
+            ))
+
+            with xfer.Uploader(
+                max_parallel=1, project=self.project.get_id(), wait_on_close=True,
+                return_handler=True
+            ) as up:
+                up.enqueue_file("plain_file", plain_file, skip_compress=True)
+                up.enqueue_file("zip_file", to_zip_file)
+                up.enqueue_list(
+                    "tar_file", to_tar_filenames, archive=True, remote_prefix="test"
+                )
+                up.enqueue_dict(dict_files, skip_compress=True)
+                result = up.wait()
+
+            self.assertEqual(5, len(result))
+            self.assertEqual(
+                {"plain_file", "zip_file", "tar_file", "dict_file_0", "dict_file_1"},
+                set(result.keys())
+            )
+            for key, val in result.items():
+                self.assertIsInstance(val, dxpy.DXFile)
+
+            self.assertEqual("test0", result["plain_file"].read())
+
+            for i in range(2):
+                self.assertEqual(
+                    "test{}".format(i),
+                    result["dict_file_{}".format(i)].read()
+                )
+
+            self._assert_tar_equal(result["tar_file"], to_tar_filenames)
+
+
+class TestDownload(unittest.TestCase):
+    project = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.project = dxpy.DXProject()
+        cls.project.new(name=random_name())
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.project.destroy()
+
+    def setUp(self):
+        self.folder = random_name("/{}")
+        self.project.new_folder(self.folder)
+
+    def tearDown(self):
+        self.project.remove_folder(self.folder, recurse=True)
+
+    def _upload_file(self, filename):
+        return dxpy.upload_local_file(
+            filename,
+            wait_on_close=True,
+            project=self.project.get_id(),
+            folder=self.folder
+        )
+
+    def _upload_simple_file(self, filename="test.txt"):
+        with isolated_dir():
+            with open(filename, "wt") as out:
+                out.write("test")
+            return self._upload_file(filename)
+
+    def _upload_zip_file(self):
+        with isolated_dir():
+            with gzip.open("test.txt.gz", "wt") as out:
+                out.write("test")
+            return self._upload_file("test.txt.gz")
+
+    def _upload_tar_file(self, compress=False):
+        if compress:
+            tar_filename = "test.tar.gz"
+            opts = "czf"
+        else:
+            tar_filename = "test.tar"
+            opts = "cf"
+        with isolated_dir():
+            filenames = make_random_files(2)
+            run("tar {} {} {}".format(opts, tar_filename, " ".join(filenames)))
+            return filenames, self._upload_file(tar_filename)
+
+    def test_simple_download_file(self):
+        handler = self._upload_simple_file()
+        with isolated_dir():
+            xfer.simple_download_file(handler, "test")
+            with open("test", "rt") as inp:
+                self.assertEqual("test", inp.read())
+
+    def test_download_and_decompress_file(self):
+        handler = self._upload_zip_file()
+        with isolated_dir():
+            unpacked_file = xfer.download_and_decompress_file(handler)
+            with open(unpacked_file, "rt") as inp:
+                self.assertEqual("test", inp.read())
+
+    def test_download_and_unpack_archive(self):
+        for compress in (True, False):
+            tar_filenames, handler = self._upload_tar_file(compress=compress)
+            with isolated_dir():
+                unpacked_filenames = xfer.download_and_unpack_archive(handler)
+                self.assertEqual(2, len(unpacked_filenames))
+                self.assertSetEqual(
+                    set(os.path.abspath(path) for path in tar_filenames),
+                    set(unpacked_filenames)
+                )
+                for i, fname in enumerate(tar_filenames):
+                    with open(fname, "rt") as inp:
+                        self.assertEqual("test{}".format(i), inp.read())
+
+    def test_downloader(self):
+        simple_handler1 = self._upload_simple_file("test1.txt")
+        simple_handler2 = self._upload_simple_file("test2.txt")
+        zip_handler = self._upload_zip_file()
+        tar_filenames, tar_handler = self._upload_tar_file()
+
+        with isolated_dir():
+            with xfer.Downloader(max_parallel=1, project=self.project.get_id()) as down:
+                down.enqueue_list("simple", [simple_handler1, simple_handler2])
+                down.enqueue_dict({
+                    "zip": zip_handler,
+                    "tar": tar_handler
+                })
+                result = down.wait()
+
+            self.assertIn("zip", result)
+            with open(result["zip"], "rt") as inp:
+                self.assertEqual("test", inp.read())
+
+            self.assertIn("simple", result)
+            for i, fname in enumerate(result["simple"]):
+                with open(fname, "rt") as inp:
+                    self.assertEqual("test".format(i), inp.read())
+
+            self.assertIn("tar", result)
+            unpacked_filenames = result["tar"]
+            self.assertEqual(2, len(unpacked_filenames))
+            self.assertSetEqual(
+                set(os.path.abspath(path) for path in tar_filenames),
+                set(unpacked_filenames)
+            )
+            for i, fname in enumerate(tar_filenames):
+                with open(fname, "rt") as inp:
+                    self.assertEqual("test{}".format(i), inp.read())

--- a/src/python/test/sugar/test_transfers.py
+++ b/src/python/test/sugar/test_transfers.py
@@ -114,8 +114,8 @@ class TestUpload(unittest.TestCase):
 
             handler = xfer.simple_upload_file(
                 filename,
-                remote_filename=remote_filename,
-                remote_folder=self.folder,
+                name=remote_filename,
+                folder=self.folder,
                 project=self.project.get_id(),
                 return_handler=True,
                 wait_on_close=True
@@ -133,8 +133,8 @@ class TestUpload(unittest.TestCase):
             try:
                 handler = xfer.compress_and_upload_file(
                     filename,
-                    remote_filename=remote_filename,
-                    remote_folder=self.folder,
+                    name=remote_filename,
+                    folder=self.folder,
                     project=self.project.get_id(),
                     return_handler=True,
                     wait_on_close=True
@@ -154,10 +154,10 @@ class TestUpload(unittest.TestCase):
             remote_prefix = random_name()
             remote_filename = "{}.tar.gz".format(remote_prefix)
 
-            handler = xfer.archive_and_upload_files(
+            handler = xfer.tar_and_upload_files(
                 filenames,
-                remote_prefix=remote_prefix,
-                remote_folder=self.folder,
+                prefix=remote_prefix,
+                folder=self.folder,
                 return_handler=True,
                 project=self.project.get_id(),
                 wait_on_close=True
@@ -188,7 +188,7 @@ class TestUpload(unittest.TestCase):
                 up.enqueue_file("plain_file", plain_file, skip_compress=True)
                 up.enqueue_file("zip_file", to_zip_file)
                 up.enqueue_list(
-                    "tar_file", to_tar_filenames, archive=True, remote_prefix="test"
+                    "tar_file", to_tar_filenames, archive=True, prefix="test"
                 )
                 up.enqueue_dict(dict_files, skip_compress=True)
                 result = up.wait()


### PR DESCRIPTION
This new branch is based on SCI-1321, rather than master.

* Add quote and makedirs to dxpy.compat
* Most of the changes suggested in #508 are implemented. Some exceptions:
    * The tmpfile contextmanager cannot be replaced by tempfile.TemporaryFile. It is needed in situations where the tempfile needs to be written from python and then closed and read from the subprocess.
    * I am still using dx commands for file upload and download when compression/decompression is involved. The python implementations of compression libraries are at least 2x slower than the system commands.
    * Regarding use of bash shell for subprocesses, see comment here: https://github.com/dnanexus/dx-toolkit/pull/508#discussion_r270569217
    * Regarding use of *args for passing commands, see comment here: https://github.com/dnanexus/dx-toolkit/pull/508#discussion_r269405402
    * For --buffer-size, I get the max value from project.describe(), but I also limit it to a max of 2GB - 1, due to a macOS bug that prevents read() from taking any value larger than that.