### PR TITLE
TIP-2332: New databaseUIViewOnly project flag to dx-toolkit

### DIFF
--- a/src/python/dxpy/bindings/dxproject.py
+++ b/src/python/dxpy/bindings/dxproject.py
@@ -300,14 +300,14 @@ class DXProject(DXContainer):
         :type download_restricted: boolean
         :param contains_phi: If provided, whether the project should be marked as containing protected health information (PHI)
         :type contains_phi: boolean
-        :param database_ui_view_only: If provided, whether the viewers on the project can access the database details directly
-        :type database_ui_view_only: boolean
         :param tags: If provided, tags to associate with the project
         :type tags: list of strings
         :param properties: If provided, properties to associate with the project
         :type properties: dict
         :param bill_to: If provided, ID of the entity to which any costs associated with this project will be billed; must be the ID of the requesting user or an org of which the requesting user is a member with allowBillableActivities permission
         :type bill_to: string
+        :param database_ui_view_only: If provided, whether the viewers on the project can access the database data directly
+        :type database_ui_view_only: boolean
 
         Creates a new project. Initially only the user performing this action
         will be in the permissions/member list, with ADMINISTER access.
@@ -330,10 +330,10 @@ class DXProject(DXContainer):
             input_hash["downloadRestricted"] = download_restricted
         if contains_phi is not None:
             input_hash["containsPHI"] = contains_phi
-        if database_ui_view_only is not None:
-            input_hash["databaseUIViewOnly"] = database_ui_view_only
         if bill_to is not None:
             input_hash["billTo"] = bill_to
+        if database_ui_view_only is not None:
+            input_hash["databaseUIViewOnly"] = database_ui_view_only
         if tags is not None:
             input_hash["tags"] = tags
         if properties is not None:
@@ -345,7 +345,8 @@ class DXProject(DXContainer):
 
     def update(self, name=None, summary=None, description=None, protected=None,
                restricted=None, download_restricted=None, version=None, 
-               allowed_executables=None, unset_allowed_executables=None, **kwargs):
+               allowed_executables=None, unset_allowed_executables=None, 
+               database_ui_view_only=None, **kwargs):
         """
         :param name: If provided, the new project name
         :type name: string
@@ -361,6 +362,8 @@ class DXProject(DXContainer):
         :type download_restricted: boolean
         :param allowed_executables: If provided, these are the only executable ID(s) allowed to run as root executions in this project
         :type allowed_executables: list
+        :param database_ui_view_only: If provided, whether the viewers on the project can access the database data directly
+        :type database_ui_view_only: boolean
         :param version: If provided, the update will only occur if the value matches the current project's version number
         :type version: int
 
@@ -390,6 +393,8 @@ class DXProject(DXContainer):
             update_hash["allowedExecutables"] = allowed_executables
         if unset_allowed_executables is not None:
             update_hash["allowedExecutables"] = None
+        if database_ui_view_only is not None:
+            input_hash["databaseUIViewOnly"] = database_ui_view_only
         dxpy.api.project_update(self._dxid, update_hash, **kwargs)
 
     def invite(self, invitee, level, send_email=True, **kwargs):

--- a/src/python/dxpy/bindings/dxproject.py
+++ b/src/python/dxpy/bindings/dxproject.py
@@ -282,8 +282,9 @@ class DXProject(DXContainer):
     _class = "project"
 
     def new(self, name, summary=None, description=None, protected=None,
-            restricted=None, download_restricted=None, contains_phi=None, tags=None,
-            properties=None, bill_to=None, **kwargs):
+            restricted=None, download_restricted=None, contains_phi=None, 
+            tags=None, properties=None, bill_to=None, database_ui_view_only=None,
+            **kwargs):
         """
         :param name: The name of the project
         :type name: string
@@ -299,6 +300,8 @@ class DXProject(DXContainer):
         :type download_restricted: boolean
         :param contains_phi: If provided, whether the project should be marked as containing protected health information (PHI)
         :type contains_phi: boolean
+        :param database_ui_view_only: If provided, whether the viewers on the project can access the database details directly
+        :type database_ui_view_only: boolean
         :param tags: If provided, tags to associate with the project
         :type tags: list of strings
         :param properties: If provided, properties to associate with the project
@@ -327,6 +330,8 @@ class DXProject(DXContainer):
             input_hash["downloadRestricted"] = download_restricted
         if contains_phi is not None:
             input_hash["containsPHI"] = contains_phi
+        if database_ui_view_only is not None:
+            input_hash["databaseUIViewOnly"] = database_ui_view_only
         if bill_to is not None:
             input_hash["billTo"] = bill_to
         if tags is not None:

