### PR TITLE
Remove very old/optional dependencies

### DIFF
--- a/src/python/dxpy/cli/exec_io.py
+++ b/src/python/dxpy/cli/exec_io.py
@@ -37,7 +37,10 @@ from ..compat import input, str, shlex, basestring, USING_PYTHON2
 try:
     import gnureadline as readline
 except ImportError:
-    import readline
+    try:
+        import readline
+    except ImportError:
+        pass
 ####################
 # -i Input Parsing #
 ####################

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -4,6 +4,3 @@ python-dateutil>=2.5
 psutil>=3.3.0
 requests>=2.8.0,<2.24.0
 cryptography>=2.3,<3.0
-gnureadline==8.0.0; sys_platform == "darwin" and python_version < "3.9"
-pyreadline==2.1; sys_platform == "win32" 
-colorama==0.2.4; sys_platform == "win32"


### PR DESCRIPTION
1. Remove windows-only colorama dependency (that seems like it doesn't
matter regardless?). This version of colorama is from 2014. Makes dxpy
unable to work with other packages.
2. Remove pyreadline and gnureadline dependency (both repos say
generally not needed) - codebase is designed to not have readline
installed and still work.

While readline may still be necessary on OSX, dxpy prints out that it's
not available and all usages of readline are within try/except so it
should not actually break anything.

closes #676 