### PR TITLE
TIP-1021: support for passing httpcontext to execute operation.

### DIFF
--- a/src/java/src/main/java/com/dnanexus/DXHTTPRequest.java
+++ b/src/java/src/main/java/com/dnanexus/DXHTTPRequest.java
@@ -29,6 +29,8 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.BasicHttpContext;
 
 import com.dnanexus.exceptions.DXAPIException;
 import com.dnanexus.exceptions.DXHTTPException;
@@ -164,6 +166,12 @@ public class DXHTTPRequest {
     }
 
     /**
+     * Allows custom HttpContext to setup overridden http. parameters
+     * e.g. http.conn-manager.timeout for PoolingHttpClientConnectionManager
+     */
+    protected HttpContext getHttpContext() { return new BasicHttpContext(); }
+
+    /**
      * Issues a request against the specified resource (assuming requests ARE safe to be retried)
      * and returns the result as a JSON object.
      *
@@ -289,7 +297,7 @@ public class DXHTTPRequest {
                 // TODO: distinguish between errors during connection init and socket errors while
                 // sending or receiving data. The former can always be retried, but the latter can
                 // only be retried if the request is idempotent.
-                HttpResponse response = getHttpClient().execute(request);
+                HttpResponse response = getHttpClient().execute(request, getHttpContext());
 
                 statusCode = response.getStatusLine().getStatusCode();
                 requestId = getHeader(response, "X-Request-ID");


### PR DESCRIPTION
Allows derived implementations to override with custom timeouts etc.

Apollo HTTP client for apiserver uses http-commons PoolingHttpClientConnectionManager which allows client to throw ConnectionTimeoutException if timeout exceeds. The timeout is passed by overridden method in derived instance of DXHttpRequest class.

See https://github.com/dnanexus/nucleus/pull/2773