### PR TITLE
DEVEX-1723 Freeze 14.04 builds

### DIFF
--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -84,35 +84,35 @@ stage 'Build'
                 deleteDir()
             }
         },
-        "osx-10.10" : {
-            node('idna'){
-                deleteDir()
-                sh """
-                    git clone https://github.com/dnanexus/dx-toolkit.git
-                    commit_hash=\"${env.commit_hash}\"
-                    mkdir \"${env.commit_hash}\"
-                    cd dx-toolkit
+        // "osx-10.10" : {
+        //     node('idna'){
+        //         deleteDir()
+        //         sh """
+        //             git clone https://github.com/dnanexus/dx-toolkit.git
+        //             commit_hash=\"${env.commit_hash}\"
+        //             mkdir \"${env.commit_hash}\"
+        //             cd dx-toolkit
                     
-                    git checkout \$commit_hash
-                    export LC_ALL=en.UTF-8
+        //             git checkout \$commit_hash
+        //             export LC_ALL=en.UTF-8
                     
-                    export CPATH=/opt/local/include
-                    export CC=clang
-                    export CXX=clang++
-                    export CXXFLAGS="-stdlib=libc++ -mmacosx-version-min=10.7"
+        //             export CPATH=/opt/local/include
+        //             export CC=clang
+        //             export CXX=clang++
+        //             export CXXFLAGS="-stdlib=libc++ -mmacosx-version-min=10.7"
 
-                    # For the Python cryptography package:
-                    export CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
-                    export LDFLAGS="/opt/local/lib/libssl.a /opt/local/lib/libcrypto.a"
-                    export CPPFLAGS="-I/opt/local/include"
+        //             # For the Python cryptography package:
+        //             export CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
+        //             export LDFLAGS="/opt/local/lib/libssl.a /opt/local/lib/libcrypto.a"
+        //             export CPPFLAGS="-I/opt/local/include"
 
-                    build/package.sh osx
-                    mv dx-toolkit-*-osx.tar.gz ../\$commit_hash/
-                """
-                archive "${env.commit_hash}/dx-toolkit-*-osx.tar.gz"
-                deleteDir()
-            }
-        },
+        //             build/package.sh osx
+        //             mv dx-toolkit-*-osx.tar.gz ../\$commit_hash/
+        //         """
+        //         archive "${env.commit_hash}/dx-toolkit-*-osx.tar.gz"
+        //         deleteDir()
+        //     }
+        // },
         "windows" : {
             node('windowsprodbuilds') {
                 echo "Deleting workspace"

--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -27,7 +27,7 @@ stage 'Build'
                     commit_hash=\"${env.commit_hash}\"
                     working_dir=\$(pwd)
                     mkdir \$commit_hash
-                    docker run -v \$working_dir/\$commit_hash:/\$commit_hash --rm dnanexus/dx-toolkit:14.04 /bin/bash -c \"git clone https://github.com/dnanexus/dx-toolkit.git; cd dx-toolkit; \\
+                    docker run -v \$working_dir/\$commit_hash:/\$commit_hash --rm dnanexus/dx-toolkit:16.04 /bin/bash -c \"git clone https://github.com/dnanexus/dx-toolkit.git; cd dx-toolkit; \\
                         git checkout \$commit_hash; make toolkit_version git_submodules; rm -rf .git src/jq/.git; cd ..; \\
                         tar -czf dx-toolkit-\$commit_hash-source.tar.gz dx-toolkit; \\
                         tar -C dx-toolkit/src/R -czf dxR_\$commit_hash.tar.gz dxR; \\
@@ -52,21 +52,6 @@ stage 'Build'
                 deleteDir()
             }
         },
-        "14.04-amd64" : { 
-            node('master'){
-                deleteDir()
-                sh  """
-                    commit_hash=\"${env.commit_hash}\"
-                    mkdir \$commit_hash
-                    working_dir=\$(pwd)
-                    docker run -v \$working_dir/\$commit_hash:/\$commit_hash --rm dnanexus/dx-toolkit:14.04 /bin/bash -c \"git clone https://github.com/dnanexus/dx-toolkit.git; cd dx-toolkit; \\
-                        git checkout \$commit_hash; build/package.sh ubuntu-14.04-amd64; \\
-                        mv dx-toolkit-*.tar.gz /\$commit_hash/\"
-                    """
-                archive "${env.commit_hash}/dx-toolkit-*.tar.gz"
-                deleteDir()
-            }
-        },
         "centos-amd64" : { 
             node('master'){
                 deleteDir()
@@ -80,22 +65,6 @@ stage 'Build'
                         mv dx-toolkit-*.tar.gz /\$commit_hash/\"
                     """
                 archive "${env.commit_hash}/dx-toolkit-*.tar.gz"
-                deleteDir()
-            }
-        },
-        "trusty-deb" : { 
-            node('master'){
-                deleteDir()
-                sh  """
-                    commit_hash=\"${env.commit_hash}\"
-                    working_dir=\$(pwd)
-                    mkdir -p \$working_dir/\$commit_hash/trusty
-                    docker run -v \$working_dir/\$commit_hash/trusty:/\$commit_hash/trusty --rm dnanexus/dx-toolkit:14.04 \\
-                        /bin/bash -xc \"git clone https://github.com/dnanexus/dx-toolkit.git; \\
-                        cd dx-toolkit; git checkout \$commit_hash; build/build-dx-toolkit-debs.sh; \\
-                        mv /*.{changes,deb,dsc,tar.gz} /\$commit_hash/trusty\"
-                    """
-                archive "${env.commit_hash}/trusty/dx*"
                 deleteDir()
             }
         },

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -5,6 +5,6 @@ python-magic==0.4.6
 beautifulsoup4==4.4.1
 psutil>=3.3.0
 requests>=2.8.0
-cryptography==2.8
+cryptography>=2.8
 gnureadline==6.3.8; sys_platform == "darwin"
 xattr==0.9.6; sys_platform == 'linux2' or sys_platform == 'linux'

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -5,6 +5,6 @@ python-magic==0.4.6
 beautifulsoup4==4.4.1
 psutil>=3.3.0
 requests>=2.8.0
-cryptography<=2.2.2
+cryptography==2.8
 gnureadline==6.3.8; sys_platform == "darwin"
 xattr==0.9.6; sys_platform == 'linux2' or sys_platform == 'linux'

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -5,6 +5,6 @@ python-magic==0.4.6
 beautifulsoup4==4.4.1
 psutil>=3.3.0
 requests>=2.8.0
-cryptography>=2.8
+cryptography>=2.8,<3.0
 gnureadline==6.3.8; sys_platform == "darwin"
 xattr==0.9.6; sys_platform == 'linux2' or sys_platform == 'linux'

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -5,6 +5,6 @@ python-magic==0.4.6
 beautifulsoup4==4.4.1
 psutil>=3.3.0
 requests>=2.8.0
-cryptography>=2.8,<3.0
+cryptography>=2.3,<3.0
 gnureadline==6.3.8; sys_platform == "darwin"
 xattr==0.9.6; sys_platform == 'linux2' or sys_platform == 'linux'


### PR DESCRIPTION
Remove 14.04 build targets. Temporarily disable Mac builds while jenkins nodes are not online.

Bump python cryptography dependency to >= 2.3.