### PR TITLE
DEVEX-1067 Fix upload issue via proxy in Azure

### DIFF
--- a/src/python/dxpy/__init__.py
+++ b/src/python/dxpy/__init__.py
@@ -622,6 +622,7 @@ def DXHTTPRequest(resource, data, method='POST', headers=None, auth=True,
                     # This is needed for python 3 urllib
                     _headers.pop(b'host', None)
                     _headers.pop(b'content-length', None)
+                    _headers.pop(b'Content-Length', None)
 
                     # The libraries downstream (http client) require elimination of non-ascii
                     # chars from URL.


### PR DESCRIPTION
The header we are getting from Azure as an output from the initial [ file-xxxx/upload](https://wiki.dnanexus.com/API-Specification-v1.0.0/Files#API-method:-/file-xxxx/upload) contains these fields:

```
{'Content-Length': '100663296',
 'Content-MD5': 'PaoHSrYPnhEqtVPEp5doKg==',
 'x-ms-blob-type': 'BlockBlob',
 'x-ms-date': 'Mon, 06 May 2019 18:44:24 GMT'}
```

A corresponding header from AWS:

```
{'host': 'dnanexus-platform-upload-prod.s3.amazonaws.com',
 'content-type': 'binary/octet-stream',
 'x-amz-server-side-encryption':  ‘AES256', 
 'content-md5': 'PaoHSrYPnhEqtVPEp5doKg==',
 'content-length': '100663296'}
```

For urllib3 with Python3 we need to remove some of the fields, including content length, before sending the header with the request uploading a file part.


