### PR TITLE
Add support to UA for JSON manifest

### DIFF
--- a/doc/examples/ua/manifest.json
+++ b/doc/examples/ua/manifest.json
@@ -1,0 +1,14 @@
+{
+  "project-FJ90qPj0jy8zYvVV9yz3F5gv": [
+    {
+      "path": "/dxsrc/src/foo",
+      "folder": "/",
+      "name": "foo"
+    },
+    {
+      "path": "/dxsrc/src/bar",
+      "folder": "/",
+      "name": "bar"
+    }
+  ]
+}

--- a/src/Makefile
+++ b/src/Makefile
@@ -210,17 +210,17 @@ endif
 
 BOOST_LIBS=filesystem,program_options,regex,system,thread,atomic,chrono,date_time,exception,iostreams,signals
 
-ifeq ($(UNAME)$(CC), Darwinclang)
-	BOOST_MAJOR=1
-	BOOST_MINOR=56
-	BOOST_PV=$(BOOST_MAJOR).$(BOOST_MINOR)
-	BOOST_URL=http://downloads.sourceforge.net/project/boost/boost/${BOOST_PV}.0/boost_${BOOST_MAJOR}_${BOOST_MINOR}_0.tar.bz2
-	BOOST_SHA=f94bb008900ed5ba1994a1072140590784b9b5df
-else
-	BOOST_PV=1.55
-	BOOST_URL=${UBUNTU_MIRROR}/pool/universe/b/boost${BOOST_PV}/boost${BOOST_PV}_${BOOST_PV}.0.orig.tar.bz2
-	BOOST_SHA=cef9a0cc7084b1d639e06cd3bc34e4251524c840
-endif
+#ifeq ($(UNAME), Darwin)
+BOOST_MAJOR=1
+BOOST_MINOR=56
+BOOST_PV=$(BOOST_MAJOR).$(BOOST_MINOR)
+BOOST_URL=http://downloads.sourceforge.net/project/boost/boost/${BOOST_PV}.0/boost_${BOOST_MAJOR}_${BOOST_MINOR}_0.tar.bz2
+BOOST_SHA=f94bb008900ed5ba1994a1072140590784b9b5df
+#else
+#	BOOST_PV=1.55
+#	BOOST_URL=${UBUNTU_MIRROR}/pool/universe/b/boost${BOOST_PV}/boost${BOOST_PV}_${BOOST_PV}.0.orig.tar.bz2
+#	BOOST_SHA=cef9a0cc7084b1d639e06cd3bc34e4251524c840
+#endif
 
 boost: boost/stage
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -210,17 +210,17 @@ endif
 
 BOOST_LIBS=filesystem,program_options,regex,system,thread,atomic,chrono,date_time,exception,iostreams,signals
 
-#ifeq ($(UNAME), Darwin)
-BOOST_MAJOR=1
-BOOST_MINOR=56
-BOOST_PV=$(BOOST_MAJOR).$(BOOST_MINOR)
-BOOST_URL=http://downloads.sourceforge.net/project/boost/boost/${BOOST_PV}.0/boost_${BOOST_MAJOR}_${BOOST_MINOR}_0.tar.bz2
-BOOST_SHA=f94bb008900ed5ba1994a1072140590784b9b5df
-#else
-#	BOOST_PV=1.55
-#	BOOST_URL=${UBUNTU_MIRROR}/pool/universe/b/boost${BOOST_PV}/boost${BOOST_PV}_${BOOST_PV}.0.orig.tar.bz2
-#	BOOST_SHA=cef9a0cc7084b1d639e06cd3bc34e4251524c840
-#endif
+ifeq ($(UNAME)$(CC), Darwinclang)
+	BOOST_MAJOR=1
+	BOOST_MINOR=56
+	BOOST_PV=$(BOOST_MAJOR).$(BOOST_MINOR)
+	BOOST_URL=http://downloads.sourceforge.net/project/boost/boost/${BOOST_PV}.0/boost_${BOOST_MAJOR}_${BOOST_MINOR}_0.tar.bz2
+	BOOST_SHA=f94bb008900ed5ba1994a1072140590784b9b5df
+else
+	BOOST_PV=1.55
+	BOOST_URL=${UBUNTU_MIRROR}/pool/universe/b/boost${BOOST_PV}/boost${BOOST_PV}_${BOOST_PV}.0.orig.tar.bz2
+	BOOST_SHA=cef9a0cc7084b1d639e06cd3bc34e4251524c840
+endif
 
 boost: boost/stage
 

--- a/src/ua/options.cpp
+++ b/src/ua/options.cpp
@@ -71,6 +71,7 @@ Options::Options():
     ("project,p", po::value<vector<string> >(&projects), "Name or ID of the destination project")
     ("folder,f", po::value<vector<string> >(&folders)->default_value(defaultFolders, "/"), "Name of the destination folder")
     ("name,n", po::value<vector<string> >(&names), "Name of the remote file (Note: Extension \".gz\" will be appended if the file is compressed before uploading)")
+    ("manifest,m", po::bool_switch(&manifest)->default_value(false), "The first input file is a JSON manifest (Note: see documentation for file format)")
     ("visibility", po::value<string>(&visibility)->default_value("visible"), "Use \"--visibility hidden\" to set the file's visibility as hidden.")
     ("property", po::value<vector<string> >(&propertiesInput), "Key-value pair to add as a property; repeat as necessary, e.g. \"--property key1=val1 --property key2=val2\"")
     ("type", po::value<vector<string> >(&typeInput), "Type of the data object; repeat as necessary, e.g. \"--type type1 --type type2\"")

--- a/src/ua/options.h
+++ b/src/ua/options.h
@@ -59,7 +59,7 @@ public:
   std::vector<std::string> propertiesInput;
   std::vector<std::string> typeInput;
   std::vector<std::string> tagsInput;
-    
+
   int readThreads;
   int compressThreads;
   int uploadThreads;
@@ -73,7 +73,8 @@ public:
   bool recursive;
   bool overrideFileLimit;
   bool standardInput;
-
+  bool manifest;
+  
   // Import flags
   bool reads;
   bool pairedReads;


### PR DESCRIPTION
This adds support for uploading files described by a manifest. This is required in order to add support for parallel upload of outputs to dxWDL.

One thing to note: I tested this on 18.04, but I am not able to get this to compile on 20.04. Specifically, there is an error when using openssl 1.1, and there is no openssl 1.0 package available for 20.04.