### PR TITLE
Apps-554 set globalworkflow project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 
 * `Total price` for `dx describe` prints formatted currency based on `currency` metadata
 
+### Fixed
+* `dx run <globalworkflow> --project/--destination/--folder` now submits analysis to given project or path
+
 ## [312.0] -  2021.07.06 
 
 * No significant changes

--- a/src/python/dxpy/bindings/dxglobalworkflow.py
+++ b/src/python/dxpy/bindings/dxglobalworkflow.py
@@ -262,7 +262,7 @@ class DXGlobalWorkflow(DXObject, DXExecutable):
         region = dxpy.api.project_describe(project,
                                            input_params={"fields": {"region": True}})["region"]
         dxworkflow = self.get_underlying_workflow(region)
-        return dxworkflow._get_run_input(workflow_input, **kwargs)
+        return dxworkflow._get_run_input(workflow_input, project=project, **kwargs)
 
     def _run_impl(self, run_input, **kwargs):
         if self._dxid is not None:

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -3381,8 +3381,6 @@ def run(args):
                 'Please run "dx select" to set the working project, or use --folder=project:path'
             ))
 
-    is_workflow = isinstance(handler, dxpy.DXWorkflow)
-    is_global_workflow = isinstance(handler, dxpy.DXGlobalWorkflow)
 
     # Get region from the project context
     args.region = None


### PR DESCRIPTION
This PR fixed the issue that when `dx run <globalworkflow> --project project-XXXXXX` does not submit the global workflow to the target project. Similar problems are observed when using flags '--destination', '--folder'.

It is caused by missing the 'project' argument when updating run inputs for the underlying workflow, and it is now fixed by bringing the 'project' argument back.

[APPS-554: Submitting globalworkflow does not respect project flag](https://jira.internal.dnanexus.com/browse/APPS-554)