### PR TITLE
DEVEX-1248 Update app wizard with v2 instance types

### DIFF
--- a/src/python/dxpy/cli/parsers.py
+++ b/src/python/dxpy/cli/parsers.py
@@ -228,7 +228,7 @@ class PrintInstanceTypeHelp(argparse.Action):
         print()
         print(fill('A single instance type can be requested to be used by all entry points by providing the instance type name.  Different instance types can also be requested for different entry points of an app or applet by providing a JSON string mapping from function names to instance types, e.g.'))
         print()
-        print('    {"main": "mem2_hdd2_x2", "other_function": "mem2_hdd2_x1"}')
+        print('    {"main": "mem2_hdd2_v2_x2", "other_function": "mem1_ssd1_v2_x2"}')
         if parser.prog == 'dx run':
             print()
             print(fill('If running a workflow, different stages can have different instance type ' +
@@ -238,11 +238,11 @@ class PrintInstanceTypeHelp(argparse.Action):
                        'identifier is provided, the value is applied as a default for all stages.'))
             print()
             print(fill('The following example runs all entry points of the first stage with ' +
-                       'mem2_hdd2_x2, the stage named "BWA" with mem2_hdd2_x1, and all other ' +
-                       'stages with mem2_hdd2_x4'))
+                       'mem2_hdd2_v2_x2, the stage named "BWA" with mem1_ssd1_v2_x2, and all other ' +
+                       'stages with mem2_hdd2_v2_x4'))
             print()
-            print('    Example: dx run workflow --instance-type 0=mem2_hdd2_x2 \\')
-            print('               --instance-type BWA=mem2_hdd2_x1 --instance-type mem2_hdd2_x4')
+            print('    Example: dx run workflow --instance-type 0=mem2_hdd2_v2_x2 \\')
+            print('               --instance-type BWA=mem1_ssd1_v2_x2 --instance-type mem2_hdd2_v2_x4')
         print()
         print('Available instance types:')
         print()

--- a/src/python/dxpy/utils/completer.py
+++ b/src/python/dxpy/utils/completer.py
@@ -477,7 +477,7 @@ class InstanceTypesCompleter():
               InstanceTypeSpec('mem3_hdd2_v2_x4', 32.0, 1000, 4),
               InstanceTypeSpec('mem3_hdd2_v2_x8', 64.0, 2000, 8)):
         instance_types[i.Name] = i
-    default_instance_type = aws_preferred_instance_types['mem1_ssd1_x4']
+    default_instance_type = aws_preferred_instance_types['mem1_ssd1_v2_x4']
     instance_type_names = instance_types.keys()
 
     def complete(self, text, state):

--- a/src/python/dxpy/utils/completer.py
+++ b/src/python/dxpy/utils/completer.py
@@ -469,16 +469,13 @@ class InstanceTypesCompleter():
     instance_types.update(aws_preferred_instance_types)
     instance_types.update(azure_preferred_instance_types)
 
-    for i in (InstanceTypeSpec('mem1_hdd2_x8', 7.0, 1680, 8),
-              InstanceTypeSpec('mem1_hdd2_x32', 60.5, 3360, 32),
+    for i in (
+              InstanceTypeSpec('mem2_hdd2_v2_x2', 8.0, 1000, 2),
+              InstanceTypeSpec('mem2_hdd2_v2_x4', 16.0, 2000, 4),
 
-              InstanceTypeSpec('mem2_hdd2_x1', 3.8, 410, 1),
-              InstanceTypeSpec('mem2_hdd2_x2', 7.5, 840, 2),
-              InstanceTypeSpec('mem2_hdd2_x4', 15.0, 1680, 4),
-
-              InstanceTypeSpec('mem3_hdd2_x2', 17.1, 420, 2),
-              InstanceTypeSpec('mem3_hdd2_x4', 34.2, 850, 4),
-              InstanceTypeSpec('mem3_hdd2_x8', 68.4, 1680, 8)):
+              InstanceTypeSpec('mem3_hdd2_v2_x2', 16.0, 500, 2),
+              InstanceTypeSpec('mem3_hdd2_v2_x4', 32.0, 1000, 4),
+              InstanceTypeSpec('mem3_hdd2_v2_x8', 64.0, 2000, 8)):
         instance_types[i.Name] = i
     default_instance_type = aws_preferred_instance_types['mem1_ssd1_x4']
     instance_type_names = instance_types.keys()

