### PR TITLE
DEVEX-1894 Connection (socket) leak in DxFile

### DIFF
--- a/src/java/src/main/java/com/dnanexus/DXEnvironment.java
+++ b/src/java/src/main/java/com/dnanexus/DXEnvironment.java
@@ -41,7 +41,7 @@ import com.google.common.base.Preconditions;
  * Immutable class storing configuration for selecting, authenticating to, and communicating with a
  * DNAnexus API server.
  */
-public class DXEnvironment {
+public class DXEnvironment implements AutoCloseable {
 
     /**
      * Builder class for creating DXEnvironment objects.
@@ -723,6 +723,11 @@ public class DXEnvironment {
      */
     public int getConnectionTimeout() {
         return this.connectionTimeout;
+    }
+
+    @Override
+    public void close() throws IOException {
+        httpclient.close();
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(DXEnvironment.class);

--- a/src/java/src/main/java/com/dnanexus/DXEnvironment.java
+++ b/src/java/src/main/java/com/dnanexus/DXEnvironment.java
@@ -580,7 +580,7 @@ public class DXEnvironment {
                 .build();
     }
 
-    public HttpClient getHttpClient() {
+    HttpClient getHttpClient() {
         return httpclient;
     }
 

--- a/src/java/src/main/java/com/dnanexus/DXFile.java
+++ b/src/java/src/main/java/com/dnanexus/DXFile.java
@@ -16,17 +16,19 @@
 
 package com.dnanexus;
 
-import com.dnanexus.DXHTTPRequest.RetryStrategy;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpResponse;
@@ -38,9 +40,19 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.impl.client.HttpClientBuilder;
 
-import java.io.*;
-import java.util.*;
+import com.dnanexus.DXHTTPRequest.RetryStrategy;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
 /**
  * A file (an opaque sequence of bytes).

--- a/src/java/src/main/java/com/dnanexus/DXHTTPRequest.java
+++ b/src/java/src/main/java/com/dnanexus/DXHTTPRequest.java
@@ -269,7 +269,6 @@ public class DXHTTPRequest {
         }
 
         request.setHeader("Content-Type", "application/json");
-        request.setHeader("Connection", "close");
         request.setHeader("Authorization", securityContext.get("auth_token_type").textValue() + " "
                 + securityContext.get("auth_token").textValue());
         request.setEntity(new StringEntity(data, Charset.forName("UTF-8")));

--- a/src/java/src/test/java/com/dnanexus/DXHTTPRequestTest.java
+++ b/src/java/src/test/java/com/dnanexus/DXHTTPRequestTest.java
@@ -16,6 +16,22 @@
 
 package com.dnanexus;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.http.client.HttpClient;
+import org.apache.http.pool.ConnPoolControl;
+import org.junit.Assert;
+import org.junit.Test;
+
 import com.dnanexus.DXHTTPRequest.RetryStrategy;
 import com.dnanexus.exceptions.InternalErrorException;
 import com.dnanexus.exceptions.InvalidAuthenticationException;
@@ -28,16 +44,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
-import org.apache.http.client.HttpClient;
-import org.apache.http.pool.ConnPoolControl;
-import org.junit.Assert;
-import org.junit.Test;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.*;
 
 /**
  * Tests for DXHTTPRequest and DXEnvironment.


### PR DESCRIPTION
Hi, this is a follow-up to Case #00026075.

Generally, the sole problem is in the constant creation of `HttpClient` overall and specifically whenever `FileApiInputStream` empties its buffer (see [DXFile:577](https://github.com/dnanexus/dx-toolkit/blob/master/src/java/src/main/java/com/dnanexus/DXFile.java#L577) for ex).
This leads to the creation of a new connection pool and leasing a single connection. Then without closing the `HttpClient` we just leave it to GC to cleanup. Since the default protocol for `HttpClient` is `HTTP 1.1` and [it requires any connection to be persistent by default](https://tools.ietf.org/html/rfc2616#section-8.1.2) we can't rely on the server or client to terminate TCP session unless we provide `Connection: close` header explicitly and we can't rely on any timeouts (connection/read/write) due to its defaults of infinity.

It seems to me that just sharing a single `HttpClient` for the entire SDK is the most sensible way to handle this.
Essentially, this PR just moves the creation of `HttpClient` from `DXHTTPRequest` to the `DXEnvironment` and since the environment is involved in every request anyway, it might as well manage the client.

This change renders some of the getters of `DXEnvironment` (timeouts, proxy) unused, but I didn't remove them for backward compatibility. You guys should know better if they could be removed.

A couple of questions:
- This change constrains every HTTP request to a single connection pool. Which is basically an introduction of a bottleneck into the library. Due to a large number of use-cases from a mobile app just checking job statuses once in X min to 72 core servers utilizing full bandwidth to download files from DNA nexus as fast as possible I think we need to introduce a way for users to fine-tune how a connection pool or the entire HttpClient should behave. There are a few ways I know of:
  - expose `http.connection-manager.max-per-host` and `http.connection-manager.max-total` [HttpClient settings](https://github.com/apache/httpcomponents-client/blob/4.5.x/httpclient/src/examples/org/apache/http/examples/client/ClientConfiguration.java#L198) 
  - allow them to provide their own `HttpClient` instance which they could tune however they like. This also allows sharing the same `HttpClient` between multiple `DXEnvironments` (for ex: ETL between 2 projects)