### PR TITLE
Update find_projects() documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,5 @@ test-job-workspaces
 
 # artifacts from tracibility
 *.traceability.*.csv
+
+.vscode/

--- a/src/python/dxpy/bindings/search.py
+++ b/src/python/dxpy/bindings/search.py
@@ -445,6 +445,7 @@ def find_projects(name=None, name_mode='exact', properties=None, tags=None,
     :param tags: Tags that each result must have
     :type tags: list of strings
     :param level: One of "VIEW", "UPLOAD", "CONTRIBUTE", or "ADMINSTER". If specified, only returns projects where the current user has at least the specified permission level.
+        If not specified the default value is "CONTRIBUTE" for the API method /system/findProjects
     :type level: string
     :param describe: Controls whether to also return the output of
         calling describe() on each project. Supply False to omit


### PR DESCRIPTION
Note that "CONTRIBUTE" is the default `level` for `/system/findProjects` if not provided to the API method.