### PR TITLE
DEVEX-1961 Support FIPS enabled Python

### DIFF
--- a/src/python/dxpy/bindings/dxdatabase_functions.py
+++ b/src/python/dxpy/bindings/dxdatabase_functions.py
@@ -257,7 +257,7 @@ def _download_dxdatabasefile(dxid, filename, src_filename, file_status, part_ret
                 if chunk_part != cur_part:
                     # TODO: remove permanently if we don't find use for this
                     # verify_part(cur_part, got_bytes, hasher)
-                    cur_part, got_bytes, hasher = chunk_part, 0, hashlib.md5()
+                    cur_part, got_bytes, hasher = chunk_part, 0, hashlib.new('md5', usedforsecurity=False)
                 got_bytes += len(chunk_data)
                 hasher.update(chunk_data)
                 fh.write(chunk_data)

--- a/src/python/dxpy/bindings/dxfile.py
+++ b/src/python/dxpy/bindings/dxfile.py
@@ -673,7 +673,7 @@ class DXFile(DXDataObject):
         if index is not None:
             req_input["index"] = int(index)
 
-        md5 = hashlib.md5()
+        md5 = hashlib.new('md5', usedforsecurity=False)
         if hasattr(data, 'seek') and hasattr(data, 'tell'):
             # data is a buffer; record initial position (so we can rewind back)
             rewind_input_buffer_offset = data.tell()

--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -350,7 +350,7 @@ def _download_dxfile(dxid, filename, part_retry_counter,
                     if "md5" not in part_info:
                         raise DXFileError("File {} does not contain part md5 checksums".format(dxfile.get_id()))
                     bytes_to_read = part_info["size"]
-                    hasher = hashlib.md5()
+                    hasher = hashlib.new('md5', usedforsecurity=False)
                     while bytes_to_read > 0:
                         chunk = fh.read(min(max_verify_chunk_size, bytes_to_read))
                         if len(chunk) < min(max_verify_chunk_size, bytes_to_read):
@@ -384,7 +384,7 @@ def _download_dxfile(dxid, filename, part_retry_counter,
                                                             do_first_task_sequentially=get_first_chunk_sequentially):
                 if chunk_part != cur_part:
                     verify_part(cur_part, got_bytes, hasher)
-                    cur_part, got_bytes, hasher = chunk_part, 0, hashlib.md5()
+                    cur_part, got_bytes, hasher = chunk_part, 0, hashlib.new('md5', usedforsecurity=False)
                 got_bytes += len(chunk_data)
                 hasher.update(chunk_data)
                 fh.write(chunk_data)


### PR DESCRIPTION
Support FIPS enabled Python https://github.com/dnanexus/dx-toolkit/issues/702

Refactor `hashlib.md5()` --> `hashlib.new('md5', usedforsecurity=False)`

`usedforsecurity` param is ignored on Python versions < 3.9. md5 is allowed in this context since it is only used for file part checksums file, not security. 