### PR TITLE
xattr import fix / test fixes

### DIFF
--- a/src/python/scripts/dx-upload-all-outputs
+++ b/src/python/scripts/dx-upload-all-outputs
@@ -38,7 +38,6 @@ import stat
 import sys
 import json
 import argparse
-import xattr
 import dxpy
 from dxpy.utils import file_load_utils
 from dxpy.utils.printing import fill, refill_paragraphs, BOLD, RED
@@ -293,6 +292,10 @@ def create_entry(subdir_desc, local_path, target_path, basename):
             'dxlink': None}
 
 def return_xattr_as_properties(file):
+    try:
+        import xattr
+    except ImportError:
+        return {}
     properties = {}
     for attribute in xattr.listxattr(file):
         if attribute.startswith('user.'):

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -50,7 +50,7 @@ version = make_valid_pypi_version(version)
 
 # The readme file is used as the long-description of the package.
 # It will show up in the pypi site.
-with open("Readme.md", "r") as fh:
+with open(os.path.join(os.path.dirname(__file__), "Readme.md"), "r") as fh:
     readme_content = fh.read()
 
 # Grab all the scripts from dxpy/scripts and install them without their .py extension.

--- a/src/python/test/file_load/basic/dxapp.json
+++ b/src/python/test/file_load/basic/dxapp.json
@@ -5,7 +5,7 @@
     "file": "run.sh",
     "interpreter": "bash",
     "distribution": "Ubuntu",
