### PR TITLE
DEVEX-1687 Fix `dx-upload-all-outputs ---xattr-properties`

### DIFF
--- a/src/python/scripts/dx-upload-all-outputs
+++ b/src/python/scripts/dx-upload-all-outputs
@@ -42,6 +42,7 @@ import xattr
 import dxpy
 from dxpy.utils import file_load_utils
 from dxpy.utils.printing import fill, refill_paragraphs, BOLD, RED
+from dxpy.compat import USING_PYTHON2
 
 description = BOLD('Note') + ''': this is a utility for use by bash apps
 running in the DNAnexus Platform.
@@ -295,7 +296,10 @@ def return_xattr_as_properties(file):
     properties = {}
     for attribute in xattr.listxattr(file):
         if attribute.startswith('user.'):
-            properties[attribute.lstrip('user.')] = xattr.getxattr(file, attribute)
+            value = xattr.getxattr(file, attribute)
+            if not USING_PYTHON2:
+                value = value.decode()
+            properties[attribute[5:]] = value
     return properties
 
 def upload_one_file(entry, wait_on_close, xattr_properties):

--- a/src/python/test/file_load/xattr_properties/run.sh
+++ b/src/python/test/file_load/xattr_properties/run.sh
@@ -14,6 +14,7 @@ main() {
         cp dummy_data.txt out/$d/$d
         attr -s "key0" -V "val0" out/$d/$d
         attr -s "key1" -V "val1" out/$d/$d
+        attr -s "runFolder" -V "runValue" out/$d/$d
     done
 
     # sequential upload with metadata as properties
@@ -37,6 +38,7 @@ function compare_xattr_to_properties()
         properties=$(dx describe --json $basename | jq -r .properties)
         [[ "val0" == $(echo $properties | jq -r .key0) ]]
         [[ "val1" == $(echo $properties | jq -r .key1) ]]
+        [[ "runValue" == $(echo $properties | jq -r .runFolder) ]]
     done
 }
 


### PR DESCRIPTION
Strip the first 5 chars of the xattr key "user." not with `lstrip()` which strips characters, not a substring. Fix python3 bytes compatibility.