### PR TITLE
Update dx-clone-asset for python3

### DIFF
--- a/src/python/scripts/dx-clone-asset
+++ b/src/python/scripts/dx-clone-asset
@@ -76,7 +76,7 @@ def _find_asset_project(region):
             cmd = 'dx new project --region "{region}" "{proj_name}" --brief '
             return subprocess.check_output(cmd.format(region=region, proj_name=project_name), shell=True).strip()
         else:
-            projects = projects.split('\n')
+            projects = projects.decode().split('\n')
             return projects[0]
     except subprocess.CalledProcessError:
         traceback.print_exc()
@@ -105,7 +105,7 @@ def _clone_asset_into_region(region, record_name, asset_properties, asset_file_n
     while curr_try <= num_retries:
         cmd = ['dx', 'run', CLONE_ASSET_APP_NAME, '--project', project_id, '-iurl=' + url, '-irecord_name=' + record_name]
         cmd += ['-iasset_file_name=' + asset_file_name, '-iasset_properties=' + json.dumps(asset_properties), '--brief']
-        job = subprocess.check_output(cmd).strip()
+        job = subprocess.check_output(cmd).strip().decode()
         print('{region}: {job_id}'.format(region=region, job_id=job), file=sys.stderr)
         try:
             cmd = 'dx wait {job_id} '.format(job_id=job)


### PR DESCRIPTION
This is to fix the error message below when running dx-toolkit in Python3:

```
multiprocessing.pool.RemoteTraceback:
"""
Traceback (most recent call last):
  File "/usr/lib/python3.6/multiprocessing/pool.py", line 119, in worker
    result = (True, func(*args, **kwds))
  File "/usr/lib/python3.6/multiprocessing/pool.py", line 44, in mapstar
    return list(map(*args))
  File "/usr/local/bin/dx-clone-asset", line 96, in _clone_asset_into_region
    project_id = _find_asset_project(region)
  File "/usr/local/bin/dx-clone-asset", line 79, in _find_asset_project
    projects = projects.split('\n')
TypeError: a bytes-like object is required, not 'str'
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/bin/dx-clone-asset", line 208, in <module>
    main(args.record, args.regions, args.num_retries, args.priority)
  File "/usr/local/bin/dx-clone-asset", line 199, in main
    record_ids = clone_asset(record, regions, num_retries, priority)
  File "/usr/local/bin/dx-clone-asset", line 186, in clone_asset
    results = results.get()
  File "/usr/lib/python3.6/multiprocessing/pool.py", line 644, in get
    raise self._value
TypeError: a bytes-like object is required, not 'str'
```

A manual test have done and the script worked both under Python3 and Python2. 