### PR TITLE
DEVEX-1205 xattr properties on dx-upload-all-outputs

### DIFF
--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -6,3 +6,4 @@ beautifulsoup4==4.4.1
 psutil>=3.3.0
 requests>=2.8.0
 cryptography<=2.2.2
+xattr==0.9.6

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -7,3 +7,4 @@ psutil>=3.3.0
 requests>=2.8.0
 cryptography<=2.2.2
 xattr==0.9.6
+cffi==1.12.3

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -6,5 +6,4 @@ beautifulsoup4==4.4.1
 psutil>=3.3.0
 requests>=2.8.0
 cryptography<=2.2.2
-xattr==0.9.6
-cffi==1.12.3
+xattr==0.9.6; sys_platform == 'linux2' or sys_platform == 'linux'

--- a/src/python/scripts/dx-upload-all-outputs
+++ b/src/python/scripts/dx-upload-all-outputs
@@ -291,7 +291,7 @@ def create_entry(subdir_desc, local_path, target_path, basename):
             'fname': basename,
             'dxlink': None}
 
-def return_xatrr_as_properties(file):
+def return_xattr_as_properties(file):
     properties = {}
     for attribute in xattr.listxattr(file):
         if attribute.startswith('user.'):
@@ -303,7 +303,7 @@ def upload_one_file(entry, wait_on_close, xattr_properties):
     uploaded object in the entry.
     '''
     local_path = os.path.join(entry['local_dir_path'], entry['fname'])
-    properties = return_xatrr_as_properties(local_path) if xattr_properties is not None else {}
+    properties = return_xattr_as_properties(local_path) if xattr_properties is not None else {}
     if entry['target_dir_path'] is None:
         trg_path = "/{}".format(entry['fname'])
         print("uploading file: {} -> {}".format(local_path, trg_path))

--- a/src/python/scripts/dx-upload-all-outputs
+++ b/src/python/scripts/dx-upload-all-outputs
@@ -38,6 +38,7 @@ import stat
 import sys
 import json
 import argparse
+import xattr
 import dxpy
 from dxpy.utils import file_load_utils
 from dxpy.utils.printing import fill, refill_paragraphs, BOLD, RED
@@ -92,6 +93,8 @@ parser.add_argument("--wait-on-close", help="Wait for files to close, default is
                     action="store_true",
                     default=False,
                     dest="wait_on_close")
+parser.add_argument("--xattr-properties", help="Get filesystem attributes and set them as properties on each file uploaded", 
+                    action="store_true")
 args = parser.parse_args()
 parser.parse_args()
 max_num_parallel_uploads = 8
@@ -288,35 +291,42 @@ def create_entry(subdir_desc, local_path, target_path, basename):
             'fname': basename,
             'dxlink': None}
 
-def upload_one_file(entry, wait_on_close):
+def return_xatrr_as_properties(file):
+    properties = {}
+    for attribute in xattr.listxattr(file):
+        properties[attribute.lstrip('user.')] = xattr.getxattr(file, attribute)
+    return properties
+
+def upload_one_file(entry, wait_on_close, xattr_properties):
     '''Upload a file from the output directory. Record a reference to the
     uploaded object in the entry.
     '''
     local_path = os.path.join(entry['local_dir_path'], entry['fname'])
+    properties = return_xatrr_as_properties(local_path) if xattr_properties is not None else {}
     if entry['target_dir_path'] is None:
         trg_path = "/{}".format(entry['fname'])
         print("uploading file: {} -> {}".format(local_path, trg_path))
         sys.stdout.flush()
-        f_obj = dxpy.upload_local_file(local_path, wait_on_close=wait_on_close)
+        f_obj = dxpy.upload_local_file(local_path, wait_on_close=wait_on_close, properties=properties)
     else:
         trg_path = "/{}/{}".format(entry['target_dir_path'], entry['fname'])
         print("uploading file: {} -> {}".format(local_path, trg_path))
         sys.stdout.flush()
         f_obj = dxpy.upload_local_file(local_path,
                                        folder=("/" + entry['target_dir_path']),
-                                       parents=True, wait_on_close=wait_on_close)
+                                       parents=True, wait_on_close=wait_on_close, properties=properties)
     entry['dxlink'] = dxpy.dxlink(f_obj)
 
-def sequential_file_upload(to_upload, wait_on_close):
+def sequential_file_upload(to_upload, wait_on_close, xattr_properties):
     '''Sequentially upload everything that is in the output directory.
     '''
     for entry in to_upload:
-        upload_one_file(entry, wait_on_close)
+        upload_one_file(entry, wait_on_close, xattr_properties)
 
-def parallel_file_upload(to_upload, wait_on_close):
+def parallel_file_upload(to_upload, wait_on_close, xattr_properties):
     ''' same as sequential_file_upload, but in parallel '''
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_num_parallel_uploads) as executor:
-        future_files = {executor.submit(upload_one_file, e, wait_on_close): e for e in to_upload}
+        future_files = {executor.submit(upload_one_file, e, wait_on_close, xattr_properties): e for e in to_upload}
         for future in concurrent.futures.as_completed(future_files):
             entry = future_files[future]
             try:
@@ -415,9 +425,9 @@ for key in subdir_recs:
 
 # upload concurrently
 if args.parallel:
-    parallel_file_upload(to_upload, args.wait_on_close)
+    parallel_file_upload(to_upload, args.wait_on_close, args.xattr_properties)
 else:
-    sequential_file_upload(to_upload, args.wait_on_close)
+    sequential_file_upload(to_upload, args.wait_on_close, args.xattr_properties)
 
 # Uploads are complete, we can collect all results. This avoids
 # data races in the parallel upload case.

--- a/src/python/scripts/dx-upload-all-outputs
+++ b/src/python/scripts/dx-upload-all-outputs
@@ -294,7 +294,8 @@ def create_entry(subdir_desc, local_path, target_path, basename):
 def return_xatrr_as_properties(file):
     properties = {}
     for attribute in xattr.listxattr(file):
-        properties[attribute.lstrip('user.')] = xattr.getxattr(file, attribute)
+        if attribute.startswith('user.'):
+            properties[attribute.lstrip('user.')] = xattr.getxattr(file, attribute)
     return properties
 
 def upload_one_file(entry, wait_on_close, xattr_properties):

--- a/src/python/test/file_load/xattr_properties/README.md
+++ b/src/python/test/file_load/xattr_properties/README.md
@@ -1,0 +1,1 @@
+This test checks that dx-upload-all-outputs works correctly with filesystem xattr. 

--- a/src/python/test/file_load/xattr_properties/dxapp.json
+++ b/src/python/test/file_load/xattr_properties/dxapp.json
@@ -6,7 +6,7 @@
     "interpreter": "bash",
     "distribution": "Ubuntu",
     "release": "16.04",
-    "execDepends": [{"name": "attr", "package_manager": "apt"}]
+    "execDepends": [{"name": "attr", "package_manager": "apt"}, {"name": "libffi-dev", "package_manager": "apt"}]
   },
   "inputSpec": [
     {"name": "seq1", "class": "file"},

--- a/src/python/test/file_load/xattr_properties/dxapp.json
+++ b/src/python/test/file_load/xattr_properties/dxapp.json
@@ -1,0 +1,25 @@
+{ "name": "xattr_properties",
+  "title": "xattr_properties",
+  "summary" : "Tests dx-upload-all-outputs uploading with filesystem metadata as properties",
+  "runSpec": {
+    "file": "run.sh",
+    "interpreter": "bash",
+    "distribution": "Ubuntu",
+    "release": "16.04",
+    "execDepends": [{"name": "attr", "package_manager": "apt"}]
+  },
+  "inputSpec": [
+    {"name": "seq1", "class": "file"},
+    {"name": "seq2", "class": "file"},
+    {"name": "ref",  "class": "array:file"}
+  ],
+  "outputSpec": [
+    {"name": "result1", "class": "file"},
+    {"name": "result2", "class": "file"},
+    {"name": "result3", "class": "file"},
+    {"name": "result4", "class": "file"}
+  ],
+  "access": {
+    "network": ["*"]
+  }
+}

--- a/src/python/test/file_load/xattr_properties/run.sh
+++ b/src/python/test/file_load/xattr_properties/run.sh
@@ -28,6 +28,7 @@ main() {
 
 function compare_xattr_to_properties()
 {
+    set -x
     files=$(find "out" -type f)
     for f in $files
     do

--- a/src/python/test/file_load/xattr_properties/run.sh
+++ b/src/python/test/file_load/xattr_properties/run.sh
@@ -1,0 +1,78 @@
+main() {
+    # parallel download
+    dx-download-all-inputs --parallel
+
+    # creating some output results
+    echo "ABCD" > dummy_data.txt
+    mkdir -p out
+    dirs="result1 result2 result3 result4"
+    keys="key1 "
+
+    for d in $dirs
+    do
+        mkdir -p out/$d
+        cp dummy_data.txt out/$d/$d
+        attr -s "key0" -V "val0" out/$d/$d
+        attr -s "key1" -V "val1" out/$d/$d
+    done
+
+    # sequential upload with metadata as properties
+    dx-upload-all-outputs --sequential --wait-on-close --xattr-properties
+    compare_xattr_to_properties
+    remove_uploaded_files
+
+    # parallel upload with metadata as properties
+    dx-upload-all-outputs --clearJSON=true --parallel --wait-on-close --xattr-properties
+    compare_xattr_to_properties
+}
+
+function compare_xattr_to_properties()
+{
+    files=$(find "out" -type f)
+    for f in $files
+    do
+        echo "f=$f"
+        basename=${f##*/}
+        properties=$(dx describe --json $basename | jq -r .properties)
+        [[ "val0" == $(echo $properties | jq -r .key0) ]]
+        [[ "val1" == $(echo $properties | jq -r .key1) ]]
+    done
+
+# download files uploaded from the "out" directory, and compare
+# against the originals
+function compare_upload_to_outdir()
+{
+    files=$(find "out" -type f)
+
+    mkdir -p tmp
+    for f in $files
+    do
+        basename=${f##*/}
+
+        # ensure the file is closed before downloading it
+        dx wait "$basename"
+        dx download "$basename" -o tmp/"$basename"
+        DIFF=$(diff out/$basename/$basename tmp/$basename)
+        if [ "$DIFF" != "" ]
+        then
+            echo "Error in upload, file $basename is incorrect"
+            exit 1
+        fi
+    done
+
+    rm -rf tmp
+}
+
+
+function remove_uploaded_files()
+{
+    files=$(find "out" -type f)
+
+    for f in $files
+    do
+        echo "f=$f"
+        basename=${f##*/}
+
+        dx rm $basename
+    done
+}

--- a/src/python/test/file_load/xattr_properties/run.sh
+++ b/src/python/test/file_load/xattr_properties/run.sh
@@ -37,6 +37,7 @@ function compare_xattr_to_properties()
         [[ "val0" == $(echo $properties | jq -r .key0) ]]
         [[ "val1" == $(echo $properties | jq -r .key1) ]]
     done
+}
 
 # download files uploaded from the "out" directory, and compare
 # against the originals

--- a/src/python/test/test_dx_bash_helpers.py
+++ b/src/python/test/test_dx_bash_helpers.py
@@ -252,6 +252,25 @@ class TestDXBashHelpers(DXTestCase):
             cmd_args.extend(applet_args)
             run(cmd_args, env=env)
 
+    def test_xattr_parameters(self):
+        ''' Tests dx-upload-all-outputs uploading with filesystem metadata as properties '''
+        with temporary_project('TestDXBashHelpers.test_app1 temporary project') as dxproj:
+            env = update_environ(DX_PROJECT_CONTEXT_ID=dxproj.get_id())
+
+            # Upload some files for use by the applet
+            dxpy.upload_string("1234\n", project=dxproj.get_id(), name="A.txt")
+            dxpy.upload_string("ABCD\n", project=dxproj.get_id(), name="B.txt")
+
+            # Build the applet, patching in the bash helpers from the
+            # local checkout
+            applet_id = build_app_with_bash_helpers(os.path.join(TEST_APPS, 'xattr_properties'), dxproj.get_id())
+
+            # Run the applet
+            applet_args = ["-iseq1=A.txt", "-iseq2=B.txt", "-iref=A.txt", "-iref=B.txt"]
+            cmd_args = ['dx', 'run', '--yes', '--watch', applet_id]
+            cmd_args.extend(applet_args)
+            run(cmd_args, env=env)
+
     @unittest.skipUnless(testutil.TEST_RUN_JOBS, 'skipping test that would run a job')
     def test_file_optional(self):
         ''' Tests that optional and non-optional file output arguments are


### PR DESCRIPTION
Add a new parameter `--xattr-properties` to `dx-upload-all-outputs`. If this argument is passed, read filesystem metadata and set `k,v` properties for each file uploaded, stripping the `user.` prefix from the key. Some additional checks may be required to make sure only user attributes are set as properties.

Add `xattr` as a dependency Linux builds of dx-toolkit, other distributions do not require it since this script only runs inside the DNAnexus execution environment.
