### PR TITLE
DEVEX-1796 remove round-robin from UA upload

### DIFF
--- a/src/ua/chunk.cpp
+++ b/src/ua/chunk.cpp
@@ -295,16 +295,6 @@ void Chunk::upload(Options &opt) {
     // http://curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTERRORBUFFER
     checkConfigCURLcode(curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errorBuffer), errorBuffer);
 
-    if (!hostName.empty() && !resolvedIP.empty()) { // Will never be true when compiling on windows
-      log("Adding ip '" + resolvedIP + "' to resolve list for hostname '" + hostName + "'");
-      slist_resolved_ip = curl_slist_append(slist_resolved_ip, (hostName + ":443:" + resolvedIP).c_str());
-      slist_resolved_ip = curl_slist_append(slist_resolved_ip, (hostName + ":80:" + resolvedIP).c_str());
-      // Note: We don't remove this extra host name resolution info by setting "-HOST:PORT:IP" at the end,
-      // since we don't reuse the curl handle anyway
-    } else {
-      log("Not adding any explicit IP address using CURLOPT_RESOLVE. resolvedIP = '" + resolvedIP + "', hostName = '" + hostName + "'", dx::logWARNING);
-    }
-
     // If we are using the TCP tunnel, then we'll be tunneling to the normal
     // AWS IP, receiving that certificate, and then raise a warning because
     // the TCP tunnel URL won't appear on the AWS certificate.  We'll resolve

--- a/src/ua/chunk.cpp
+++ b/src/ua/chunk.cpp
@@ -504,22 +504,6 @@ pair<string, dx::JSON> Chunk::uploadURL(Options &opt) {
   const string &url = toReturn.first;
   log("/" + fileID + "/upload call returned this url: " + url);
 
-  if (!opt.noRoundRobinDNS) {
-    // Now, try to resolve the host name in url to an ip address (for explicit round robin DNS)
-    // If we are unable to do so, just leave the resolvedIP variable an empty string
-    resolvedIP.clear();
-    hostName = extractHostFromURL(url);
-    log("Host name extracted from URL ('" + url + "'): '" + hostName + "'");
-
-    if (attemptExplicitDNSResolve(hostName)) {
-      resolvedIP = getRandomIP(hostName);
-      log("Call to getRandomIP() returned: '" + resolvedIP + "'", dx::logWARNING);
-    } else {
-      log("Not attempting to resolve hostname '" + hostName + "'");
-    }
-  } else {
-    log("Flag --no-round-robin-dns was set, so won't try to explicitly resolve ip address");
-  }
   return toReturn;
 }
 

--- a/src/ua/main.cpp
+++ b/src/ua/main.cpp
@@ -363,11 +363,6 @@ void uploadChunks(vector<File> &files) {
         int numTry = NUMTRIES_g - c->triesLeft + 1; // find out which try is it
         int timeout = (numTry > 6) ? 256 : 4 << numTry; // timeout is always between [8, 256] seconds
         c->log("Will retry reading and uploading this chunks in " + boost::lexical_cast<string>(timeout) + " seconds", logWARNING);
-        if (!opt.noRoundRobinDNS) {
-          boost::mutex::scoped_lock forceRefreshLock(forceRefreshDNSMutex);
-          c->log("Setting forceRefreshDNS = true in main.cpp:uploadChunks()");
-          forceRefreshDNS = true; // refresh the DNS list in next call to getRandomIP()
-        }
         --(c->triesLeft);
         c->clear(); // we will read & compress data again
         boost::this_thread::sleep(boost::posix_time::milliseconds(timeout * 1000));

--- a/src/ua/options.cpp
+++ b/src/ua/options.cpp
@@ -99,7 +99,6 @@ Options::Options():
     ("apiserver-host", po::value<string>(&apiserverHost), "API server host")
     ("apiserver-port", po::value<int>(&apiserverPort)->default_value(-1), "API server port")
     ("certificate-file", po::value<string>(&certificateFile)->default_value(""), "Certificate file (for verifying peer). Set to NOVERIFY for no check.")
-    ("no-round-robin-dns", po::bool_switch(&noRoundRobinDNS), "Disable explicit resolution of ip address by /UPLOAD calls (for round robin DNS)")
     ("override-file-limit", po::bool_switch(&overrideFileLimit), "Override the file number limit")
     // Options for running import apps
     ("reads", po::bool_switch(&reads), "After uploading is complete, run import app to convert file(s) to Reads object(s)")
@@ -609,8 +608,7 @@ ostream &operator<<(ostream &out, const Options &opt) {
         << "  mappings: " << opt.mappings << endl
         << "  variants: " << opt.variants << endl
         << "  ref-genome: " << opt.refGenome << endl
-        << "  certificate-file" << opt.certificateFile << endl
-        << "  no-round-robin-dns" << opt.noRoundRobinDNS << endl;
+        << "  certificate-file" << opt.certificateFile << endl;
   }
   return out;
 }

--- a/src/ua/options.h
+++ b/src/ua/options.h
@@ -81,7 +81,6 @@ public:
   bool variants;
   std::string refGenome;
 
-  bool noRoundRobinDNS;
 
   int64_t throttle;
   


### PR DESCRIPTION
Remove round-robin DNS upload strategy from upload agent. Was originally implemented for the deprecated v1 upload. 

Most likely the cause of https://github.com/dnanexus/dx-toolkit/issues/581