### PR TITLE
DEVEX-1961 Add md5_hasher() to compat functions

### DIFF
--- a/src/python/dxpy/bindings/dxdatabase_functions.py
+++ b/src/python/dxpy/bindings/dxdatabase_functions.py
@@ -36,7 +36,7 @@ from .. import logger
 from . import dxfile, DXFile
 from . import dxdatabase, DXDatabase
 from .dxfile import FILE_REQUEST_TIMEOUT
-from ..compat import open, USING_PYTHON2
+from ..compat import open, USING_PYTHON2, md5_hasher
 from ..exceptions import DXFileError, DXChecksumMismatchError, DXIncompleteReadsError, err_exit
 from ..utils import response_iterator
 import subprocess
@@ -257,7 +257,8 @@ def _download_dxdatabasefile(dxid, filename, src_filename, file_status, part_ret
                 if chunk_part != cur_part:
                     # TODO: remove permanently if we don't find use for this
                     # verify_part(cur_part, got_bytes, hasher)
-                    cur_part, got_bytes, hasher = chunk_part, 0, hashlib.md5()
+
+                    cur_part, got_bytes, hasher = chunk_part, 0, md5_hasher()
                 got_bytes += len(chunk_data)
                 hasher.update(chunk_data)
                 fh.write(chunk_data)

--- a/src/python/dxpy/bindings/dxfile.py
+++ b/src/python/dxpy/bindings/dxfile.py
@@ -34,7 +34,7 @@ from . import DXDataObject
 from ..exceptions import DXFileError, DXIncompleteReadsError
 from ..utils import warn
 from ..utils.resolver import object_exists_in_project
-from ..compat import BytesIO, basestring, USING_PYTHON2
+from ..compat import BytesIO, basestring, USING_PYTHON2, md5_hasher
 
 
 DXFILE_HTTP_THREADS = min(cpu_count(), 8)
@@ -673,7 +673,7 @@ class DXFile(DXDataObject):
         if index is not None:
             req_input["index"] = int(index)
 
-        md5 = hashlib.md5()
+        md5 = md5_hasher()
         if hasattr(data, 'seek') and hasattr(data, 'tell'):
             # data is a buffer; record initial position (so we can rewind back)
             rewind_input_buffer_offset = data.tell()

--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -37,7 +37,7 @@ import dxpy
 from .. import logger
 from . import dxfile, DXFile
 from .dxfile import FILE_REQUEST_TIMEOUT
-from ..compat import open, USING_PYTHON2
+from ..compat import open, md5_hasher, USING_PYTHON2
 from ..exceptions import DXFileError, DXPartLengthMismatchError, DXChecksumMismatchError, DXIncompleteReadsError, err_exit
 from ..utils import response_iterator
 import subprocess
@@ -350,7 +350,7 @@ def _download_dxfile(dxid, filename, part_retry_counter,
                     if "md5" not in part_info:
                         raise DXFileError("File {} does not contain part md5 checksums".format(dxfile.get_id()))
                     bytes_to_read = part_info["size"]
-                    hasher = hashlib.md5()
+                    hasher = md5_hasher()
                     while bytes_to_read > 0:
                         chunk = fh.read(min(max_verify_chunk_size, bytes_to_read))
                         if len(chunk) < min(max_verify_chunk_size, bytes_to_read):
@@ -384,7 +384,7 @@ def _download_dxfile(dxid, filename, part_retry_counter,
                                                             do_first_task_sequentially=get_first_chunk_sequentially):
                 if chunk_part != cur_part:
                     verify_part(cur_part, got_bytes, hasher)
-                    cur_part, got_bytes, hasher = chunk_part, 0, hashlib.md5()
+                    cur_part, got_bytes, hasher = chunk_part, 0, md5_hasher()
                 got_bytes += len(chunk_data)
                 hasher.update(chunk_data)
                 fh.write(chunk_data)

--- a/src/python/dxpy/compat.py
+++ b/src/python/dxpy/compat.py
@@ -16,7 +16,7 @@
 
 from __future__ import print_function, unicode_literals, division, absolute_import
 
-import os, sys, io, locale, threading
+import os, sys, io, locale, threading, hashlib
 from io import TextIOWrapper
 from contextlib import contextmanager
 try:
@@ -220,3 +220,11 @@ def unwrap_stream(stream_name):
     finally:
         if wrapped_stream:
             setattr(sys, stream_name, wrapped_stream)
+
+# Support FIPS enabled Python
+def md5_hasher():
+    try:
+        md5_hasher = hashlib.new('md5', usedforsecurity=False)
+    except:
+        md5_hasher = hashlib.new('md5')
+    return md5_hasher


### PR DESCRIPTION
For FIPS enabled python compatibility, attempt to pass the `usedforsecurity=False` param.