### PR TITLE
Bump gnureadline to 8.0.0, install for Python < 3.9

### DIFF
--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -6,5 +6,5 @@ beautifulsoup4==4.4.1
 psutil>=3.3.0
 requests>=2.8.0,<2.24.0
 cryptography>=2.3,<3.0
-gnureadline==6.3.8; sys_platform == "darwin"
+gnureadline==8.0.0; sys_platform == "darwin" and python_version < '3.9'
 xattr==0.9.6; sys_platform == 'linux2' or sys_platform == 'linux'

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -6,5 +6,5 @@ beautifulsoup4==4.4.1
 psutil>=3.3.0
 requests>=2.8.0,<2.24.0
 cryptography>=2.3,<3.0
-gnureadline==8.0.0; sys_platform == "darwin" and python_version < '3.9'
+gnureadline==8.0.0; sys_platform == "darwin" and python_version < "3.9"
 xattr==0.9.6; sys_platform == 'linux2' or sys_platform == 'linux'


### PR DESCRIPTION
gnureadline fails to build with recent macOS catalina and clang updates. Bumping to 8.0.0 helps for Python < 3.8, as their are prebuilt wheelfiles hosted on pypi. For Python > 3.8, gnureadline is probably not required since homebrew managed python installs come with gnu readline, not libedit like the macOS system python. 