--- a/src/python/dxpy/bindings/dxproject.py
+++ b/src/python/dxpy/bindings/dxproject.py
@@ -394,7 +394,7 @@ class DXProject(DXContainer):
         if unset_allowed_executables is not None:
             update_hash["allowedExecutables"] = None
         if database_ui_view_only is not None:
-            input_hash["databaseUIViewOnly"] = database_ui_view_only
+            update_hash["databaseUIViewOnly"] = database_ui_view_only
         dxpy.api.project_update(self._dxid, update_hash, **kwargs)
 
     def invite(self, invitee, level, send_email=True, **kwargs):

--- a/src/python/dxpy/cli/parsers.py
+++ b/src/python/dxpy/cli/parsers.py
@@ -281,10 +281,6 @@ contains_phi.add_argument('--phi', dest='containsPHI', choices=["true", "false"]
                           help='If set to true, only projects that contain PHI data will be retrieved. ' +
                           'If set to false, only projects that do not contain PHI data will be retrieved.')
 
-database_ui_view_only = argparse.ArgumentParser(add_help=False)
-database_ui_view_only.add_argument('--database-ui-view-only', dest='databaseUIViewOnly', choices=["true", "false"],
-                          help='If set to true, viewers of the project will not be able to access database data directly')
-
 def _parse_dictionary_or_string_input(thing, arg_name):
     if thing.strip().startswith('{'):
         # expects a map, e.g of entry point to instance type or instance count

--- a/src/python/dxpy/cli/parsers.py
+++ b/src/python/dxpy/cli/parsers.py
@@ -281,6 +281,10 @@ contains_phi.add_argument('--phi', dest='containsPHI', choices=["true", "false"]
                           help='If set to true, only projects that contain PHI data will be retrieved. ' +
                           'If set to false, only projects that do not contain PHI data will be retrieved.')
 
+database_ui_view_only = argparse.ArgumentParser(add_help=False)
+database_ui_view_only.add_argument('--database-ui-view-only', dest='databaseUIViewOnly', choices=["true", "false"],
+                          help='If set to true, viewers of the project will not be able to access database details directly')
+
 def _parse_dictionary_or_string_input(thing, arg_name):
     if thing.strip().startswith('{'):
         # expects a map, e.g of entry point to instance type or instance count
@@ -343,6 +347,8 @@ def get_update_project_args(args):
         input_params["downloadRestricted"] = True if args.download_restricted == 'true' else False
     if args.containsPHI is not None:
         input_params["containsPHI"] = True if args.containsPHI == 'true' else False
+    if args.database_ui_view_only is not None:
+        input_params["databaseUIViewOnly"] = True if args.database_ui_view_only == 'true' else False
     if args.bill_to is not None:
         input_params["billTo"] = args.bill_to
     if args.allowed_executables is not None:

--- a/src/python/dxpy/cli/parsers.py
+++ b/src/python/dxpy/cli/parsers.py
@@ -283,7 +283,7 @@ contains_phi.add_argument('--phi', dest='containsPHI', choices=["true", "false"]
 
 database_ui_view_only = argparse.ArgumentParser(add_help=False)
 database_ui_view_only.add_argument('--database-ui-view-only', dest='databaseUIViewOnly', choices=["true", "false"],
-                          help='If set to true, viewers of the project will not be able to access database details directly')
+                          help='If set to true, viewers of the project will not be able to access database data directly')
 
 def _parse_dictionary_or_string_input(thing, arg_name):
     if thing.strip().startswith('{'):

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -48,7 +48,7 @@ from ..cli.parsers import (no_color_arg, delim_arg, env_args, stdout_args, all_a
                            process_single_dataobject_output_args, find_executions_args, add_find_executions_search_gp,
                            set_env_from_args, extra_args, process_extra_args, DXParserError, exec_input_args,
                            instance_type_arg, process_instance_type_arg, process_instance_count_arg, get_update_project_args,
-                           property_args, tag_args, contains_phi, process_phi_param)
+                           property_args, tag_args, contains_phi, database_ui_view_only, process_phi_param)
 from ..cli.exec_io import (ExecutableInputs, format_choices_or_suggestions)
 from ..cli.org import (get_org_invite_args, add_membership, remove_membership, update_membership, new_org, update_org,
                        find_orgs, org_find_members, org_find_projects, org_find_apps)
@@ -1397,6 +1397,8 @@ def new_project(args):
         inputs["region"] = args.region
     if args.phi:
         inputs["containsPHI"] = True
