### PR TITLE
DEVEX-1591: add dx-mount-all-inputs script (similar to dx-download-all-inputs)

### DIFF
--- a/src/python/dxpy/bindings/__init__.py
+++ b/src/python/dxpy/bindings/__init__.py
@@ -660,6 +660,7 @@ class DXDataObject(DXObject):
 from .dxfile import DXFile, DXFILE_HTTP_THREADS, DEFAULT_BUFFER_SIZE
 from .dxdatabase import DXDatabase, DXFILE_HTTP_THREADS, DEFAULT_BUFFER_SIZE
 from .download_all_inputs import download_all_inputs
+from .mount_all_inputs import mount_all_inputs
 from .dxfile_functions import open_dxfile, new_dxfile, download_dxfile, upload_local_file, upload_string, list_subfolders, download_folder
 from .dxdatabase_functions import download_dxdatabasefile
 from .dxrecord import DXRecord, new_dxrecord

--- a/src/python/dxpy/bindings/mount_all_inputs.py
+++ b/src/python/dxpy/bindings/mount_all_inputs.py
@@ -143,6 +143,9 @@ def mount_all_inputs(exclude=None):
     with open(mount_manifest_file, 'w') as mfile:
         json.dump(files_manifest, mfile)
 
+    dxfuse_version = subprocess.check_output([dxfuse_cmd, "-version"])
+    print("Using dxfuse version " + str(dxfuse_version))
+
     uid = str(int(subprocess.check_output(["id", "-u"])))
     gid = str(int(subprocess.check_output(["id", "-g"])))
     print(subprocess.check_output([dxfuse_cmd, "-uid", uid, "-gid", gid, mount_dir, mount_manifest_file]))

--- a/src/python/dxpy/bindings/mount_all_inputs.py
+++ b/src/python/dxpy/bindings/mount_all_inputs.py
@@ -18,8 +18,8 @@ from __future__ import print_function
 import subprocess
 import json
 import os
-import dxpy
 from dxpy.utils import file_load_utils
+from dxpy.exceptions import err_exit
 
 def _build_mount_manifest(to_mount):
     files_list = []
@@ -39,6 +39,15 @@ def _build_mount_manifest(to_mount):
     print(files_manifest)
     return files_manifest
 
