### PR TITLE
DEVEX-1005 Decrease libcurl timeout

### DIFF
--- a/src/cpp/SimpleHttpLib/SimpleHttp.cpp
+++ b/src/cpp/SimpleHttpLib/SimpleHttp.cpp
@@ -276,9 +276,6 @@ namespace dx {
       // Make a copy of reqData, because read_callback (see HTTP_PUT case below) will modify it
       reqData_struct reqData_temp;
 
-      std::cout << "METHOD USED: " << method << " \n";
-      std::cout << "CURLOPT_URL USED: " << url.c_str() << " \n";
-
       // Set timeout to 15 minutes. It can be overriden for each method separately
       assertLibCurlFunctions(curl_easy_setopt(curl, CURLOPT_TIMEOUT, 900l));
 

--- a/src/cpp/SimpleHttpLib/SimpleHttp.cpp
+++ b/src/cpp/SimpleHttpLib/SimpleHttp.cpp
@@ -276,8 +276,8 @@ namespace dx {
       // Make a copy of reqData, because read_callback (see HTTP_PUT case below) will modify it
       reqData_struct reqData_temp;
 
-      // Set timeout to 15 minutes. It can be overriden for each method separately
-      assertLibCurlFunctions(curl_easy_setopt(curl, CURLOPT_TIMEOUT, 900l));
+      // Set max time the request is allowed to take. It can be overriden for each method separately
+      assertLibCurlFunctions(curl_easy_setopt(curl, CURLOPT_TIMEOUT, 600l));
 
       switch (method) {
         case HTTP_POST:
@@ -302,7 +302,7 @@ namespace dx {
             /** set data object to pass to callback function */
             assertLibCurlFunctions(curl_easy_setopt(curl, CURLOPT_READDATA, &reqData_temp));
           }
-          assertLibCurlFunctions(curl_easy_setopt(curl, CURLOPT_TIMEOUT, 1800l));
+          assertLibCurlFunctions(curl_easy_setopt(curl, CURLOPT_TIMEOUT, 900l));
           break;
         case HTTP_GET:
           assertLibCurlFunctions(curl_easy_setopt(curl, CURLOPT_HTTPGET, 1l));

--- a/src/cpp/SimpleHttpLib/SimpleHttp.cpp
+++ b/src/cpp/SimpleHttpLib/SimpleHttp.cpp
@@ -302,7 +302,6 @@ namespace dx {
             /** set data object to pass to callback function */
             assertLibCurlFunctions(curl_easy_setopt(curl, CURLOPT_READDATA, &reqData_temp));
           }
-          assertLibCurlFunctions(curl_easy_setopt(curl, CURLOPT_TIMEOUT, 900l));
           break;
         case HTTP_GET:
           assertLibCurlFunctions(curl_easy_setopt(curl, CURLOPT_HTTPGET, 1l));

--- a/src/cpp/SimpleHttpLib/SimpleHttp.cpp
+++ b/src/cpp/SimpleHttpLib/SimpleHttp.cpp
@@ -279,7 +279,7 @@ namespace dx {
       std::cout << "METHOD USED: " << method << " \n";
       std::cout << "CURLOPT_URL USED: " << url.c_str() << " \n";
 
-      // Set timeout to 30 minutes. It can be overriden for each method separately
+      // Set timeout to 15 minutes. It can be overriden for each method separately
       assertLibCurlFunctions(curl_easy_setopt(curl, CURLOPT_TIMEOUT, 900l));
 
       switch (method) {

--- a/src/cpp/SimpleHttpLib/SimpleHttp.cpp
+++ b/src/cpp/SimpleHttpLib/SimpleHttp.cpp
@@ -242,8 +242,6 @@ namespace dx {
         }
       }
       respData = "";
-      // Set time out to infinite
-      assertLibCurlFunctions(curl_easy_setopt(curl, CURLOPT_TIMEOUT, 0l));
 
       /* Set the user agent - optional */
       assertLibCurlFunctions(curl_easy_setopt(curl, CURLOPT_USERAGENT, config::USER_AGENT_STRING().c_str()));
@@ -278,6 +276,12 @@ namespace dx {
       // Make a copy of reqData, because read_callback (see HTTP_PUT case below) will modify it
       reqData_struct reqData_temp;
 
+      std::cout << "METHOD USED: " << method << " \n";
+      std::cout << "CURLOPT_URL USED: " << url.c_str() << " \n";
+
+      // Set timeout to 30 minutes. It can be overriden for each method separately
+      assertLibCurlFunctions(curl_easy_setopt(curl, CURLOPT_TIMEOUT, 900l));
+
       switch (method) {
         case HTTP_POST:
           assertLibCurlFunctions(curl_easy_setopt(curl, CURLOPT_POST, 1L));
@@ -301,6 +305,7 @@ namespace dx {
             /** set data object to pass to callback function */
             assertLibCurlFunctions(curl_easy_setopt(curl, CURLOPT_READDATA, &reqData_temp));
           }
+          assertLibCurlFunctions(curl_easy_setopt(curl, CURLOPT_TIMEOUT, 1800l));
           break;
         case HTTP_GET:
           assertLibCurlFunctions(curl_easy_setopt(curl, CURLOPT_HTTPGET, 1l));

--- a/src/cpp/dxcpp/dxcpp.cc
+++ b/src/cpp/dxcpp/dxcpp.cc
@@ -269,7 +269,7 @@ namespace dx {
       assert(countTries < NUM_MAX_RETRIES);
 
       if (!reqCompleted) {
-        DXLOG(logWARNING) << "Unable to complete request: POST '" << url << "' (in retry #" << (countTries + 1) << "). Details: '" << hre.what() << "'";
+        DXLOG(logWARNING) << (unsigned long)time(NULL) << "; PID " << ::getpid() << "; Unable to complete request: POST '" << url << "' (in retry #" << (countTries + 1) << "). Details: '" << hre.what() << "'";
       }
       DXLOG(logWARNING) << "Waiting ... " << sec_to_wait << " seconds before retry " << (countTries + 1) << " of " << NUM_MAX_RETRIES << " ...";
       boost::this_thread::interruption_point();
@@ -295,7 +295,8 @@ namespace dx {
                        respJSON["error"]["type"].get<string>(),
                        req.responseCode);
     } else {
-      DXLOG(logERROR) << "Unable to complete request: POST '" << url << "' in '" << countTries << "' attempts." << endl;
+	
+      DXLOG(logERROR) << (unsigned long)time(NULL) << "; PID " << ::getpid() << "; Unable to complete request: POST '" << url << "' in '" << countTries << "' attempts." << endl;
       throw DXConnectionError("Was unable to make the request: POST '" + url + "' . Details: '" + hre.err + "'.", hre.errorCode);
     }
     // Unreachable line

--- a/src/cpp/dxcpp/dxcpp.cc
+++ b/src/cpp/dxcpp/dxcpp.cc
@@ -269,7 +269,7 @@ namespace dx {
       assert(countTries < NUM_MAX_RETRIES);
 
       if (!reqCompleted) {
-        DXLOG(logWARNING) << (unsigned long)time(NULL) << "; PID " << ::getpid() << "; Unable to complete request: POST '" << url << "' (in retry #" << (countTries + 1) << "). Details: '" << hre.what() << "'";
+        DXLOG(logWARNING) << (unsigned long)time(NULL) << " PID " << ::getpid() << " Unable to complete request: POST '" << url << "' (in retry #" << (countTries + 1) << "). Details: '" << hre.what() << "'";
       }
       DXLOG(logWARNING) << "Waiting ... " << sec_to_wait << " seconds before retry " << (countTries + 1) << " of " << NUM_MAX_RETRIES << " ...";
       boost::this_thread::interruption_point();
@@ -296,7 +296,7 @@ namespace dx {
                        req.responseCode);
     } else {
 	
-      DXLOG(logERROR) << (unsigned long)time(NULL) << "; PID " << ::getpid() << "; Unable to complete request: POST '" << url << "' in '" << countTries << "' attempts." << endl;
+      DXLOG(logERROR) << (unsigned long)time(NULL) << " PID " << ::getpid() << " Unable to complete request: POST '" << url << "' in '" << countTries << "' attempts." << endl;
       throw DXConnectionError("Was unable to make the request: POST '" + url + "' . Details: '" + hre.err + "'.", hre.errorCode);
     }
     // Unreachable line

--- a/src/ua/main.cpp
+++ b/src/ua/main.cpp
@@ -491,7 +491,8 @@ void uploadProgressHelper(vector<File> &files) {
     }
   }
   queueLock.unlock();
-  DXLOG(logUSERINFO) << "Transfer speed: Average  = " << setw(6) << setprecision(2) << std::fixed << mbps << " MB/sec " << "; Instantaneous = " << setw(6) << setprecision(2) << std::fixed << mbps2 << " MB/sec";
+    
+  DXLOG(logUSERINFO) << (unsigned long)time(NULL) << "; PID " << ::getpid() <<  "; Xfer speed: AVG  = " << setw(6) << setprecision(2) << std::fixed << mbps << " MB/sec " << "; INS = " << setw(6) << setprecision(2) << std::fixed << mbps2 << " MB/sec";
 
   if (opt.throttle >= 0) {
     DXLOG(logUSERINFO) << " (throttled to " << opt.throttle << " bytes/sec)";

--- a/src/ua/main.cpp
+++ b/src/ua/main.cpp
@@ -442,7 +442,7 @@ void updateFileState(vector<File> &files) {
 
 void waitOnClose(vector<File> &files) {
   do {
-    boost::this_thread::sleep(boost::posix_time::milliseconds(10000));
+    boost::this_thread::sleep(boost::posix_time::milliseconds(1000));
     updateFileState(files);
   } while (!allFilesDone(files));
 }

--- a/src/ua/main.cpp
+++ b/src/ua/main.cpp
@@ -492,8 +492,7 @@ void uploadProgressHelper(vector<File> &files) {
   }
   queueLock.unlock();
     
-  DXLOG(logUSERINFO) << (unsigned long)time(NULL) << " PID " << ::getpid() <<  " Xfer speed: AVG  = " << setw(6) << setprecision(2) << std::fixed << mbps << " MB/sec " << " INS = " << setw(6) << setprecision(2) << std::fixed << mbps2 << " MB/sec";
-
+  DXLOG(logUSERINFO) << (unsigned long)time(NULL) << " PID " << ::getpid() <<  " Transfer speed: average = " << setw(6) << setprecision(2) << std::fixed << mbps << " MB/sec " << " instantaneous = " << setw(6) << setprecision(2) << std::fixed << mbps2 << " MB/sec";
   if (opt.throttle >= 0) {
     DXLOG(logUSERINFO) << " (throttled to " << opt.throttle << " bytes/sec)";
   }
@@ -503,7 +502,7 @@ void uploadProgress(vector<File> &files) {
   try {
     do {
       uploadProgressHelper(files);
-      boost::this_thread::sleep(boost::posix_time::milliseconds(1000));
+      boost::this_thread::sleep(boost::posix_time::milliseconds(10000));
     } while (keepShowingUploadProgress);
     uploadProgressHelper(files);
     return;
@@ -964,7 +963,7 @@ int main(int argc, char * argv[]) {
       if (files[i].failed) {
         DXLOG(logUSERINFO) << "File \""<< files[i].localFile << "\" could not be uploaded." << endl;
       } else {
-        DXLOG(logUSERINFO) << "File \"" << files[i].localFile << "\" was uploaded successfully. Closing..." << endl;
+        DXLOG(logUSERINFO) << (unsigned long)time(NULL) << " PID " << ::getpid() << " File \"" << files[i].localFile << "\" was uploaded successfully. Closing...";
         if (files[i].isRemoteFileOpen) {
           files[i].close();
         }
@@ -978,6 +977,7 @@ int main(int argc, char * argv[]) {
     DXLOG(logINFO) << "Joining wait-on-close thread...";
     waitOnCloseThread.join();
     DXLOG(logINFO) << "Wait-on-close thread finished.";
+    DXLOG(logUSERINFO) << (unsigned long)time(NULL) << " PID " << ::getpid() << " ... all files closed.";
     if (anyImportAppToBeCalled) {
       runImportApps(opt, files);
     }

--- a/src/ua/main.cpp
+++ b/src/ua/main.cpp
@@ -492,7 +492,7 @@ void uploadProgressHelper(vector<File> &files) {
   }
   queueLock.unlock();
     
-  DXLOG(logUSERINFO) << (unsigned long)time(NULL) << "; PID " << ::getpid() <<  "; Xfer speed: AVG  = " << setw(6) << setprecision(2) << std::fixed << mbps << " MB/sec " << "; INS = " << setw(6) << setprecision(2) << std::fixed << mbps2 << " MB/sec";
+  DXLOG(logUSERINFO) << (unsigned long)time(NULL) << " PID " << ::getpid() <<  " Xfer speed: AVG  = " << setw(6) << setprecision(2) << std::fixed << mbps << " MB/sec " << " INS = " << setw(6) << setprecision(2) << std::fixed << mbps2 << " MB/sec";
 
   if (opt.throttle >= 0) {
     DXLOG(logUSERINFO) << " (throttled to " << opt.throttle << " bytes/sec)";

--- a/src/ua/main.cpp
+++ b/src/ua/main.cpp
@@ -397,7 +397,7 @@ void uploadChunks(vector<File> &files) {
 
 void monitor() {
   while (true) {
-    boost::this_thread::sleep(boost::posix_time::milliseconds(1000));
+    boost::this_thread::sleep(boost::posix_time::milliseconds(10000));
     {
       DXLOG(logINFO) << "[monitor]"
           << "  to read: " << chunksToRead.size()
@@ -442,7 +442,7 @@ void updateFileState(vector<File> &files) {
 
 void waitOnClose(vector<File> &files) {
   do {
-    boost::this_thread::sleep(boost::posix_time::milliseconds(1000));
+    boost::this_thread::sleep(boost::posix_time::milliseconds(10000));
     updateFileState(files);
   } while (!allFilesDone(files));
 }

--- a/src/ua/main.cpp
+++ b/src/ua/main.cpp
@@ -467,8 +467,7 @@ void uploadProgressHelper(vector<File> &files) {
   int64_t timediff  = std::time(0) - startTime;
   double mbps = (timediff > 0) ? (double(bytesUploadedSinceStart) / (1024.0 * 1024.0)) / timediff : 0.0;
   boLock.unlock();
-  DXLOG(logUSERINFO) << " ... Average transfer speed = " << setw(6) << setprecision(2) << std::fixed << mbps << " MB/sec";
-
+ 
   // Print instantaneous transfer rate
   boost::mutex::scoped_lock queueLock(instantaneousBytesMutex);
   double mbps2 = 0.0;
@@ -492,7 +491,7 @@ void uploadProgressHelper(vector<File> &files) {
     }
   }
   queueLock.unlock();
-  DXLOG(logUSERINFO) << " ... Instantaneous transfer speed = " << setw(6) << setprecision(2) << std::fixed << mbps2 << " MB/sec";
+  DXLOG(logUSERINFO) << "Transfer speed: Average  = " << setw(6) << setprecision(2) << std::fixed << mbps << " MB/sec " << "; Instantaneous = " << setw(6) << setprecision(2) << std::fixed << mbps2 << " MB/sec";
 
   if (opt.throttle >= 0) {
     DXLOG(logUSERINFO) << " (throttled to " << opt.throttle << " bytes/sec)";


### PR DESCRIPTION
A libcurl's option [CURLOPT_TIMEOUT](https://curl.haxx.se/libcurl/c/CURLOPT_TIMEOUT.html) was set to infinity for the cpp bindings http requests. This was causing UA to hang instead of timing out and retrying sending another request to the API server. This setting doesn't affect the libcurl session used for uploading chunk data [here](https://github.com/dnanexus/dx-toolkit/blob/0b85ce034e48f3a5c6f6e993b2f681af32d0848a/src/ua/chunk.cpp#L360). 

I set it to 15 minutes by default and 30 for PUT (potentially used by the binding's upload) though from a quick search I cannot find where HTTP_PUT might be used: https://github.com/dnanexus/dx-toolkit/search?q=HTTP_PUT&unscoped_q=HTTP_PUT