### PR TITLE
PTFM-24811 Remove Project Describe Archival Fields

### DIFF
--- a/src/python/dxpy/utils/describe.py
+++ b/src/python/dxpy/utils/describe.py
@@ -410,8 +410,7 @@ def print_project_desc(desc, verbose=False):
         'id', 'class', 'name', 'summary', 'description', 'protected', 'restricted', 'created', 'modified',
         'dataUsage', 'sponsoredDataUsage', 'tags', 'level', 'folders', 'objects', 'permissions', 'properties',
         'appCaches', 'billTo', 'version', 'createdBy', 'totalSponsoredEgressBytes', 'consumedSponsoredEgressBytes',
-        'containsPHI', 'region', 'storageCost', 'pendingTransfer', 'archivalState', 'atSpendingLimit',
-        'archivalProgress',
+        'containsPHI', 'region', 'storageCost', 'pendingTransfer','atSpendingLimit',
         # Following are app container-specific
         'destroyAt', 'project', 'type', 'app', 'appName'
     ]
@@ -445,10 +444,6 @@ def print_project_desc(desc, verbose=False):
         print_json_field("Restricted", desc["restricted"])
     if 'containsPHI' in desc:
         print_json_field('Contains PHI', desc['containsPHI'])
-    if 'archivalState' in desc and verbose:
-        print_field('Archival state', desc['archivalState'])
-    if 'archivalProgress' in desc and verbose:
-        print_json_field('Archival progress', desc['archivalProgress'])
 
     # Usage
     print_field("Created", render_timestamp(desc['created']))

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -633,8 +633,6 @@ class TestDXClient(DXTestCase):
         self.assertRegex(desc_output, field_regexp("Name", "dxclient_test_pröject"))
         self.assertRegex(desc_output, field_regexp("Region", "aws:us-east-1"))
         self.assertRegex(desc_output, field_regexp("Contains PHI", "false"))
-        self.assertNotRegex(desc_output, field_regexp("Archival state", "null"))
-        self.assertNotRegex(desc_output, field_regexp("Archival progress", "null"))
         self.assertRegex(desc_output, field_regexp("Data usage", "0.00 GB"))
         self.assertRegex(desc_output,
                          field_regexp("Storage cost", "$0.000/month"),
@@ -642,10 +640,6 @@ class TestDXClient(DXTestCase):
         self.assertRegex(desc_output, field_regexp("Sponsored egress", "0.00 GB used of 0.00 GB total"))
         self.assertRegex(desc_output, field_regexp("At spending limit?", "false"))
         self.assertRegex(desc_output, field_regexp("Properties", "-"))
-
-        desc_output = run("dx describe --verbose :").strip()
-        self.assertRegex(desc_output, field_regexp("Archival state", "live"))
-        self.assertRegex(desc_output, field_regexp("Archival progress", "null"))
 
     @pytest.mark.TRACEABILITY_MATRIX
     @testutil.update_traceability_matrix(["DNA_CLI_PROJ_DELETE","DNA_API_PROJ_DELETE_PROJECT"])


### PR DESCRIPTION
Remove archivalState and archivalProgress from project describe and tests.

Testing: `test_dx_describe_project`

Nucleus_Integration_Tests:
https://jenkins-vstg.internal.dnanexus.com/view/NucleusBuildCop/job/Nucleus/job/BuildSheriff/job/Nucleus_Integration_Tests/2172/