### PR TITLE
Fix gnureadline import for macOS

### DIFF
--- a/src/mk/Makefile.osx
+++ b/src/mk/Makefile.osx
@@ -22,9 +22,6 @@ $(DNANEXUS_HOME)/bin/dx: $(shell find python/{dxpy,scripts,requirements*,setup*}
 
 	unset PYTHONPATH; source "$(DX_PY_ENV)/$(ACTIVATE)"; ${PIP} install --upgrade -r python/requirements_setuptools.txt
 
-	# install the gnureadline package and download other osx specific packages
-	unset PYTHONPATH; source "$(DX_PY_ENV)/$(ACTIVATE)"; ${PIP} install --no-cache-dir --prefix="$(DNANEXUS_HOME)" -r python/requirements_readline.txt
-
 	# Build the dxpy wheel and move it into place
 	unset PYTHONPATH; source "$(DX_PY_ENV)/$(ACTIVATE)"; cd python; python setup.py bdist_wheel
 	unset PYTHONPATH; source "$(DX_PY_ENV)/$(ACTIVATE)"; pip install --ignore-installed --prefix="$(DNANEXUS_HOME)" python/dist/*.whl

--- a/src/python/dxpy/cli/exec_io.py
+++ b/src/python/dxpy/cli/exec_io.py
@@ -246,7 +246,10 @@ def get_input_array(param_desc):
     print(fill(prompt))
 
     try:
-        import readline
+        try:
+            import gnureadline as readline
+        except ImportError:
+            import readline
         if in_class in dx_data_classes:
             from dxpy.utils.completer import DXPathCompleter
             readline.set_completer(DXPathCompleter(classes=[in_class],
@@ -351,7 +354,10 @@ def get_input_single(param_desc):
     print(fill(prompt))
 
     try:
-        import readline
+        try:
+            import gnureadline as readline
+        except ImportError:
+            import readline
         if in_class in dx_data_classes:
             from dxpy.utils.completer import DXPathCompleter
             readline.set_completer(DXPathCompleter(classes=[in_class],
@@ -670,7 +676,10 @@ class ExecutableInputs(object):
 
     def init_completer(self):
         try:
-            import readline
+            try:
+                import gnureadline as readline
+            except ImportError:
+                import readline
             import rlcompleter
             readline.parse_and_bind("tab: complete")
 
@@ -684,7 +693,10 @@ class ExecutableInputs(object):
 
     def uninit_completer(self):
         try:
-            import readline
+            try:
+                import gnureadline as readline
+            except ImportError:
+                import readline
             readline.set_completer()
             readline.clear_history()
         except:

--- a/src/python/dxpy/cli/exec_io.py
+++ b/src/python/dxpy/cli/exec_io.py
@@ -34,7 +34,10 @@ from ..utils.resolver import (parse_input_keyval, is_hashid, is_job_id, is_local
                               resolve_existing_path, resolve_multiple_existing_paths, split_unescaped, is_analysis_id)
 from ..utils import OrderedDefaultdict
 from ..compat import input, str, shlex, basestring, USING_PYTHON2
-
+try:
+    import gnureadline as readline
+except ImportError:
+    import readline
 ####################
 # -i Input Parsing #
 ####################
@@ -246,10 +249,7 @@ def get_input_array(param_desc):
     print(fill(prompt))
 
     try:
-        try:
-            import gnureadline as readline
-        except ImportError:
-            import readline
+        
         if in_class in dx_data_classes:
             from dxpy.utils.completer import DXPathCompleter
             readline.set_completer(DXPathCompleter(classes=[in_class],
@@ -354,10 +354,6 @@ def get_input_single(param_desc):
     print(fill(prompt))
 
     try:
-        try:
-            import gnureadline as readline
-        except ImportError:
-            import readline
         if in_class in dx_data_classes:
             from dxpy.utils.completer import DXPathCompleter
             readline.set_completer(DXPathCompleter(classes=[in_class],
@@ -676,10 +672,6 @@ class ExecutableInputs(object):
 
     def init_completer(self):
         try:
-            try:
-                import gnureadline as readline
-            except ImportError:
-                import readline
             import rlcompleter
             readline.parse_and_bind("tab: complete")
 
@@ -693,10 +685,6 @@ class ExecutableInputs(object):
 
     def uninit_completer(self):
         try:
-            try:
-                import gnureadline as readline
-            except ImportError:
-                import readline
             readline.set_completer()
             readline.clear_history()
         except:

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -91,7 +91,11 @@ if '_ARGCOMPLETE' not in os.environ:
         if 'TERM' in os.environ and os.environ['TERM'].startswith('xterm'):
             old_term_setting = os.environ['TERM']
             os.environ['TERM'] = 'vt100'
-        import readline
+        # gnureadline required on macos
+        try:
+            import gnureadline as readline
+        except ImportError:
+            import readline
         if old_term_setting:
             os.environ['TERM'] = old_term_setting
 

--- a/src/python/dxpy/templating/utils.py
+++ b/src/python/dxpy/templating/utils.py
@@ -40,7 +40,10 @@ completer_state = {
 }
 
 try:
-    import readline
+    try:
+        import gnureadline as readline
+    except ImportError:
+        import readline
     import rlcompleter
     readline.parse_and_bind("tab: complete")
     readline.set_completer_delims("")

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -6,4 +6,5 @@ beautifulsoup4==4.4.1
 psutil>=3.3.0
 requests>=2.8.0
 cryptography<=2.2.2
+gnureadline==6.3.8; sys_platform == "darwin"
 xattr==0.9.6; sys_platform == 'linux2' or sys_platform == 'linux'

--- a/src/python/requirements_readline.txt
+++ b/src/python/requirements_readline.txt
@@ -1,1 +1,0 @@
-gnureadline==6.3.8

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -74,17 +74,6 @@ if platform.system() == 'Windows':
     dependencies = [d for d in dependencies if not (d.startswith('distribute'))]
     dependencies.append("colorama==0.2.4")
 
-# If this is an OS X system where GNU readline is imitated by libedit, add the readline module from pypi to dependencies.
-# See also http://stackoverflow.com/questions/7116038
-# Warning: This may not work as intended in cross-compilation scenarios
-if platform.system() == 'Darwin':
-    try:
-        import readline
-        if 'libedit' in readline.__doc__:
-            dependencies.extend(readline_dependencies)
-    except ImportError:
-        dependencies.extend(readline_dependencies)
-
 if sys.version_info[0] < 3:
     dependencies.extend(backports_dependencies)
 

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -66,7 +66,6 @@ for module in os.listdir(os.path.join(os.path.dirname(__file__), 'dxpy', 'script
 
 dependencies = [line.rstrip() for line in open(os.path.join(os.path.dirname(__file__), "requirements.txt"))]
 test_dependencies = [line.rstrip() for line in open(os.path.join(os.path.dirname(__file__), "requirements_test.txt"))]
-readline_dependencies = [line.rstrip() for line in open(os.path.join(os.path.dirname(__file__), "requirements_readline.txt"))]
 backports_dependencies = [line.rstrip() for line in open(os.path.join(os.path.dirname(__file__), "requirements_backports.txt"))]
 
 # If on Windows, also depend on colorama, which translates ANSI terminal color control sequences into whatever cmd.exe uses.


### PR DESCRIPTION
Move the gnureadline to requirements.txt file only for macOS. Wherever `readline` is imported, first try to import `gnureadline`