### PR TITLE
DEVEX-1386 'python3' support for dx-app-wizard

### DIFF
--- a/src/python/dxpy/scripts/dx_app_wizard.py
+++ b/src/python/dxpy/scripts/dx_app_wizard.py
@@ -396,6 +396,7 @@ array:boolean  array:int      boolean        hash           string''')
 
     app_json['runSpec']['distribution'] = 'Ubuntu'
     app_json['runSpec']['release'] = '16.04'
+    app_json['runSpec']['version'] = "1"
 
     #################
     # WRITING FILES #

--- a/src/python/dxpy/scripts/dx_build_app.py
+++ b/src/python/dxpy/scripts/dx_build_app.py
@@ -230,7 +230,7 @@ def _check_syntax(code, lang, temp_dir, enforce=True):
     """
     # This function needs the language to be explicitly set, so we can
     # generate an appropriate temp filename.
-    if lang == 'python2.7' or 'python3' in lang':
+    if lang == 'python2.7' or 'python3' in lang:
         temp_basename = 'inlined_code_from_dxapp_json.py'
     elif lang == 'bash':
         temp_basename = 'inlined_code_from_dxapp_json.sh'

--- a/src/python/dxpy/scripts/dx_build_app.py
+++ b/src/python/dxpy/scripts/dx_build_app.py
@@ -230,12 +230,12 @@ def _check_syntax(code, lang, temp_dir, enforce=True):
     """
     # This function needs the language to be explicitly set, so we can
     # generate an appropriate temp filename.
-    if lang == 'python2.7':
+    if lang == 'python2.7' or lang == 'python3':
         temp_basename = 'inlined_code_from_dxapp_json.py'
     elif lang == 'bash':
         temp_basename = 'inlined_code_from_dxapp_json.sh'
     else:
-        raise ValueError('lang must be one of "python2.7" or "bash"')
+        raise ValueError('lang must be one of "python2.7", "python3", or "bash"')
     # Dump the contents out to a temporary file, then call _check_file_syntax.
     with open(os.path.join(temp_dir, temp_basename), 'w') as ofile:
         ofile.write(code)

--- a/src/python/dxpy/scripts/dx_build_app.py
+++ b/src/python/dxpy/scripts/dx_build_app.py
@@ -230,7 +230,7 @@ def _check_syntax(code, lang, temp_dir, enforce=True):
     """
     # This function needs the language to be explicitly set, so we can
     # generate an appropriate temp filename.
-    if lang == 'python2.7' or lang == 'python3':
+    if lang == 'python2.7' or 'python3' in lang':
         temp_basename = 'inlined_code_from_dxapp_json.py'
     elif lang == 'bash':
         temp_basename = 'inlined_code_from_dxapp_json.sh'

--- a/src/python/dxpy/templating/python.py
+++ b/src/python/dxpy/templating/python.py
@@ -22,7 +22,7 @@ from __future__ import print_function, unicode_literals, division, absolute_impo
 from ..utils.printing import fill
 
 def get_interpreter():
-    return 'python2.7'
+    return 'python3'
 
 def get_path():
     return 'python'

--- a/src/python/dxpy/templating/templates/python/basic/test/test.py
+++ b/src/python/dxpy/templating/templates/python/basic/test/test.py
@@ -8,6 +8,8 @@ import dxpy
 import dxpy.app_builder
 
 from dxpy.exceptions import DXAPIError
+from __future__ import print_function
+
 
 src_dir = os.path.join(os.path.dirname(__file__), "..")
 test_resources_dir = os.path.join(src_dir, "test", "resources")
@@ -35,8 +37,8 @@ class TestDX_APP_WIZARD_NAME(unittest.TestCase):
         try:
             dxpy.api.container_remove_objects(dxpy.WORKSPACE_ID, {"objects": [cls.applet_id]})
         except DXAPIError as e:
-            print "Error removing %s during cleanup; ignoring." % (cls.applet_id,)
-            print e
+            print("Error removing %s during cleanup; ignoring." % (cls.applet_id,))
+            print(e)
 
     def setUp(self):
         pass
@@ -49,9 +51,9 @@ class TestDX_APP_WIZARD_NAME(unittest.TestCase):
         Tests the app with a basic input.
         """
         job = dxpy.DXApplet(self.applet_id).run(self.base_input)
-        print "Waiting for %s to complete" % (job.get_id(),)
+        print("Waiting for %s to complete" % (job.get_id(),))
         job.wait_on_done()
-        print json.dumps(job.describe()["output"])
+        print( json.dumps(job.describe()["output"]) )
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/python/dxpy/templating/templates/python/parallelized/test/test.py
+++ b/src/python/dxpy/templating/templates/python/parallelized/test/test.py
@@ -8,6 +8,8 @@ import dxpy
 import dxpy.app_builder
 
 from dxpy.exceptions import DXAPIError
+from __future__ import print_function
+
 
 src_dir = os.path.join(os.path.dirname(__file__), "..")
 test_resources_dir = os.path.join(src_dir, "test", "resources")

--- a/src/python/dxpy/templating/templates/python/scatter-process-gather/test/test.py
+++ b/src/python/dxpy/templating/templates/python/scatter-process-gather/test/test.py
@@ -8,6 +8,8 @@ import dxpy
 import dxpy.app_builder
 
 from dxpy.exceptions import DXAPIError
+from __future__ import print_function
+
 
 src_dir = os.path.join(os.path.dirname(__file__), "..")
 test_resources_dir = os.path.join(src_dir, "test", "resources")
@@ -35,8 +37,8 @@ class TestDX_APP_WIZARD_NAME(unittest.TestCase):
         try:
             dxpy.api.container_remove_objects(dxpy.WORKSPACE_ID, {"objects": [cls.applet_id]})
         except DXAPIError as e:
-            print "Error removing %s during cleanup; ignoring." % (cls.applet_id,)
-            print e
+            print("Error removing %s during cleanup; ignoring." % (cls.applet_id,))
+            print(e)
 
     def setUp(self):
         pass
@@ -49,9 +51,9 @@ class TestDX_APP_WIZARD_NAME(unittest.TestCase):
         Tests the app with a basic input.
         """
         job = dxpy.DXApplet(self.applet_id).run(self.base_input)
-        print "Waiting for %s to complete" % (job.get_id(),)
+        print("Waiting for %s to complete" % (job.get_id(),))
         job.wait_on_done()
-        print json.dumps(job.describe()["output"])
+        print(json.dumps(job.describe()["output"]))
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/python/dxpy/templating/utils.py
+++ b/src/python/dxpy/templating/utils.py
@@ -285,7 +285,7 @@ def create_files_from_templates(template_dir, app_json, language,
 
     if os.path.exists(os.path.join(template_dir, 'test')):
         for template_filename in os.listdir(os.path.join(template_dir, 'test')):
-            if any(template_filename.endswith(ext) for ext in ('~', '.pyc', '.pyo')):
+            if any(template_filename.endswith(ext) for ext in ('~', '.pyc', '.pyo', '__pycache__')):
                 continue
             use_template_file(os.path.join('test', template_filename))
 

--- a/src/python/test/test_dx_app_wizard.py
+++ b/src/python/test/test_dx_app_wizard.py
@@ -154,6 +154,8 @@ class TestDXAppWizard(DXTestCase):
                          InstanceTypesCompleter.default_instance_type.Name)
         self.assertEqual(dxapp_json['runSpec']['distribution'], 'Ubuntu')
         self.assertEqual(dxapp_json['runSpec']['release'], '16.04')
+        self.assertEqual(dxapp_json['runSpec']['version'], '1')
+        self.assertEqual(dxapp_json['runSpec']['interpreter'], 'python3')
         self.assertEqual(dxapp_json['runSpec']['timeoutPolicy']['*']['hours'], 24)
 
     def test_dx_app_wizard_with_azure_instance_type(self):


### PR DESCRIPTION
Adds support for 'interpreter':'python3' with 'version':'1', Ubuntu 16.04 in the toolkit. This will be replacing the old Python 2 as the default.  Tested manually the creation, building, and running of both bash and Python 3 apps.  Added tests app wizard testing script that is also run for traceability testing.

I believe documentation of the python3 support at large is a separate ticket, so this will be the only PR for this ticket.