### PR TITLE
DEVEX-1101 Provide project ID for make_download_url

### DIFF
--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -1714,11 +1714,11 @@ def make_download_url(args):
     try:
         dxfile = dxpy.DXFile(entity_result['id'], project=project)
         # Only provide project ID, not job workspace container ID
-        project = project if re.match(r"^project-[a-zA-Z0-9]{24}$", project) else dxpy.DXFile.NO_PROJECT_HINT
+        project = dxfile.project if re.match(r"^project-[a-zA-Z0-9]{24}$", dxfile.project) else dxpy.DXFile.NO_PROJECT_HINT
         url, _headers = dxfile.get_download_url(preauthenticated=True,
                                                 duration=normalize_timedelta(args.duration)//1000 if args.duration else 24*3600,
                                                 filename=args.filename,
-                                                project=dxpy.DXFile.NO_PROJECT_HINT)
+                                                project=project)
         print(url)
     except:
         err_exit()

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -1713,6 +1713,8 @@ def make_download_url(args):
     # TODO: how to do data egress billing for make_download_url?
     try:
         dxfile = dxpy.DXFile(entity_result['id'], project=project)
+        # Only provide project ID, not job workspace container ID
+        project = project if re.match(r"^project-[a-zA-Z0-9]{24}$", project) else dxpy.DXFile.NO_PROJECT_HINT
         url, _headers = dxfile.get_download_url(preauthenticated=True,
                                                 duration=normalize_timedelta(args.duration)//1000 if args.duration else 24*3600,
                                                 filename=args.filename,

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -9123,8 +9123,8 @@ def main(in1):
         published_desc = json.loads(run("dx describe {} --json".format(desc['id'])))
         self.assertTrue("published" in published_desc)
 
-        "with self.assertSubprocessFailure(stderr_regexp="InvalidState",
-                                          exit_code=3):"
+        with self.assertSubprocessFailure(stderr_regexp="InvalidState",
+                                          exit_code=3):
             run("dx publish {name}/{version}".format(name=app_name, version="2.0.0"))
 
 


### PR DESCRIPTION
Provide the project ID for `make_download_url` unless it is a job workspace or app container. Originally this was set to `None` in https://github.com/dnanexus/dx-toolkit/commit/b5c82db4afdda20f7a778fef1457314130cf118c but this should still allow those links to work.