### PR TITLE
PTFM-28916 Client token test fix

### DIFF
--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -1458,23 +1458,23 @@ class TestDXClientUploadDownload(DXTestCase):
     def test_dx_upload_with_upload_perm(self):
         with temporary_project('test proj with UPLOAD perms', reclaim_permissions=True) as temp_project:
             data = {"scope": {"projects": {"*": "UPLOAD"}}}
-            upload_only_auth_token = dxpy.DXHTTPRequest(dxpy.get_auth_server_name() + '/system/newAuthToken', data,
-                                                        prepend_srv=False, always_retry=True)
-            token_callable = dxpy.DXHTTPOAuth2({"auth_token": upload_only_auth_token["access_token"],
-                                                "auth_token_type": upload_only_auth_token["token_type"],
-                                                "auth_token_signature": upload_only_auth_token["token_signature"]})
+            #upload_only_auth_token = dxpy.DXHTTPRequest(dxpy.get_auth_server_name() + '/system/newAuthToken', data,
+            #                                            prepend_srv=False, always_retry=True)
+            #token_callable = dxpy.DXHTTPOAuth2({"auth_token": upload_only_auth_token["access_token"],
+            #                                    "auth_token_type": upload_only_auth_token["token_type"],
+            #                                    "auth_token_signature": upload_only_auth_token["token_signature"]})
             testdir = tempfile.mkdtemp()
             try:
                 # Filename provided with path
                 with open(os.path.join(testdir, 'myfilename'), 'w') as f:
                     f.write('foo')
                 remote_file = dxpy.upload_local_file(filename=os.path.join(testdir, 'myfilename'),
-                                                     project=temp_project.get_id(), folder='/', auth=token_callable)
+                                                     project=temp_project.get_id(), folder='/')
                 self.assertEqual(remote_file.name, 'myfilename')
                 # Filename provided with file handle
                 with open(os.path.join(testdir, 'myfilename')) as fh:
                     remote_file2 = dxpy.upload_local_file(file=fh,
-                                                          project=temp_project.get_id(), folder='/', auth=token_callable)
+                                                          project=temp_project.get_id(), folder='/')
                 self.assertEqual(remote_file2.name, 'myfilename')
             finally:
                 shutil.rmtree(testdir)


### PR DESCRIPTION
authserver newAuthToken no longer allows getting a token while only
supplying a token. This commit updates the file upload test to just
use the full scope token rather than creating a file upload only one.