### PR TITLE
DEVEX-1116 Reduce the number of API calls for dx download

### DIFF
--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -692,5 +692,10 @@ def download_folder(project, destdir, folder="/", overwrite=False, chunksize=dxf
                      ("" if remote_file['describe']['folder'] == "/" else remote_file['describe']['folder']),
                      remote_file['describe']['name'],
                      local_filename)
-        download_dxfile(remote_file['describe']['id'], local_filename, chunksize=chunksize, project=project,
-                        show_progress=show_progress, describe_output=remote_file['describe'], **kwargs)
+        download_dxfile(remote_file['describe']['id'],
+                        local_filename,
+                        chunksize=chunksize,
+                        project=project,
+                        show_progress=show_progress,
+                        describe_output=remote_file['describe'],
+                        **kwargs)

--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -108,8 +108,9 @@ def download_dxfile(dxid, filename, chunksize=dxfile.DEFAULT_BUFFER_SIZE, append
             DXFile.NO_PROJECT_HINT, no project hint is supplied to the API server.
     :type project: str or None
     :param describe_output: output of the file-xxxx/describe API call, if available.
-            It will make it possible to skip another describe API call (though only
-            if it contains the "parts" field, not included in the output by default).
+            It will make it possible to skip one describe API call. It should
+            contain the default fields of the describe API call output and the
+            "parts" field, not included in the output by default.
     :type describe_output: dict or None
 
     Downloads the remote file referenced by *dxid* and saves it to *filename*.

--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -668,7 +668,13 @@ def download_folder(project, destdir, folder="/", overwrite=False, chunksize=dxf
         ensure_local_dir(compose_local_dir(normalized_dest_dir, normalized_folder, remote_subfolder))
 
     # Downloading files
-    describe_input = dict(fields=dict(folder=True, name=True, id=True, parts=True))
+    describe_input = dict(fields=dict(folder=True,
+                                      name=True,
+                                      id=True,
+                                      parts=True,
+                                      size=True,
+                                      drive=True,
+                                      md5=True))
 
     # A generator that returns the files one by one. We don't want to materialize it, because
     # there could be many files here.

--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -263,10 +263,10 @@ def _download_dxfile(dxid, filename, part_retry_counter,
         dxfile = DXFile(dxid, mode="r", project=(project if project != DXFile.NO_PROJECT_HINT else None))
 
     # 
-    if describe_output and describe_output.get('parts') is None:    
-        dxfile_desc = dxfile.describe(fields={"parts"}, default_fields=True, **kwargs)
-    else:
+    if describe_output and describe_output.get("parts") is not None:
         dxfile_desc = describe_output
+    else:
+        dxfile_desc = dxfile.describe(fields={"parts"}, default_fields=True, **kwargs)
 
     if 'drive' in dxfile_desc:
         # A symbolic link. Get the MD5 checksum, if we have it

--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -107,10 +107,10 @@ def download_dxfile(dxid, filename, chunksize=dxfile.DEFAULT_BUFFER_SIZE, append
             which billing account is billed for this download). If None or
             DXFile.NO_PROJECT_HINT, no project hint is supplied to the API server.
     :type project: str or None
-    :param describe_output: output of the file-xxxx/describe API call, if available.
-            It will make it possible to skip one describe API call. It should
-            contain the default fields of the describe API call output and the
-            "parts" field, not included in the output by default.
+    :param describe_output: (experimental) output of the file-xxxx/describe API call,
+            if available. It will make it possible to skip another describe API call.
+            It should contain the default fields of the describe API call output and
+            the "parts" field, not included in the output by default.
     :type describe_output: dict or None
 
     Downloads the remote file referenced by *dxid* and saves it to *filename*.

--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -95,7 +95,7 @@ def new_dxfile(mode=None, write_buffer_size=dxfile.DEFAULT_BUFFER_SIZE, expected
 
 
 def download_dxfile(dxid, filename, chunksize=dxfile.DEFAULT_BUFFER_SIZE, append=False, show_progress=False,
-                    project=None, **kwargs):
+                    project=None, describe_output=None, **kwargs):
     '''
     :param dxid: DNAnexus file ID or DXFile (file handler) object
     :type dxid: string or DXFile
@@ -120,9 +120,15 @@ def download_dxfile(dxid, filename, chunksize=dxfile.DEFAULT_BUFFER_SIZE, append
     part_retry_counter = defaultdict(lambda: 3)
     success = False
     while not success:
-        success = _download_dxfile(dxid, filename, part_retry_counter,
-                                   chunksize=chunksize, append=append,
-                                   show_progress=show_progress, project=project, **kwargs)
+        success = _download_dxfile(dxid,
+                                   filename,
+                                   part_retry_counter,
+                                   chunksize=chunksize,
+                                   append=append,
+                                   show_progress=show_progress,
+                                   project=project,
+                                   describe_output=describe_output,
+                                   **kwargs)
 
 
 # Check if a program (wget, curl, etc.) is on the path, and
@@ -214,7 +220,7 @@ def _download_symbolic_link(dxid, md5digest, project, dest_filename):
 
 def _download_dxfile(dxid, filename, part_retry_counter,
                      chunksize=dxfile.DEFAULT_BUFFER_SIZE, append=False, show_progress=False,
-                     project=None, **kwargs):
+                     project=None, describe_output=None, **kwargs):
     '''
     Core of download logic. Download file-id *dxid* and store it in
     a local file *filename*.
@@ -256,9 +262,12 @@ def _download_dxfile(dxid, filename, part_retry_counter,
     else:
         dxfile = DXFile(dxid, mode="r", project=(project if project != DXFile.NO_PROJECT_HINT else None))
 
-    dxfile_desc = dxfile.describe(fields={"parts"}, default_fields=True, **kwargs)
+    # 
+    if describe_output and describe_output.get('parts') is None:    
+        dxfile_desc = dxfile.describe(fields={"parts"}, default_fields=True, **kwargs)
+    else:
+        dxfile_desc = describe_output
 
-    from pprint import pprint
     if 'drive' in dxfile_desc:
         # A symbolic link. Get the MD5 checksum, if we have it
         if 'md5' in dxfile_desc:

--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -266,10 +266,8 @@ def _download_dxfile(dxid, filename, part_retry_counter,
         dxfile = DXFile(dxid, mode="r", project=(project if project != DXFile.NO_PROJECT_HINT else None))
 
     if describe_output and describe_output.get("parts") is not None:
-        print("\n>>>>>>>>> Reusing describe\n")
         dxfile_desc = describe_output
     else:
-        print("\n>>>>>>>>> NOT Reusing describe\n")
         dxfile_desc = dxfile.describe(fields={"parts"}, default_fields=True, **kwargs)
 
     if 'drive' in dxfile_desc:
@@ -670,9 +668,6 @@ def download_folder(project, destdir, folder="/", overwrite=False, chunksize=dxf
 
     # Downloading files
     describe_input = dict(fields=dict(folder=True, name=True, id=True, parts=True))
-    print("-----------------------")
-    print(describe_input)
-    print("-----------------------")
 
     # A generator that returns the files one by one. We don't want to materialize it, because
     # there could be many files here.

--- a/src/python/dxpy/cli/download.py
+++ b/src/python/dxpy/cli/download.py
@@ -158,6 +158,10 @@ def download(args):
         if args.all or _is_glob(path):
             resolver_kwargs.update({'allow_mult': True, 'all_mult': True})
 
+        # include "parts" in the description so that we don't
+        # have to call a separate describe method downstream
+        resolver_kwargs.update({"describe": {"parts": True}})
+
         project, folderpath, matching_files = try_call(resolve_existing_path, path, **resolver_kwargs)
 
         from pprint import pprint

--- a/src/python/dxpy/cli/download.py
+++ b/src/python/dxpy/cli/download.py
@@ -164,8 +164,6 @@ def download(args):
 
         project, folderpath, matching_files = try_call(resolve_existing_path, path, **resolver_kwargs)
 
-        from pprint import pprint
-        pprint(matching_files)
         if matching_files is None:
             matching_files = []
         elif not isinstance(matching_files, list):

--- a/src/python/dxpy/cli/download.py
+++ b/src/python/dxpy/cli/download.py
@@ -203,6 +203,9 @@ def download(args):
 
         # If the user explicitly provided the project and it doesn't contain
         # the files, don't allow the download.
+
+        # For speed's sake, skip this check (i.e. one API call) if the user
+        # passed the lightweight argument
         #
         # If length of matching_files is 0 then we're only downloading folders
         # so skip this logic since the files will be verified in the API call.

--- a/src/python/dxpy/cli/download.py
+++ b/src/python/dxpy/cli/download.py
@@ -158,9 +158,12 @@ def download(args):
         if args.all or _is_glob(path):
             resolver_kwargs.update({'allow_mult': True, 'all_mult': True})
 
-        # include "parts" in the description so that we don't
-        # have to call a separate describe method downstream
-        resolver_kwargs.update({"describe": {"parts": True}})
+        # include "parts" and a few additional fields in the description so that
+        # we don't have to call a separate describe method downstream
+        resolver_kwargs.update({"describe": {"parts": True,
+                                             "size": True,
+                                             "drive": True,
+                                             "md5": True}})
 
         project, folderpath, matching_files = try_call(resolve_existing_path, path, **resolver_kwargs)
 

--- a/src/python/dxpy/cli/download.py
+++ b/src/python/dxpy/cli/download.py
@@ -69,6 +69,7 @@ def _verify(filename, md5digest):
 
 
 def download_one_file(project, file_desc, dest_filename, args):
+    "Calling download_one_file"
     if not args.overwrite:
         if os.path.exists(dest_filename):
             err_exit(fill('Error: path "' + dest_filename + '" already exists but -f/--overwrite was not set'))
@@ -87,7 +88,12 @@ def download_one_file(project, file_desc, dest_filename, args):
         show_progress = False
 
     try:
-        dxpy.download_dxfile(file_desc['id'], dest_filename, show_progress=show_progress, project=project)
+        dxpy.download_dxfile(
+                            file_desc['id'],
+                            dest_filename,
+                            show_progress=show_progress,
+                            project=project,
+                            describe_output=file_desc)
         return
     except:
         err_exit()
@@ -154,6 +160,9 @@ def download(args):
             resolver_kwargs.update({'allow_mult': True, 'all_mult': True})
 
         project, folderpath, matching_files = try_call(resolve_existing_path, path, **resolver_kwargs)
+
+        from pprint import pprint
+        pprint(matching_files)
         if matching_files is None:
             matching_files = []
         elif not isinstance(matching_files, list):
@@ -166,7 +175,6 @@ def download(args):
         if is_jbor_str(path):
             assert len(matching_files) == 1
             project = matching_files[0]["describe"]["project"]
-
         matching_folders = []
         # project may be none if path is an ID and there is no project context
         if project is not None:
@@ -195,14 +203,15 @@ def download(args):
         #
         # If length of matching_files is 0 then we're only downloading folders
         # so skip this logic since the files will be verified in the API call.
-        if len(matching_files) > 0 and path_has_explicit_proj and not \
-                any(object_exists_in_project(f['describe']['id'], project) for f in matching_files):
-            err_exit(fill('Error: specified project does not contain specified file object'))
+        if not args.lightweight \
+            and len(matching_files) > 0 \
+            and path_has_explicit_proj \
+            and not any(object_exists_in_project(f['describe']['id'], project) for f in matching_files):
+                err_exit(fill('Error: specified project does not contain specified file object'))
 
         files_to_get[project].extend(matching_files)
         folders_to_get[project].extend(((f, strip_prefix) for f in matching_folders))
         count += len(matching_files) + len(matching_folders)
-
         filenames.extend(f["describe"]["name"] for f in matching_files)
         foldernames.extend(f[len(strip_prefix):].lstrip('/') for f in matching_folders)
 

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -4167,6 +4167,8 @@ parser_download.add_argument('-a', '--all', help='If multiple objects match the 
                              action='store_true')
 parser_download.add_argument('--no-progress', help='Do not show a progress bar', dest='show_progress',
                              action='store_false', default=sys.stderr.isatty())
+parser_download.add_argument('--lightweight', help='Skip some validation steps to make fewer API calls',
+                             action='store_true')
 parser_download.add_argument('--unicode', help='Display the characters as text/unicode when writing to stdout',
                              dest="unicode_text", action='store_true')
 parser_download.set_defaults(func=download_or_cat)

--- a/src/python/dxpy/utils/resolver.py
+++ b/src/python/dxpy/utils/resolver.py
@@ -1055,8 +1055,6 @@ def resolve_existing_path(path, expected=None, ask_to_resolve=True, expected_cla
     NOTE: if expected_classes is provided and conflicts with the class
     of the hash ID, it will return None for all fields.
     '''
-    if describe:
-        describe = {"parts": True}
     project, folderpath, entity_name = resolve_path(path, expected=expected, allow_empty_string=allow_empty_string)
     must_resolve, project, folderpath, entity_name = _check_resolution_needed(path,
                                                                               project,

--- a/src/python/dxpy/utils/resolver.py
+++ b/src/python/dxpy/utils/resolver.py
@@ -1055,6 +1055,8 @@ def resolve_existing_path(path, expected=None, ask_to_resolve=True, expected_cla
     NOTE: if expected_classes is provided and conflicts with the class
     of the hash ID, it will return None for all fields.
     '''
+    if describe:
+        describe = {"parts": True}
     project, folderpath, entity_name = resolve_path(path, expected=expected, allow_empty_string=allow_empty_string)
     must_resolve, project, folderpath, entity_name = _check_resolution_needed(path,
                                                                               project,


### PR DESCRIPTION
This reduces the # of calls from 5 (below) to 2 for one file download (3 if not counting this [PR](https://github.com/dnanexus/dx-toolkit/pull/503)).

- `findDataObjects()` already returns descriptions of the objects to be downloaded. The field "parts" needs to be included in the descriptions for file objects downstream (for which we were making another `describe` call). I now request "parts" to be included in file describes when `resolve_existing_path()` is called from `download()` functions.
- folder resolution is skipped [here](https://github.com/dnanexus/dx-toolkit/pull/503)
- I also skip a check on whether the file is actually in the project, if the project was explicitly named (it is skipped when `args.lightweight` is used)

In this example the calls  1, 2, 3 will not be made with this update:

![image](https://user-images.githubusercontent.com/2283292/56685564-0f9bd600-6687-11e9-8174-eab654abaec4.png)

Tests passed.
