### PR TITLE
DEVEX-1206 require futures backport only in python2.7

### DIFF
--- a/src/mk/Makefile.windows
+++ b/src/mk/Makefile.windows
@@ -35,7 +35,7 @@ pynsist_installer: toolkit_version $(DNANEXUS_HOME)/bin/dx dx-verify-file jq
 	    cp "$(DNANEXUS_HOME)"/src/python/dist/$${DXPY_WHEEL_FILENAME} "$(DNANEXUS_HOME)"/build/pynsist_files/
 
 	# Download the .whl files for each of dxpy's Python dependencies, to bundle with NSIS installer
-	unset PYTHONPATH; source "$(DX_PY_ENV)/$(ACTIVATE)"; mkdir -p "$(DNANEXUS_HOME)"/build/pynsist_files/wheelfile_depends; python -m pip install --download "$(DNANEXUS_HOME)"/build/pynsist_files/wheelfile_depends -r python/requirements.txt -r python/requirements_backports.txt -r python/requirements_windows.txt
+	unset PYTHONPATH; source "$(DX_PY_ENV)/$(ACTIVATE)"; mkdir -p "$(DNANEXUS_HOME)"/build/pynsist_files/wheelfile_depends; python -m pip download "$(DNANEXUS_HOME)"/build/pynsist_files/wheelfile_depends -r python/requirements.txt -r python/requirements_backports.txt -r python/requirements_windows.txt
 
 	# Insert the wheel filename into installer.cfg
 	export DXPY_WHEEL_FILENAME=$$(basename $(DNANEXUS_HOME)/src/python/dist/dxpy-*.whl) ; \

--- a/src/mk/Makefile.windows
+++ b/src/mk/Makefile.windows
@@ -35,7 +35,7 @@ pynsist_installer: toolkit_version $(DNANEXUS_HOME)/bin/dx dx-verify-file jq
 	    cp "$(DNANEXUS_HOME)"/src/python/dist/$${DXPY_WHEEL_FILENAME} "$(DNANEXUS_HOME)"/build/pynsist_files/
 
 	# Download the .whl files for each of dxpy's Python dependencies, to bundle with NSIS installer
-	unset PYTHONPATH; source "$(DX_PY_ENV)/$(ACTIVATE)"; mkdir -p "$(DNANEXUS_HOME)"/build/pynsist_files/wheelfile_depends; python -m pip download "$(DNANEXUS_HOME)"/build/pynsist_files/wheelfile_depends -r python/requirements.txt -r python/requirements_backports.txt -r python/requirements_windows.txt
+	unset PYTHONPATH; source "$(DX_PY_ENV)/$(ACTIVATE)"; mkdir -p "$(DNANEXUS_HOME)"/build/pynsist_files/wheelfile_depends; python -m pip download --dest "$(DNANEXUS_HOME)"/build/pynsist_files/wheelfile_depends -r python/requirements.txt -r python/requirements_backports.txt -r python/requirements_windows.txt
 
 	# Insert the wheel filename into installer.cfg
 	export DXPY_WHEEL_FILENAME=$$(basename $(DNANEXUS_HOME)/src/python/dist/dxpy-*.whl) ; \

--- a/src/python/requirements_backports.txt
+++ b/src/python/requirements_backports.txt
@@ -1,2 +1,2 @@
-futures>=3.2
+futures>=3.2; python_version == "2.7"
 backports.ssl_match_hostname==3.5.0.1

--- a/src/python/requirements_setuptools.txt
+++ b/src/python/requirements_setuptools.txt
@@ -1,3 +1,3 @@
-pip==9.0.1
-setuptools==19.4
-wheel==0.26.0
+pip==19.0.1
+setuptools==41.0.1
+wheel==0.33.4


### PR DESCRIPTION
**Motivation**

The [`futures` backport](https://pypi.org/project/futures/) dependency should only be required in python2.7. 

**Changes**

This PR updates the backports requirements to specify a conditional dependency for `python` == "2.7".