--- a/src/python/dxpy/utils/completer.py
+++ b/src/python/dxpy/utils/completer.py
@@ -416,27 +416,28 @@ class InstanceTypesCompleter():
 
     # AWS
     aws_preferred_instance_types = OrderedDict()
-    for i in (InstanceTypeSpec('mem1_ssd1_x2', 3.8, 32, 2),
-              InstanceTypeSpec('mem1_ssd1_x4', 7.5, 80, 4),
-              InstanceTypeSpec('mem1_ssd1_x8', 15.0, 160, 8),
-              InstanceTypeSpec('mem1_ssd1_x16', 30.0, 320, 16),
+    for i in (InstanceTypeSpec('mem1_ssd1_v2_x2', 4.0, 47, 2),
+              InstanceTypeSpec('mem1_ssd1_v2_x4', 8.0, 93, 4),
+              InstanceTypeSpec('mem1_ssd1_v2_x8', 16.0, 186, 8),
+              InstanceTypeSpec('mem1_ssd1_v2_x16', 32.0, 372, 16),
               InstanceTypeSpec('mem1_ssd1_x32', 60.0, 640, 32),
+              InstanceTypeSpec('mem1_ssd1_v2_x36', 72.0, 837, 36),
 
-              InstanceTypeSpec('mem2_ssd1_x2', 7.5, 32, 2),
-              InstanceTypeSpec('mem2_ssd1_x4', 15.0, 80, 4),
-              InstanceTypeSpec('mem2_ssd1_x8', 30.0, 160, 8),
+              InstanceTypeSpec('mem2_ssd1_v2_x2', 8.0, 69, 2),
+              InstanceTypeSpec('mem2_ssd1_v2_x4', 16.0, 139, 4),
+              InstanceTypeSpec('mem2_ssd1_v2_x8', 32.0, 279, 8),
 
-              InstanceTypeSpec('mem3_ssd1_x2', 15.0, 32, 2),
-              InstanceTypeSpec('mem3_ssd1_x4', 30.5, 80, 4),
-              InstanceTypeSpec('mem3_ssd1_x8', 61.0, 160, 8),
-              InstanceTypeSpec('mem3_ssd1_x16', 122.0, 320, 16),
-              InstanceTypeSpec('mem3_ssd1_x32', 244.0, 640, 32),
+              InstanceTypeSpec('mem3_ssd1_v2_x2', 16.0, 69, 2),
+              InstanceTypeSpec('mem3_ssd1_v2_x4', 32.0, 139, 4),
+              InstanceTypeSpec('mem3_ssd1_v2_x8', 64.0, 279, 8),
+              InstanceTypeSpec('mem3_ssd1_v2_x16', 128.0, 558, 16),
+              InstanceTypeSpec('mem3_ssd1_v2_x32', 256.0, 1166, 32),
 
-              InstanceTypeSpec('mem1_ssd2_x2', 3.8, 160, 2),
-              InstanceTypeSpec('mem1_ssd2_x4', 7.5, 320, 4),
-              InstanceTypeSpec('mem1_ssd2_x8', 15, 640, 8),
-              InstanceTypeSpec('mem1_ssd2_x16', 30, 1280, 16),
-              InstanceTypeSpec('mem1_ssd2_x36', 60, 2880, 36)):
+              InstanceTypeSpec('mem1_ssd2_v2_x2', 4.0, 160, 2),
+              InstanceTypeSpec('mem1_ssd2_v2_x4', 8.0, 320, 4),
+              InstanceTypeSpec('mem1_ssd2_v2_x8', 16.0, 640, 8),
+              InstanceTypeSpec('mem1_ssd2_v2_x16', 32.0, 1280, 16),
+              InstanceTypeSpec('mem1_ssd2_v2_x36', 72.0, 2880, 36)):
         aws_preferred_instance_types[i.Name] = i
 
     # Azure


### PR DESCRIPTION
Use the v2 instance types by default for `dx-app-wizard`. Removed some older HDD instance types which are outdated.