### PR TITLE
DEVEX-1443 fix java build

### DIFF
--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -83,22 +83,6 @@ stage 'Build'
                 deleteDir()
             }
         },
-        "precise-deb" : { 
-            node('master'){
-                deleteDir()
-               sh  """
-                    commit_hash=\"${env.commit_hash}\"
-                    working_dir=\$(pwd)
-                    mkdir -p \$working_dir/\$commit_hash/precise
-                    docker run -v \$working_dir/\$commit_hash/precise:/\$commit_hash/precise --rm dnanexus/dx-toolkit:12.04 \\
-                        /bin/bash -xc \"git clone https://github.com/dnanexus/dx-toolkit.git; \\
-                        cd dx-toolkit; git checkout \$commit_hash; build/build-dx-toolkit-debs.sh; \\
-                        mv /*.{changes,deb,dsc,tar.gz} /\$commit_hash/precise\"
-                    """
-                archive "${env.commit_hash}/precise/dx*"
-                deleteDir()
-            }
-        },
         "trusty-deb" : { 
             node('master'){
                 deleteDir()

--- a/src/java/m2-settings.xml
+++ b/src/java/m2-settings.xml
@@ -9,10 +9,4 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
   <localRepository>/tmp/dx-toolkit-m2/repository</localRepository>
-  <repositories>
-    <repository>
-        <id>central</id>
-        <urlhttps://repo.maven.apache.org/maven2/</url>
-    </repository>
-  </repositories>
 </settings>

--- a/src/java/m2-settings.xml
+++ b/src/java/m2-settings.xml
@@ -9,4 +9,10 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
   <localRepository>/tmp/dx-toolkit-m2/repository</localRepository>
+  <repositories>
+    <repository>
+        <id>central</id>
+        <urlhttps://repo.maven.apache.org/maven2/</url>
+    </repository>
+  </repositories>
 </settings>

--- a/src/java/pom.xml
+++ b/src/java/pom.xml
@@ -1,6 +1,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
+  <repositories>
+    <repository>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <layout>default</layout>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+  
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.dnanexus</groupId>
   <artifactId>dnanexus-api</artifactId>

--- a/src/java/pom.xml
+++ b/src/java/pom.xml
@@ -3,13 +3,8 @@
 
   <repositories>
     <repository>
-      <id>central</id>
-      <name>Central Repository</name>
+      <id>Maven-Central</id>
       <url>https://repo.maven.apache.org/maven2</url>
-      <layout>default</layout>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
     </repository>
   </repositories>
   

--- a/src/java/pom.xml
+++ b/src/java/pom.xml
@@ -1,12 +1,32 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-  <repositories>
+<repositories>
     <repository>
-        <id>central</id>
-        <urlhttps://repo.maven.apache.org/maven2/</url>
+      <id>central</id>
+      <name>Maven HTTPS</name>
+      <layout>default</layout>
+      <url>	https://repo1.maven.org/maven2</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
     </repository>
   </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>central</id>
+      <name>Maven Plugin Repository</name>
+      <url>	https://repo1.maven.org/maven2/</url>
+      <layout>default</layout>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <releases>
+        <updatePolicy>never</updatePolicy>
+      </releases>
+    </pluginRepository>
+  </pluginRepositories> 
   
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.dnanexus</groupId>

--- a/src/java/pom.xml
+++ b/src/java/pom.xml
@@ -3,8 +3,8 @@
 
   <repositories>
     <repository>
-      <id>Maven-Central</id>
-      <url>https://repo.maven.apache.org/maven2</url>
+        <id>central</id>
+        <urlhttps://repo.maven.apache.org/maven2/</url>
     </repository>
   </repositories>
   


### PR DESCRIPTION
Maven switched the central repository to disable HTTP. Update to the HTTPS repo and remove the failing precise-debian build target.