+def _which(program):
+    def is_exe(fpath):
+        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+    for path in os.environ["PATH"].split(os.pathsep):
+        exe_file = os.path.join(path, program)
+        if is_exe(exe_file):
+            return exe_file
+    return None
 
 def _gen_helper_dict(filtered_inputs):
     '''
@@ -109,7 +118,9 @@ def mount_all_inputs(exclude=None):
     home_dir = os.environ["HOME"]
     mount_dir = os.path.join(home_dir, "in")
     mount_manifest_file = os.path.join(home_dir, "mount-manifest.json")
-    dxfuse_cmd = "/usr/bin/dxfuse"
+    dxfuse_cmd = _which("dxfuse")
+    if dxfuse_cmd is None:
+        err_exit("dxfuse is not installed on this system")
 
     subprocess.check_output(["mkdir", mount_dir])
 

--- a/src/python/dxpy/bindings/mount_all_inputs.py
+++ b/src/python/dxpy/bindings/mount_all_inputs.py
@@ -1,0 +1,147 @@
+# Copyright (C) 2014-2020 DNAnexus, Inc.
+#
+# This file is part of dx-toolkit (DNAnexus platform client libraries).
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#   use this file except in compliance with the License. You may obtain a copy
+#   of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+
+from __future__ import print_function
+import subprocess
+import json
+import os
+import dxpy
+from dxpy.utils import file_load_utils
+
+def _build_mount_manifest(to_mount):
+    files_list = []
+    for file_rec in to_mount:
+        file_entry = {}
+        file_handler = file_rec['handler']
+        file_entry['proj_id'] = file_handler.get_proj_id()
+        file_entry['file_id'] = file_rec['src_file_id']
+        file_name = file_rec['trg_fname']
+        k = file_name.rfind("/")
+        file_parent = file_name[:k]
+        file_entry['parent'] = "/in/" + file_parent
+        files_list.append(file_entry)
+    files_manifest = {}
+    files_manifest['Files'] = files_list
+    print("File mount manifest:")
+    print(files_manifest)
+    return files_manifest
+
+
+def _gen_helper_dict(filtered_inputs):
+    '''
+    Create a dict of values for the mounted files. This is similar to the variables created
+    when running a bash app.
+    '''
+
+    file_key_descs, _ignore = file_load_utils.analyze_bash_vars(
+        file_load_utils.get_input_json_file(), None)
+
+    flattened_dict = {}
+
+    def add_if_no_collision(key, value, dict_):
+        if key not in dict_:
+            dict_[key] = value
+
+    for input_ in filtered_inputs:
+        if input_ not in file_key_descs:
+            continue
+        input_var_dict = file_key_descs[input_]
+        add_if_no_collision(input_ + '_path', input_var_dict["path"], flattened_dict)
+        add_if_no_collision(input_ + '_name', input_var_dict["basename"], flattened_dict)
+        add_if_no_collision(input_ + '_prefix', input_var_dict["prefix"], flattened_dict)
+
+    return flattened_dict
+
+
+def mount_all_inputs(exclude=None):
+    '''
+    :param exclude: List of input variables that should not be mounted.
+    :type exclude: Array of strings
+    :returns: dict of lists of strings where each key is the input variable
+                and each list element is the full path to the file that has
+                been mounted.
+
+    This function mounts all files that were supplied as inputs to the app.
+    By convention, if an input parameter "FOO" has value
+
+        {"$dnanexus_link": "file-xxxx"}
+
+    and filename INPUT.TXT, then the linked file will be mounted into the
+    path:
+
+        $HOME/in/FOO/INPUT.TXT
+
+    If an input is an array of files, then all files will be placed into
+    numbered subdirectories under a parent directory named for the
+    input. For example, if the input key is FOO, and the inputs are {A, B,
+    C}.vcf then, the directory structure will be:
+
+        $HOME/in/FOO/0/A.vcf
+                     1/B.vcf
+                     2/C.vcf
+
+    Zero padding is used to ensure argument order. For example, if there are
+    12 input files {A, B, C, D, E, F, G, H, I, J, K, L}.txt, the directory
+    structure will be:
+
+        $HOME/in/FOO/00/A.vcf
+                     ...
+                     11/L.vcf
+
+    This allows using shell globbing (FOO/*/*.vcf) to get all the files in the input
+    order and prevents issues with files which have the same filename.'''
+
+    print("Mounting inputs...")
+
+    home_dir = os.environ["HOME"]
+    mount_dir = os.path.join(home_dir, "mount")
+    mount_manifest_file = os.path.join(home_dir, "mount-manifest.json")
+    dxfuse_cmd = "/usr/bin/dxfuse"
+
+    subprocess.check_output(["mkdir", mount_dir])
+
+    try:
+        job_input_file = file_load_utils.get_input_json_file()
+        dirs, inputs, rest = file_load_utils.get_job_input_filenames(job_input_file)
+    except IOError:
+        msg = 'Error: Could not find the input json file: {0}.\n'.format(job_input_file)
+        msg += '       This function should only be called from within a running job.'
+        print(msg)
+        raise
+
+    # Remove excluded inputs
+    if exclude:
+        inputs = file_load_utils.filter_dict(inputs, exclude)
+
+    # Convert to a flat list of elements to mount
+    to_mount = []
+    for ival_list in inputs.values():
+        to_mount.extend(ival_list)
+
+    files_manifest = _build_mount_manifest(to_mount)
+    with open(mount_manifest_file, 'w') as mfile:
+        json.dump(files_manifest, mfile)
+
+    uid = str(int(subprocess.check_output(["id", "-u"])))
+    gid = str(int(subprocess.check_output(["id", "-g"])))
+    print(subprocess.check_output([dxfuse_cmd, "-uid", uid, "-gid", gid, mount_dir, mount_manifest_file]))
+
+    print("Done mounting inputs.")
+
+    subprocess.call(["find", mount_dir, "-name", "*"])
+
+    helper_vars = _gen_helper_dict(inputs)
+    return helper_vars

--- a/src/python/dxpy/bindings/mount_all_inputs.py
+++ b/src/python/dxpy/bindings/mount_all_inputs.py
@@ -29,12 +29,9 @@ def _build_mount_manifest(to_mount):
         file_entry['proj_id'] = file_handler.get_proj_id()
         file_entry['file_id'] = file_rec['src_file_id']
         file_name = file_rec['trg_fname']
-        k = file_name.rfind("/")
-        file_parent = file_name[:k]
-        file_entry['parent'] = "/" + file_parent
+        file_entry['parent'] = "/" + os.path.dirname(file_name)
         files_list.append(file_entry)
-    files_manifest = {}
-    files_manifest['Files'] = files_list
+    files_manifest = {'Files': files_list}
     print("File mount manifest:")
     print(files_manifest)
     return files_manifest

--- a/src/python/dxpy/bindings/mount_all_inputs.py
+++ b/src/python/dxpy/bindings/mount_all_inputs.py
@@ -31,7 +31,7 @@ def _build_mount_manifest(to_mount):
         file_name = file_rec['trg_fname']
         k = file_name.rfind("/")
         file_parent = file_name[:k]
-        file_entry['parent'] = "/in/" + file_parent
+        file_entry['parent'] = "/" + file_parent
         files_list.append(file_entry)
     files_manifest = {}
     files_manifest['Files'] = files_list
@@ -107,7 +107,7 @@ def mount_all_inputs(exclude=None):
     print("Mounting inputs...")
 
     home_dir = os.environ["HOME"]
-    mount_dir = os.path.join(home_dir, "mount")
+    mount_dir = os.path.join(home_dir, "in")
     mount_manifest_file = os.path.join(home_dir, "mount-manifest.json")
     dxfuse_cmd = "/usr/bin/dxfuse"
 

--- a/src/python/scripts/dx-mount-all-inputs
+++ b/src/python/scripts/dx-mount-all-inputs
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2014-2016 DNAnexus, Inc.
+#
+# This file is part of dx-toolkit (DNAnexus platform client libraries).
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#   use this file except in compliance with the License. You may obtain a copy
+#   of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+
+import argparse
+import dxpy
+from dxpy.utils.printing import fill, refill_paragraphs, BOLD, RED
+
+description = BOLD('Note') + ''': this is a utility for use by bash apps
+running in the DNAnexus Platform.
+
+Mounts all files that were supplied as inputs to the app.  By
+convention, if an input parameter "FOO" has value
+
+    {"$dnanexus_link": "file-xxxx"}
+
+and filename INPUT.TXT, then the linked file will be mounted into the
+path:
+
+    $HOME/in/FOO/INPUT.TXT
+
+If an input is an array of files, then all files will be placed into
+numbered subdirectories under a parent directory named for the
+input. For example, if the input key is FOO, and the inputs are {A, B,
+C}.vcf then, the directory structure will be:
+
+    $HOME/in/FOO/0/A.vcf
+                 1/B.vcf
+                 2/C.vcf
+
+Zero padding is used to ensure argument order. For example, if there are
+12 input files {A, B, C, D, E, F, G, H, I, J, K, L}.txt, the directory
+structure will be:
+
+    $HOME/in/FOO/00/A.vcf
+                 ...
+                 11/L.vcf
+
+This allows using shell globbing (FOO/*/*.vcf) to get all the files in the input
+order.
+'''
+
+# Parse the command line
+#
+# exclude -- a list of arguments to skip over
+parser = argparse.ArgumentParser(
+    description=refill_paragraphs(description),
+    formatter_class=argparse.RawTextHelpFormatter)
+parser.add_argument('--except',
+                    help=fill('Do not mount the input with this name. (May be used multiple times.)',
+                              width_adjustment=-20),
+                    action="append",
+                    dest="exclude",
+                    default=[])
+
+args = parser.parse_args()
+
+dxpy.mount_all_inputs(exclude=args.exclude)

--- a/src/python/test/file_mount/basic/Makefile
+++ b/src/python/test/file_mount/basic/Makefile
@@ -1,2 +1,2 @@
 all:
-	curl -L https://github.com/dnanexus/dxfuse/releases/latest/download/dxfuse-linux > ./resources/usr/bin/dxfuse
+	mkdir -p ./resources/usr/bin/dxfuse && curl -L https://github.com/dnanexus/dxfuse/releases/latest/download/dxfuse-linux > ./resources/usr/bin/dxfuse

--- a/src/python/test/file_mount/basic/Makefile
+++ b/src/python/test/file_mount/basic/Makefile
@@ -1,0 +1,2 @@
+all:
+	curl -L https://github.com/dnanexus/dxfuse/releases/latest/download/dxfuse-linux > ./resources/usr/bin/dxfuse

--- a/src/python/test/file_mount/basic/Makefile
+++ b/src/python/test/file_mount/basic/Makefile
@@ -1,2 +1,4 @@
 all:
-	mkdir -p ./resources/usr/bin/dxfuse && curl -L https://github.com/dnanexus/dxfuse/releases/latest/download/dxfuse-linux > ./resources/usr/bin/dxfuse
+	mkdir -p ./resources/usr/bin/
+	curl -L https://github.com/dnanexus/dxfuse/releases/latest/download/dxfuse-linux > ./resources/usr/bin/dxfuse
+	chmod +x ./resources/usr/bin/dxfuse

--- a/src/python/test/file_mount/basic/Makefile
+++ b/src/python/test/file_mount/basic/Makefile
@@ -1,4 +1,0 @@
-all:
-	mkdir -p ./resources/usr/bin/
-	curl -L https://github.com/dnanexus/dxfuse/releases/latest/download/dxfuse-linux > ./resources/usr/bin/dxfuse
-	chmod +x ./resources/usr/bin/dxfuse

--- a/src/python/test/file_mount/basic/README.md
+++ b/src/python/test/file_mount/basic/README.md
@@ -1,0 +1,2 @@
+This is a testing app, for the mount-all-inputs python script.
+

--- a/src/python/test/file_mount/basic/dxapp.json
+++ b/src/python/test/file_mount/basic/dxapp.json
@@ -5,7 +5,8 @@
     "file": "run.sh",
     "interpreter": "bash",
     "distribution": "Ubuntu",
-    "release": "14.04"
+    "release": "16.04",
+    "version": "1"
   },
   "inputSpec": [
     {"name": "seq1", "class": "file"},

--- a/src/python/test/file_mount/basic/dxapp.json
+++ b/src/python/test/file_mount/basic/dxapp.json
@@ -1,0 +1,20 @@
+{ "name": "basic",
+  "title": "basic",
+  "summary" : "basic file mount",
+  "runSpec": {
+    "file": "run.sh",
+    "interpreter": "bash",
+    "distribution": "Ubuntu",
+    "release": "14.04"
+  },
+  "inputSpec": [
+    {"name": "seq1", "class": "file"},
+    {"name": "seq2", "class": "file"},
+    {"name": "ref",  "class": "array:file"}
+  ],
+  "outputSpec": [
+  ],
+  "access": {
+    "network": ["*"]
+  }
+}

--- a/src/python/test/file_mount/basic/run.sh
+++ b/src/python/test/file_mount/basic/run.sh
@@ -1,0 +1,35 @@
+main() {
+    # Simple app test to invoke dx-mount-all-inputs and
+    # verify that the data can be accessed from the
+    # mounted file.
+
+    dx-mount-all-inputs
+
+    FILE=$(cat /home/dnanexus/in/seq1/A.txt)
+    if [ "$FILE" != "1234" ]
+    then
+        echo "Failed to read correct data from mounted file."
+        exit 1
+    fi
+
+    FILE=$(cat /home/dnanexus/in/seq2/B.txt)
+    if [ "$FILE" != "ABCD" ]
+    then
+        echo "Failed to read correct data from mounted file."
+        exit 1
+    fi
+
+    FILE=$(cat /home/dnanexus/in/ref/0/A.txt)
+    if [ "$FILE" != "1234" ]
+    then
+        echo "Failed to read correct data from mounted file."
+        exit 1
+    fi
+
+    FILE=$(cat /home/dnanexus/in/ref/1/B.txt)
+    if [ "$FILE" != "ABCD" ]
+    then
+        echo "Failed to read correct data from mounted file."
+        exit 1
+    fi
+}

--- a/src/python/test/test_dx_bash_helpers.py
+++ b/src/python/test/test_dx_bash_helpers.py
@@ -51,6 +51,7 @@ def run(command, **kwargs):
     return output
 
 TEST_APPS = os.path.join(os.path.dirname(__file__), 'file_load')
+TEST_MOUNT_APPS = os.path.join(os.path.dirname(__file__), 'file_mount')
 LOCAL_SCRIPTS = os.path.join(os.path.dirname(__file__), '..', 'scripts')
 LOCAL_UTILS = os.path.join(os.path.dirname(__file__), '..', 'dxpy', 'utils')
 DUMMY_HASH = "123456789012345678901234"
@@ -160,6 +161,24 @@ class TestDXBashHelpers(DXTestCase):
 
             # Run the applet
             applet_args = ['-iseq1=A.txt', '-iseq2=B.txt', '-iref=A.txt', '-iref=B.txt', "-ivalue=5", "-iages=4"]
+            cmd_args = ['dx', 'run', '--yes', '--watch', applet_id]
+            cmd_args.extend(applet_args)
+            run(cmd_args, env=env)
+
+    def test_mount_basic(self):
+        with temporary_project('TestDXBashHelpers.test_app1 temporary project') as dxproj:
+            env = update_environ(DX_PROJECT_CONTEXT_ID=dxproj.get_id())
+
+            # Upload some files for use by the applet
+            dxpy.upload_string("1234\n", project=dxproj.get_id(), name="A.txt")
+            dxpy.upload_string("ABCD\n", project=dxproj.get_id(), name="B.txt")
+
+            # Build the applet, patching in the bash helpers from the
+            # local checkout
+            applet_id = build_app_with_bash_helpers(os.path.join(TEST_MOUNT_APPS, 'basic'), dxproj.get_id())
+
+            # Run the applet
+            applet_args = ['-iseq1=A.txt', '-iseq2=B.txt', '-iref=A.txt', '-iref=B.txt']
             cmd_args = ['dx', 'run', '--yes', '--watch', applet_id]
             cmd_args.extend(applet_args)
             run(cmd_args, env=env)


### PR DESCRIPTION
Add dx-mount-all-inputs script, which is similar to dx-download-all-inputs except that instead of downloading the input files, it mounts them using dxfuse. This helps the performance of apps like csv_loader and vcf_loader which deal with very large input files.