### PR TITLE
Update dx-app-wizard default to Ubuntu 20.04

### DIFF
--- a/src/python/dxpy/scripts/dx_app_wizard.py
+++ b/src/python/dxpy/scripts/dx_app_wizard.py
@@ -395,8 +395,8 @@ array:boolean  array:int      boolean        hash           string''')
     ######################
 
     app_json['runSpec']['distribution'] = 'Ubuntu'
-    app_json['runSpec']['release'] = '16.04'
-    app_json['runSpec']['version'] = "1"
+    app_json['runSpec']['release'] = '20.04'
+    app_json['runSpec']['version'] = "0"
 
     #################
     # WRITING FILES #

--- a/src/python/test/test_dx_app_wizard.py
+++ b/src/python/test/test_dx_app_wizard.py
@@ -153,8 +153,8 @@ class TestDXAppWizard(DXTestCase):
         self.assertEqual(dxapp_json['regionalOptions']['aws:us-east-1']['systemRequirements']['*']['instanceType'],
                          InstanceTypesCompleter.default_instance_type.Name)
         self.assertEqual(dxapp_json['runSpec']['distribution'], 'Ubuntu')
-        self.assertEqual(dxapp_json['runSpec']['release'], '16.04')
-        self.assertEqual(dxapp_json['runSpec']['version'], '1')
+        self.assertEqual(dxapp_json['runSpec']['release'], '20.04')
+        self.assertEqual(dxapp_json['runSpec']['version'], '0')
         self.assertEqual(dxapp_json['runSpec']['interpreter'], 'python3')
         self.assertEqual(dxapp_json['runSpec']['timeoutPolicy']['*']['hours'], 24)
 


### PR DESCRIPTION
Update the default `runSpec` from Ubuntu 16.04 v1 to Ubuntu 20.04. 