### PR TITLE
Bump version of cryptography dependency

### DIFF
--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -5,5 +5,5 @@ python-magic==0.4.6
 beautifulsoup4==4.4.1
 psutil>=3.3.0
 requests>=2.8.0
-cryptography<=2.2.2
+cryptography<=2.8.0
 xattr==0.9.6; sys_platform == 'linux2' or sys_platform == 'linux'


### PR DESCRIPTION
I received a security alert while using an older version of cryptography, and the source of this was due to an older dependency in dxpy. Also, other packages seem to have moved on to move their minimum version above 2.2.2, so this should fix dependency resolutions as well.