### PR TITLE
Fix python doc build

### DIFF
--- a/build/doc_build_requirements.txt
+++ b/build/doc_build_requirements.txt
@@ -1,3 +1,4 @@
+docutils<=0.15.2
 sphinx==1.2.3
 requests==2.20.0
 futures==2.2.0


### PR DESCRIPTION
Pin docutils <= 0.15.2 for version of sphinx.