### PR TITLE
16.04 v1 remote builders. 20.04 asset builder

### DIFF
--- a/src/python/dxpy/asset_builder.py
+++ b/src/python/dxpy/asset_builder.py
@@ -34,6 +34,8 @@ ASSET_BUILDER_PRECISE = "app-create_asset_precise"
 ASSET_BUILDER_TRUSTY = "app-create_asset_trusty"
 ASSET_BUILDER_XENIAL = "app-create_asset_xenial"
 ASSET_BUILDER_XENIAL_V1 = "app-create_asset_xenial_v1"
+ASSET_BUILDER_FOCAL = "app-create_asset_focal"
+
 
 
 class AssetBuilderException(Exception):
@@ -234,6 +236,8 @@ def build_asset(args):
             app_run_result = dxpy.api.app_run(ASSET_BUILDER_XENIAL_V1, input_params=builder_run_options)
         elif asset_conf['release'] == "16.04":
             app_run_result = dxpy.api.app_run(ASSET_BUILDER_XENIAL, input_params=builder_run_options)
+        elif asset_conf['release'] == "20.04":
+            app_run_result = dxpy.api.app_run(ASSET_BUILDER_FOCAL, input_params=builder_run_options)
 
         job_id = app_run_result["id"]
 

--- a/src/python/dxpy/scripts/dx_build_app.py
+++ b/src/python/dxpy/scripts/dx_build_app.py
@@ -497,7 +497,7 @@ def _build_app_remote(mode, src_dir, publish=False, destination_override=None,
 
     app_spec = _parse_app_spec(src_dir)
     builder_versions = {"12.04": "", "14.04": "_trusty", "16.04": "_xenial",
-                        "18.04": "_bionic", "20.04": "_focal"}
+                        "20.04": "_focal"}
     release = app_spec['runSpec'].get('release')
     # Remote builder app/applet for 16.04 version 1
     if release == "16.04" and app_spec['runSpec'].get('version', '0') == '1':

--- a/src/python/dxpy/scripts/dx_build_app.py
+++ b/src/python/dxpy/scripts/dx_build_app.py
@@ -498,7 +498,13 @@ def _build_app_remote(mode, src_dir, publish=False, destination_override=None,
     app_spec = _parse_app_spec(src_dir)
     builder_versions = {"12.04": "", "14.04": "_trusty", "16.04": "_xenial",
                         "18.04": "_bionic", "20.04": "_focal"}
-    builder_app += builder_versions.get(app_spec['runSpec'].get('release'), "")
+    release = app_spec['runSpec'].get('release')
+    # Remote builder app/applet for 16.04 version 1
+    if release == "16.04" and app_spec['runSpec'].get('version', '0') == '1':
+        builder_app += "_xenial_v1"
+    else:
+        builder_app += builder_versions.get(release, "")
+
 
     temp_dir = tempfile.mkdtemp()
 


### PR DESCRIPTION
Add `20.04` asset builder.
Remove unsupported `18.04` remote builder, add `16.04` version `1` remote builder.