### PR TITLE
DEVEX-1186 Fix autocompletion in worker environment

### DIFF
--- a/environment
+++ b/environment
@@ -47,16 +47,16 @@ export DNANEXUS_HOME="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 PYTHON_VERSION_NUMBER="$(python -c 'import sys; print("{}.{}".format(sys.version_info[0], sys.version_info[1]))')"
 PYTHON_VERSION="python${PYTHON_VERSION_NUMBER}"
-
 # Detect system installation of dx-toolkit
 if [ "$DNANEXUS_HOME" = "/etc/profile.d" ]; then
-
+  ARGCOMPLETE_REGISTER_PATH="/usr/bin/register-python-argcomplete"
   export DNANEXUS_HOME="/usr/share/dnanexus"
   # Private Python packages. We really ought not pollute PYTHONPATH with these though.
   export PYTHONPATH="/usr/share/dnanexus/lib/${PYTHON_VERSION}/site-packages:$PYTHONPATH"
   export CLASSPATH="/usr/share/java/dnanexus-api-0.1.0.jar:${CLASSPATH}"
 
 else
+  ARGCOMPLETE_REGISTER_PATH="${DNANEXUS_HOME}/bin/register-python-argcomplete"
   export PATH="${DNANEXUS_HOME}/bin:$PATH"
   export CLASSPATH="${DNANEXUS_HOME}/lib/java/*:${CLASSPATH}"
 
@@ -72,8 +72,8 @@ fi
 # encoding. We reset it here to avoid having to set it for every I/O operation explicitly.
 export PYTHONIOENCODING=UTF-8
 
-if [ -e ${DNANEXUS_HOME}/bin/register-python-argcomplete ]; then
-    eval "$(${DNANEXUS_HOME}/bin/register-python-argcomplete dx|sed 's/-o default//')"
+if [ -e ${ARGCOMPLETE_REGISTER_PATH} ]; then
+    eval "$(${ARGCOMPLETE_REGISTER_PATH} dx|sed 's/-o default//')"
 fi
 
 # Clean up old session files


### PR DESCRIPTION
`register-python-argcomplete` resides in `/usr/bin` where dx-toolkit is installed via debian package as in the worker environment.