### PR TITLE
Fix for bug #537

### DIFF
--- a/src/python/dxpy/sugar/__init__.py
+++ b/src/python/dxpy/sugar/__init__.py
@@ -15,23 +15,33 @@
 #   under the License.
 import dxpy
 from functools import wraps
+#
+# from processing import run_cmd, chain_cmds
+# from transfers import (
+#     Uploader,
+#     Downloader,
+#     upload_file,
+#     tar_and_upload_files,
+#     download_file,
+# )
 
-from processing import run_cmd, chain_cmds
-from transfers import (
-    Uploader,
-    Downloader,
-    upload_file,
-    tar_and_upload_files,
-    download_file,
-)
+
+def in_worker_context():
+    return dxpy.JOB_ID is not None
+
 
 def requires_worker_context(func):
-    """This decorator checks that a given function is running within a DNAnexus job context"""
+    """This decorator checks that a given function is running within a DNAnexus job
+    context.
+    """
     @wraps(func)
     def check_job_id(*args, **kwargs):
-        if dxpy.JOB_ID is None:
-            raise dxpy.DXError("Illegal function call, must be called from within DNAnexus job context.")
-        else:
+        if in_worker_context():
             return func(*args, **kwargs)
+        else:
+            raise dxpy.DXError(
+                "Illegal function call, must be called from within DNAnexus job "
+                "context."
+            )
 
     return check_job_id

--- a/src/python/dxpy/sugar/transfers.py
+++ b/src/python/dxpy/sugar/transfers.py
@@ -141,7 +141,7 @@ def simple_upload_file(
     if return_handler:
         return handler
     else:
-        return dxpy.dxlink(handler.get_id(), handler.describe()["project"])
+        return _file_handler_as_link(handler)
 
 
 def compress_and_upload_file(
@@ -392,12 +392,21 @@ def _wrap_file_id(file_id, return_handler, project=None):
         else:
             raise ValueError("Invalid file ID: {}".format(file_id))
 
-    dxlink = dxpy.dxlink(file_id, project_id=project)
+    handler = dxpy.DXFile(file_id, project=project)
 
     if return_handler:
-        return dxpy.DXFile(dxlink)
+        return handler
     else:
-        return dxlink
+        return _file_handler_as_link(handler)
+
+
+def _file_handler_as_link(dxfile):
+    file_id = dxfile.get_id()
+    project = dxfile.describe()["project"]
+    if project is None or not project.startswith("project-"):
+        return dxpy.dxlink(file_id)
+    else:
+        return dxpy.dxlink(file_id, project_id=project)
 
 
 def download_file(


### PR DESCRIPTION
Fix for SCI-1867. When running in a job context, the project ID of an uploaded file (e.g. from dxpy.upload_local_file) will be a container ID, not the project ID. In this case, we do not want to generate fully-qualified links.