### PR TITLE
Sci 1986 fix filename regular expression

### DIFF
--- a/src/python/dxpy/sugar/transfers.py
+++ b/src/python/dxpy/sugar/transfers.py
@@ -64,7 +64,8 @@ from dxpy.sugar import processing as proc
 
 
 LOG = logging.getLogger()
-SPECIAL_RE = re.compile(r"[^\w.]")
+SPECIAL_RE = re.compile(r"[^\w-.]")
+"""Used based on recommendation here: https://superuser.com/a/748264/70028."""
 MAX_READ_SIZE = (1024 * 1024 * 1024 * 2) - 1
 """Maximum number of bytes that can be read from a file at once. The limit here is
 due to a known bug in some versions of python on macOS:


### PR DESCRIPTION
When the user does not provide a local filename to use with the dxpy.sugar.transfer.download* functions, we use the filename of the remote file, but we remove "unsafe" characters. The regular expression for identifying unsafe characters was missing '-'. The new regular expression is `r"[^\w-.]"`.