### PR TITLE
PTFM-28916 newAuthToken client test fix

### DIFF
--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -1456,22 +1456,22 @@ class TestDXClientUploadDownload(DXTestCase):
     def test_dx_upload_with_upload_perm(self):
         with temporary_project('test proj with UPLOAD perms', reclaim_permissions=True) as temp_project:
             data = {"scope": {"projects": {"*": "UPLOAD"}}}
-            upload_only_auth_token = dxpy.DXHTTPRequest(dxpy.get_auth_server_name() + '/system/newAuthToken', data,
-                                                        prepend_srv=False, always_retry=True)
-            token_callable = dxpy.DXHTTPOAuth2({"auth_token": upload_only_auth_token["access_token"],
-                                                "auth_token_type": upload_only_auth_token["token_type"],
-                                                "auth_token_signature": upload_only_auth_token["token_signature"]})
+            #upload_only_auth_token = dxpy.DXHTTPRequest(dxpy.get_auth_server_name() + '/system/newAuthToken', data,
+            #                                            prepend_srv=False, always_retry=True)
+            #token_callable = dxpy.DXHTTPOAuth2({"auth_token": upload_only_auth_token["access_token"],
+            #                                    "auth_token_type": upload_only_auth_token["token_type"],
+            #                                    "auth_token_signature": upload_only_auth_token["token_signature"]})
             testdir = tempfile.mkdtemp()
             try:
                 # Filename provided with path
                 with open(os.path.join(testdir, 'myfilename'), 'w') as f:
                     f.write('foo')
                 remote_file = dxpy.upload_local_file(filename=os.path.join(testdir, 'myfilename'),
-                                                     project=temp_project.get_id(), folder='/', auth=token_callable)
+                                                     project=temp_project.get_id(), folder='/')
                 self.assertEqual(remote_file.name, 'myfilename')
                 # Filename provided with file handle
                 remote_file2 = dxpy.upload_local_file(file=open(os.path.join(testdir, 'myfilename')),
-                                                      project=temp_project.get_id(), folder='/', auth=token_callable)
+                                                      project=temp_project.get_id(), folder='/')
                 self.assertEqual(remote_file2.name, 'myfilename')
             finally:
                 shutil.rmtree(testdir)


### PR DESCRIPTION
newAuthToken no longer returns a token if called with just a token. It
requires a username/password. Update the file-upload test to just use
the existing token - which loses some aspect of having just a file
upload token - but I don't think that's necessarily needed in this
integration test.