+    if args.database_ui_view_only:
+        inputs["databaseUIViewOnly"] = True
 
     try:
         resp = dxpy.api.project_new(inputs)
@@ -4759,6 +4761,8 @@ parser_update_project.add_argument('--download-restricted', choices=["true", "fa
                                    help="Whether the project should be DOWNLOAD RESTRICTED")
 parser_update_project.add_argument('--containsPHI', choices=["true"],
                                    help="Flag to tell if project contains PHI")
+parser_update_project.add_argument('--database-ui-view-only', choices=["true", "false"],
+                                   help="whether the viewers on the project can access the database details directly")
 parser_update_project.add_argument('--bill-to', help="Update the user or org ID of the billing account", type=str)
 allowed_executables_group = parser_update_project.add_mutually_exclusive_group()
 allowed_executables_group.add_argument('--allowed-executables', help='Executable ID(s) this project is allowed to run.  This operation overrides any existing list of executables.', type=str, nargs="+")
@@ -5050,6 +5054,8 @@ parser_new_project.add_argument('-s', '--select', help='Select the new project a
                                 action='store_true')
 parser_new_project.add_argument('--bill-to', help='ID of the user or org to which the project will be billed. The default value is the billTo of the requesting user.')
 parser_new_project.add_argument('--phi', help='Add PHI protection to project', default=False,
+                                action='store_true')
+parser_new_project.add_argument('--database-ui-view-only', help='Restrict viewers on the project from accessing the database details directly', default=False,
                                 action='store_true')
 parser_new_project.set_defaults(func=new_project)
 register_parser(parser_new_project, subparsers_action=subparsers_new, categories='fs')

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -4762,7 +4762,7 @@ parser_update_project.add_argument('--download-restricted', choices=["true", "fa
 parser_update_project.add_argument('--containsPHI', choices=["true"],
                                    help="Flag to tell if project contains PHI")
 parser_update_project.add_argument('--database-ui-view-only', choices=["true", "false"],
-                                   help="whether the viewers on the project can access the database details directly")
+                                   help="Whether the viewers on the project can access the database details directly")
 parser_update_project.add_argument('--bill-to', help="Update the user or org ID of the billing account", type=str)
 allowed_executables_group = parser_update_project.add_mutually_exclusive_group()
 allowed_executables_group.add_argument('--allowed-executables', help='Executable ID(s) this project is allowed to run.  This operation overrides any existing list of executables.', type=str, nargs="+")

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -48,7 +48,7 @@ from ..cli.parsers import (no_color_arg, delim_arg, env_args, stdout_args, all_a
                            process_single_dataobject_output_args, find_executions_args, add_find_executions_search_gp,
                            set_env_from_args, extra_args, process_extra_args, DXParserError, exec_input_args,
                            instance_type_arg, process_instance_type_arg, process_instance_count_arg, get_update_project_args,
-                           property_args, tag_args, contains_phi, database_ui_view_only, process_phi_param)
+                           property_args, tag_args, contains_phi, process_phi_param)
 from ..cli.exec_io import (ExecutableInputs, format_choices_or_suggestions)
 from ..cli.org import (get_org_invite_args, add_membership, remove_membership, update_membership, new_org, update_org,
                        find_orgs, org_find_members, org_find_projects, org_find_apps)
@@ -1397,8 +1397,6 @@ def new_project(args):
         inputs["region"] = args.region
     if args.phi:
         inputs["containsPHI"] = True
-    if args.database_ui_view_only:
-        inputs["databaseUIViewOnly"] = True
 
     try:
         resp = dxpy.api.project_new(inputs)
@@ -4762,7 +4760,7 @@ parser_update_project.add_argument('--download-restricted', choices=["true", "fa
 parser_update_project.add_argument('--containsPHI', choices=["true"],
                                    help="Flag to tell if project contains PHI")
 parser_update_project.add_argument('--database-ui-view-only', choices=["true", "false"],
-                                   help="Whether the viewers on the project can access the database details directly")
+                                   help="Whether the viewers on the project can access the database data directly")
 parser_update_project.add_argument('--bill-to', help="Update the user or org ID of the billing account", type=str)
 allowed_executables_group = parser_update_project.add_mutually_exclusive_group()
 allowed_executables_group.add_argument('--allowed-executables', help='Executable ID(s) this project is allowed to run.  This operation overrides any existing list of executables.', type=str, nargs="+")
@@ -5054,8 +5052,6 @@ parser_new_project.add_argument('-s', '--select', help='Select the new project a
                                 action='store_true')
 parser_new_project.add_argument('--bill-to', help='ID of the user or org to which the project will be billed. The default value is the billTo of the requesting user.')
 parser_new_project.add_argument('--phi', help='Add PHI protection to project', default=False,
-                                action='store_true')
-parser_new_project.add_argument('--database-ui-view-only', help='Restrict viewers on the project from accessing the database details directly', default=False,
                                 action='store_true')
 parser_new_project.set_defaults(func=new_project)
 register_parser(parser_new_project, subparsers_action=subparsers_new, categories='fs')

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -1397,6 +1397,8 @@ def new_project(args):
         inputs["region"] = args.region
     if args.phi:
         inputs["containsPHI"] = True
+    if args.database_ui_view_only:
+        inputs["databaseUIViewOnly"] = True
 
     try:
         resp = dxpy.api.project_new(inputs)
@@ -5052,6 +5054,8 @@ parser_new_project.add_argument('-s', '--select', help='Select the new project a
                                 action='store_true')
 parser_new_project.add_argument('--bill-to', help='ID of the user or org to which the project will be billed. The default value is the billTo of the requesting user.')
 parser_new_project.add_argument('--phi', help='Add PHI protection to project', default=False,
+                                action='store_true')
+parser_new_project.add_argument('--database-ui-view-only', help='If set to true, viewers of the project will not be able to access database data directly', default=False,
                                 action='store_true')
 parser_new_project.set_defaults(func=new_project)
 register_parser(parser_new_project, subparsers_action=subparsers_new, categories='fs')

--- a/src/python/dxpy/utils/describe.py
+++ b/src/python/dxpy/utils/describe.py
@@ -444,7 +444,7 @@ def print_project_desc(desc, verbose=False):
         print_json_field("Restricted", desc["restricted"])
     if 'containsPHI' in desc:
         print_json_field('Contains PHI', desc['containsPHI'])
-    if 'databaseUIViewOnly' in desc:
+    if 'databaseUIViewOnly' in desc and desc['databaseUIViewOnly']:
         print_json_field('Database UI View Only', desc['databaseUIViewOnly'])
 
     # Usage

--- a/src/python/dxpy/utils/describe.py
+++ b/src/python/dxpy/utils/describe.py
@@ -380,7 +380,7 @@ def render_timestamp(timestamp):
     return datetime.datetime.fromtimestamp(timestamp//1000).ctime()
 
 
-FIELD_NAME_WIDTH = 20
+FIELD_NAME_WIDTH = 22
 
 
 def print_field(label, value):

--- a/src/python/dxpy/utils/describe.py
+++ b/src/python/dxpy/utils/describe.py
@@ -410,7 +410,7 @@ def print_project_desc(desc, verbose=False):
         'id', 'class', 'name', 'summary', 'description', 'protected', 'restricted', 'created', 'modified',
         'dataUsage', 'sponsoredDataUsage', 'tags', 'level', 'folders', 'objects', 'permissions', 'properties',
         'appCaches', 'billTo', 'version', 'createdBy', 'totalSponsoredEgressBytes', 'consumedSponsoredEgressBytes',
-        'containsPHI', 'region', 'storageCost', 'pendingTransfer','atSpendingLimit',
+        'containsPHI', 'databaseUIViewOnly', 'region', 'storageCost', 'pendingTransfer','atSpendingLimit',
         # Following are app container-specific
         'destroyAt', 'project', 'type', 'app', 'appName'
     ]
@@ -444,6 +444,8 @@ def print_project_desc(desc, verbose=False):
         print_json_field("Restricted", desc["restricted"])
     if 'containsPHI' in desc:
         print_json_field('Contains PHI', desc['containsPHI'])
+    if 'databaseUIViewOnly' in desc:
+        print_json_field('Database UI View Only', desc['databaseUIViewOnly'])
 
     # Usage
     print_field("Created", render_timestamp(desc['created']))

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -136,6 +136,7 @@ class TestDXProject(unittest.TestCase):
             self.assertEqual(desc["restricted"], False)
             self.assertEqual(desc["downloadRestricted"], False)
             self.assertEqual(desc["containsPHI"], False)
+            self.assertEqual(desc["databaseUIViewOnly"], False)
             self.assertEqual(desc["tags"], [])
             prop = dxpy.api.project_describe(dxproject.get_id(),
                                              {'fields': {'properties': True}})


### PR DESCRIPTION
This PR adds a new `--database-ui-view-only` project flag for `update` (which can be displayed via `describe`), as well as support for the flag in our `dxpy` bindings (for `new` and `update`)

The CLI parses the `database-ui-view-only` flag into `databaseUIViewOnly`, which is ultimately passed to the apiserver as an argument.