-    "release": "14.04"
+    "release": "20.04"
   },
   "inputSpec": [
     {"name": "seq1", "class": "file"},

--- a/src/python/test/file_load/basic/dxapp.json
+++ b/src/python/test/file_load/basic/dxapp.json
@@ -5,7 +5,8 @@
     "file": "run.sh",
     "interpreter": "bash",
     "distribution": "Ubuntu",
-    "release": "20.04"
+    "release": "20.04",
+    "version": "0"
   },
   "inputSpec": [
     {"name": "seq1", "class": "file"},

--- a/src/python/test/file_load/basic_except/dxapp.json
+++ b/src/python/test/file_load/basic_except/dxapp.json
@@ -5,7 +5,7 @@
     "file": "run.sh",
     "interpreter": "bash",
     "distribution": "Ubuntu",
-    "release": "14.04"
+    "release": "20.04"
   },
   "inputSpec": [
     {"name": "seq1",  "class": "file"},

--- a/src/python/test/file_load/basic_except/dxapp.json
+++ b/src/python/test/file_load/basic_except/dxapp.json
@@ -5,7 +5,8 @@
     "file": "run.sh",
     "interpreter": "bash",
     "distribution": "Ubuntu",
-    "release": "20.04"
+    "release": "20.04",
+    "version": "0"
   },
   "inputSpec": [
     {"name": "seq1",  "class": "file"},

--- a/src/python/test/file_load/benchmark/dxapp.json
+++ b/src/python/test/file_load/benchmark/dxapp.json
@@ -5,7 +5,7 @@
     "file": "run.sh",
     "interpreter": "bash",
     "distribution": "Ubuntu",
-    "release": "14.04"
+    "release": "20.04"
   },
   "inputSpec": [
     {"name": "parallel", "class": "boolean", "optional": true},

--- a/src/python/test/file_load/benchmark/dxapp.json
+++ b/src/python/test/file_load/benchmark/dxapp.json
@@ -5,7 +5,8 @@
     "file": "run.sh",
     "interpreter": "bash",
     "distribution": "Ubuntu",
-    "release": "20.04"
+    "release": "20.04",
+    "version": "0"
   },
   "inputSpec": [
     {"name": "parallel", "class": "boolean", "optional": true},

--- a/src/python/test/file_load/deepdirs/dxapp.json
+++ b/src/python/test/file_load/deepdirs/dxapp.json
@@ -5,7 +5,8 @@
     "file": "run.sh",
     "interpreter": "bash",
     "distribution": "Ubuntu",
-    "release": "20.04"
+    "release": "20.04",
+    "version": "0"
   },
   "inputSpec": [
     {"name": "seq", "class": "file", "optional": true}

--- a/src/python/test/file_load/deepdirs/dxapp.json
+++ b/src/python/test/file_load/deepdirs/dxapp.json
@@ -5,7 +5,7 @@
     "file": "run.sh",
     "interpreter": "bash",
     "distribution": "Ubuntu",
-    "release": "14.04"
+    "release": "20.04"
   },
   "inputSpec": [
     {"name": "seq", "class": "file", "optional": true}

--- a/src/python/test/file_load/file_optional/dxapp.json
+++ b/src/python/test/file_load/file_optional/dxapp.json
@@ -5,7 +5,7 @@
     "file": "run.sh",
     "interpreter": "bash",
     "distribution": "Ubuntu",
-    "release": "14.04"
+    "release": "20.04"
   },
   "inputSpec": [
     {"name": "create_seq3", "class" : "boolean" }

--- a/src/python/test/file_load/file_optional/dxapp.json
+++ b/src/python/test/file_load/file_optional/dxapp.json
@@ -5,7 +5,8 @@
     "file": "run.sh",
     "interpreter": "bash",
     "distribution": "Ubuntu",
-    "release": "20.04"
+    "release": "20.04",
+    "version": "0"
   },
   "inputSpec": [
     {"name": "create_seq3", "class" : "boolean" }

--- a/src/python/test/file_load/parseq/dxapp.json
+++ b/src/python/test/file_load/parseq/dxapp.json
@@ -5,7 +5,7 @@
     "file": "run.sh",
     "interpreter": "bash",
     "distribution": "Ubuntu",
-    "release": "14.04"
+    "release": "20.04"
   },
   "inputSpec": [
     {"name": "seq1", "class": "file"},

--- a/src/python/test/file_load/parseq/dxapp.json
+++ b/src/python/test/file_load/parseq/dxapp.json
@@ -5,7 +5,8 @@
     "file": "run.sh",
     "interpreter": "bash",
     "distribution": "Ubuntu",
-    "release": "20.04"
+    "release": "20.04",
+    "version": "0"
   },
   "inputSpec": [
     {"name": "seq1", "class": "file"},

--- a/src/python/test/file_load/prefix_patterns/dxapp.json
+++ b/src/python/test/file_load/prefix_patterns/dxapp.json
@@ -5,7 +5,8 @@
     "file": "run.sh",
     "interpreter": "bash",
     "distribution": "Ubuntu",
-    "release": "20.04"
+    "release": "20.04",
+    "version": "0"
   },
   "inputSpec": [
     {

--- a/src/python/test/file_load/prefix_patterns/dxapp.json
+++ b/src/python/test/file_load/prefix_patterns/dxapp.json
@@ -5,7 +5,7 @@
     "file": "run.sh",
     "interpreter": "bash",
     "distribution": "Ubuntu",
-    "release": "14.04"
+    "release": "20.04"
   },
   "inputSpec": [
     {

--- a/src/python/test/file_load/vars/dxapp.json
+++ b/src/python/test/file_load/vars/dxapp.json
@@ -5,7 +5,7 @@
     "file": "run.sh",
     "interpreter": "bash",
     "distribution": "Ubuntu",
-    "release": "14.04"
+    "release": "20.04"
   },
   "inputSpec": [
     {"name": "seq1", "class": "file"},

--- a/src/python/test/file_load/vars/dxapp.json
+++ b/src/python/test/file_load/vars/dxapp.json
@@ -5,7 +5,8 @@
     "file": "run.sh",
     "interpreter": "bash",
     "distribution": "Ubuntu",
-    "release": "20.04"
+    "release": "20.04",
+    "version": "0"
   },
   "inputSpec": [
     {"name": "seq1", "class": "file"},

--- a/src/python/test/file_load/with-subjobs/dxapp.json
+++ b/src/python/test/file_load/with-subjobs/dxapp.json
@@ -28,7 +28,7 @@
     "interpreter": "bash",
     "file": "code.sh",
     "distribution": "Ubuntu",
-    "release": "14.04"
+    "release": "20.04"
   },
   "authorizedUsers": [],
   "access": {

--- a/src/python/test/file_load/with-subjobs/dxapp.json
+++ b/src/python/test/file_load/with-subjobs/dxapp.json
@@ -28,7 +28,8 @@
     "interpreter": "bash",
     "file": "code.sh",
     "distribution": "Ubuntu",
-    "release": "20.04"
+    "release": "20.04",
+    "version": "0"
   },
   "authorizedUsers": [],
   "access": {

--- a/src/python/test/file_load/xattr_properties/dxapp.json
+++ b/src/python/test/file_load/xattr_properties/dxapp.json
@@ -6,6 +6,7 @@
     "interpreter": "bash",
     "distribution": "Ubuntu",
     "release": "20.04",
+    "version": "0",
     "execDepends": [{"name": "attr", "package_manager": "apt"}, {"name": "libffi-dev", "package_manager": "apt"}]
   },
   "inputSpec": [

--- a/src/python/test/file_load/xattr_properties/dxapp.json
+++ b/src/python/test/file_load/xattr_properties/dxapp.json
@@ -5,7 +5,7 @@
     "file": "run.sh",
     "interpreter": "bash",
     "distribution": "Ubuntu",
-    "release": "16.04",
+    "release": "20.04",
     "execDepends": [{"name": "attr", "package_manager": "apt"}, {"name": "libffi-dev", "package_manager": "apt"}]
   },
   "inputSpec": [

--- a/src/python/test/file_load/xattr_properties/run.sh
+++ b/src/python/test/file_load/xattr_properties/run.sh
@@ -1,6 +1,8 @@
 main() {
     # parallel download
     dx-download-all-inputs --parallel
+    # Install xattr
+    python3 -m pip install -U xattr
 
     # creating some output results
     echo "ABCD" > dummy_data.txt

--- a/src/python/test/test_dx_bash_helpers.py
+++ b/src/python/test/test_dx_bash_helpers.py
@@ -91,11 +91,13 @@ def build_app_with_bash_helpers(app_dir, project_id):
         preamble.append('python3 -m pip install -U /dxtoolkit/src/python/dist/$DIST\n')
         # Now find the applet entry point file and prepend the
         # operations above, overwriting it in place.
-        dxapp_json = json.load(open(os.path.join(app_dir, 'dxapp.json')))
+        with open(os.path.join(app_dir, 'dxapp.json')) as f:
+            dxapp_json = json.load(f)
         if dxapp_json['runSpec']['interpreter'] != 'bash':
             raise Exception('Sorry, I only know how to patch bash apps for remote testing')
         entry_point_filename = os.path.join(app_dir, dxapp_json['runSpec']['file'])
-        entry_point_data = ''.join(preamble) + open(entry_point_filename).read()
+        with open(entry_point_filename) as fh:
+            entry_point_data = ''.join(preamble) + ofh.read()
         with open(os.path.join(updated_app_dir, dxapp_json['runSpec']['file']), 'w') as fh:
             fh.write(entry_point_data)
 

--- a/src/python/test/test_dx_bash_helpers.py
+++ b/src/python/test/test_dx_bash_helpers.py
@@ -86,11 +86,9 @@ def build_app_with_bash_helpers(app_dir, project_id):
         # Add lines to the beginning of the job to make and use our new dx-toolkit
         preamble = []
         #preamble.append("cd {appdir}/resources && git clone https://github.com/dnanexus/dx-toolkit.git".format(appdir=updated_app_dir))
-        preamble.append('sudo pip install --upgrade virtualenv\n')
-        #preamble.append('make -C {toolkitdir} python\n'.format(toolkitdir=dxtoolkit_dir))
-        #preamble.append('source {toolkitdir}/environment\n'.format(toolkitdir=dxtoolkit_dir))
-        preamble.append('make -C /dxtoolkit clean python\n')
-        preamble.append('source /dxtoolkit/environment\n')
+        preamble.append('python3 /dxtoolkit/src/python/setup.py sdist\n')
+        preamble.append('DIST=$(ls /dxtoolkit/src/python/dist)\n')
+        preamble.append('python3 -m pip install -U /dxtoolkit/src/python/dist/$DIST\n')
         # Now find the applet entry point file and prepend the
         # operations above, overwriting it in place.
         dxapp_json = json.load(open(os.path.join(app_dir, 'dxapp.json')))

--- a/src/python/test/test_dx_bash_helpers.py
+++ b/src/python/test/test_dx_bash_helpers.py
@@ -97,7 +97,7 @@ def build_app_with_bash_helpers(app_dir, project_id):
             raise Exception('Sorry, I only know how to patch bash apps for remote testing')
         entry_point_filename = os.path.join(app_dir, dxapp_json['runSpec']['file'])
         with open(entry_point_filename) as fh:
-            entry_point_data = ''.join(preamble) + ofh.read()
+            entry_point_data = ''.join(preamble) + fh.read()
         with open(os.path.join(updated_app_dir, dxapp_json['runSpec']['file']), 'w') as fh:
             fh.write(entry_point_data)
 

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -3443,6 +3443,7 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
         run_resp = dxpy.api.workflow_run(workflow_id,
                                          {"project": self.project,
                                           "input": {(stage_id + ".number"): 32}})
+        print("RUN RESP")
         print(run_resp)
         first_analysis_id = run_resp['id']
         self.assertTrue(first_analysis_id.startswith('analysis-'))

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -3456,6 +3456,7 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
         # Running the workflow again with no changes should result in
         # the job getting reused
         run_output = run("dx run " + workflow_id + " -i0.number=32 -y").strip()
+        print(run_output)
         self.assertIn('will reuse results from a previous analysis', run_output)
         self.assertIn(job_id, run_output)
         second_analysis_id = run_output[run_output.rfind('analysis-'):]

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -3378,6 +3378,7 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
 
         # no change: expect both stages to have reused jobs
         no_change_analysis_desc = dxpy.describe(no_change_analysis_id)
+        print(no_change_analysis_desc)
         self.assertEqual(no_change_analysis_desc['stages'][0]['execution']['id'],
                          orig_analysis_desc['stages'][0]['execution']['id'])
         self.assertEqual(no_change_analysis_desc['stages'][1]['execution']['id'],
@@ -3442,6 +3443,7 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
         run_resp = dxpy.api.workflow_run(workflow_id,
                                          {"project": self.project,
                                           "input": {(stage_id + ".number"): 32}})
+        print(run_resp)
         first_analysis_id = run_resp['id']
         self.assertTrue(first_analysis_id.startswith('analysis-'))
         job_id = run_resp['stages'][0]
@@ -3503,6 +3505,7 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
         self.assertEqual(all_stg_req_desc['stages'][1]['execution']['instanceType'],
                          'mem2_hdd2_x1')
         stg_req_desc = dxpy.describe(stg_req_id)
+        print(stg_req_desc)
         self.assertEqual(stg_req_desc['stages'][0]['execution']['instanceType'],
                          'mem2_hdd2_x2')
         self.assertEqual(stg_req_desc['stages'][1]['execution']['instanceType'],
@@ -3554,6 +3557,7 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
 
         def expect_stage_folders(analysis_id, first_stage_folder, second_stage_folder):
             analysis_desc = dxpy.describe(analysis_id)
+            print(analysis_desc)
             self.assertEqual(analysis_desc['stages'][0]['execution']['folder'],
                              first_stage_folder)
             self.assertEqual(analysis_desc['stages'][1]['execution']['folder'],

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -3449,9 +3449,7 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
         self.assertTrue(first_analysis_id.startswith('analysis-'))
         job_id = run_resp['stages'][0]
         self.assertTrue(job_id.startswith('job-'))
-
-        # wait for events to propagate and for the job to be created
-        time.sleep(300)
+        dxpy.DXAnalysis(first_analysis_id).wait_on_done(timeout=400)
 
         # Running the workflow again with no changes should result in
         # the job getting reused

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -3363,6 +3363,7 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
 
         # run it
         analysis_id = run("dx run myworkflow -y --brief").strip()
+        dxpy.DXAnalysis(analysis_id).wait_on_done(timeout=500)
 
         # test cases
         no_change_analysis_id = run("dx run --clone " + analysis_id + " --brief -y").strip()
@@ -3447,7 +3448,7 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
         self.assertTrue(first_analysis_id.startswith('analysis-'))
         job_id = run_resp['stages'][0]
         self.assertTrue(job_id.startswith('job-'))
-        dxpy.DXAnalysis(first_analysis_id).wait_on_done(timeout=400)
+        dxpy.DXAnalysis(first_analysis_id).wait_on_done(timeout=500)
 
         # Running the workflow again with no changes should result in
         # the job getting reused

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -3371,7 +3371,7 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
         change_inst_type_analysis_id = run("dx run --clone " + analysis_id +
                                            " --instance-type mem2_hdd2_x2 --brief -y").strip()
 
-        time.sleep(2) # May need to wait for any new jobs to be created in the system
+        time.sleep(25) # May need to wait for any new jobs to be created in the system
 
         # make assertions for test cases
         orig_analysis_desc = dxpy.describe(analysis_id)

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -3443,8 +3443,6 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
         run_resp = dxpy.api.workflow_run(workflow_id,
                                          {"project": self.project,
                                           "input": {(stage_id + ".number"): 32}})
-        print("RUN RESP")
-        print(run_resp)
         first_analysis_id = run_resp['id']
         self.assertTrue(first_analysis_id.startswith('analysis-'))
         job_id = run_resp['stages'][0]
@@ -3454,7 +3452,6 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
         # Running the workflow again with no changes should result in
         # the job getting reused
         run_output = run("dx run " + workflow_id + " -i0.number=32 -y").strip()
-        print(run_output)
         self.assertIn('will reuse results from a previous analysis', run_output)
         self.assertIn(job_id, run_output)
         second_analysis_id = run_output[run_output.rfind('analysis-'):]
@@ -3500,13 +3497,11 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
         self.assertEqual(no_req_desc['stages'][1]['execution']['instanceType'],
                          self.default_inst_type)
         all_stg_req_desc = dxpy.describe(all_stg_req_id)
-        print(all_stg_req_desc)
         self.assertEqual(all_stg_req_desc['stages'][0]['execution']['instanceType'],
                          'mem2_hdd2_x1')
         self.assertEqual(all_stg_req_desc['stages'][1]['execution']['instanceType'],
                          'mem2_hdd2_x1')
         stg_req_desc = dxpy.describe(stg_req_id)
-        print(stg_req_desc)
         self.assertEqual(stg_req_desc['stages'][0]['execution']['instanceType'],
                          'mem2_hdd2_x2')
         self.assertEqual(stg_req_desc['stages'][1]['execution']['instanceType'],
@@ -3558,7 +3553,6 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
 
         def expect_stage_folders(analysis_id, first_stage_folder, second_stage_folder):
             analysis_desc = dxpy.describe(analysis_id)
-            print(analysis_desc)
             self.assertEqual(analysis_desc['stages'][0]['execution']['folder'],
                              first_stage_folder)
             self.assertEqual(analysis_desc['stages'][1]['execution']['folder'],

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -3451,7 +3451,7 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
         self.assertTrue(job_id.startswith('job-'))
 
         # wait for events to propagate and for the job to be created
-        time.sleep(2)
+        time.sleep(300)
 
         # Running the workflow again with no changes should result in
         # the job getting reused

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -3500,6 +3500,7 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
         self.assertEqual(no_req_desc['stages'][1]['execution']['instanceType'],
                          self.default_inst_type)
         all_stg_req_desc = dxpy.describe(all_stg_req_id)
+        print(all_stg_req_desc)
         self.assertEqual(all_stg_req_desc['stages'][0]['execution']['instanceType'],
                          'mem2_hdd2_x1')
         self.assertEqual(all_stg_req_desc['stages'][1]['execution']['instanceType'],

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -3554,7 +3554,7 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
         # only modify one
         per_stg_folders_id_3 = run(cmd + '--stage-output-folder ' + stage_ids[0] + ' /hello').strip()
 
-        time.sleep(2) # give time for all jobs to be generated
+        time.sleep(10) # give time for all jobs to be generated
 
         def expect_stage_folders(analysis_id, first_stage_folder, second_stage_folder):
             analysis_desc = dxpy.describe(analysis_id)

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -3492,7 +3492,7 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
         stg_req_id = run('dx run myworkflow --instance-type an=awful=name=mem2_hdd2_x2 ' +
                          '--instance-type second=mem2_hdd2_x1 -y --brief').strip()
 
-        time.sleep(2) # give time for all jobs to be populated
+        time.sleep(10) # give time for all jobs to be populated
 
         no_req_desc = dxpy.describe(no_req_id)
         self.assertEqual(no_req_desc['stages'][0]['execution']['instanceType'],

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -3420,7 +3420,7 @@ class TestDXClientWorkflow(DXTestCaseBuildWorkflows):
             self.assertEqual(new_analysis_desc['folder'], '/foo')
             self.assertEqual(new_analysis_desc['tags'], ['sometag'])
             self.assertEqual(new_analysis_desc['properties'], {'propkey': 'propval'})
-            time.sleep(2)
+            time.sleep(10)
             new_job_desc = dxpy.describe(new_analysis_desc['stages'][0]['execution']['id'])
             self.assertEqual(new_job_desc['project'], other_proj_id)
             self.assertEqual(new_job_desc['input']['number'], 32)

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -1577,6 +1577,7 @@ def main(number):
 
         # empty rerun_stages should reuse results
         rerun_analysis = dxworkflow.run({}, rerun_stages=[])
+        print(rerun_analysis.describe())
         self.assertEqual(rerun_analysis.describe()['stages'][0]['execution']['id'],
                          job_ids[0])
 

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -1574,10 +1574,10 @@ def main(number):
         # make initial analysis
         dxanalysis = dxworkflow.run({})
         job_ids = [dxanalysis.describe()['stages'][0]['execution']['id']]
+        dxanalysis.wait_on_done(timeout=500)
 
         # empty rerun_stages should reuse results
         rerun_analysis = dxworkflow.run({}, rerun_stages=[])
-        print(rerun_analysis.describe())
         self.assertEqual(rerun_analysis.describe()['stages'][0]['execution']['id'],
                          job_ids[0])
 


### PR DESCRIPTION
Wrap `xattr` import in a try/catch in `dx-upload-all-outputs`. Was causing some test failures. 

Upgrade some of the dxclient test applets to Ubuntu 20.04 and Python 3. 

Fix a few dxclient workflow tests which require waiting for analysis execution and stage doc creation. 