### PR TITLE
Remove xrange() for Python 3 compatibility

### DIFF
--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -549,7 +549,7 @@ def upload_local_file(filename=None, file=None, media_type=None, keep_open=False
                         multithread=multithread,
                         **remaining_kwargs)
 
-        for i in xrange(MAX_RETRIES_PART_UPLOAD):
+        for i in range(MAX_RETRIES_PART_UPLOAD):
             try:
                 upload_part()
                 break


### PR DESCRIPTION
Swap `xrange()` for `range()` since that is what it was renamed to in Python 3.