### PR TITLE
fix(symlink-download): fixes bugs and improves reliability around symlink downloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 ### Fixed
 
 * `Total price` for `dx describe` prints formatted currency based on `currency` metadata
+* Improvements to symlink downloading reliability by solely using `aria2c` and enhancing various options around its use
 
 ### Fixed
 * `dx run <globalworkflow> --project/--destination/--folder` now submits analysis to given project or path

--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -97,7 +97,7 @@ def new_dxfile(mode=None, write_buffer_size=dxfile.DEFAULT_BUFFER_SIZE, expected
 
 
 def download_dxfile(dxid, filename, chunksize=dxfile.DEFAULT_BUFFER_SIZE, append=False, show_progress=False,
-                    project=None, describe_output=None, **kwargs):
+                    project=None, describe_output=None, symlink_unlimited_retries=False, **kwargs):
     '''
     :param dxid: DNAnexus file ID or DXFile (file handler) object
     :type dxid: string or DXFile
@@ -114,6 +114,9 @@ def download_dxfile(dxid, filename, chunksize=dxfile.DEFAULT_BUFFER_SIZE, append
             It should contain the default fields of the describe API call output and
             the "parts" field, not included in the output by default.
     :type describe_output: dict or None
+    :param symlink_unlimited_retries: when downloading a symlink, call aria2c with the 
+            unlimited retries parameter specified.
+    :type symlink_unlimited_retries: bool
 
     Downloads the remote file referenced by *dxid* and saves it to *filename*.
 
@@ -134,6 +137,7 @@ def download_dxfile(dxid, filename, chunksize=dxfile.DEFAULT_BUFFER_SIZE, append
                                    show_progress=show_progress,
                                    project=project,
                                    describe_output=describe_output,
+                                   symlink_unlimited_retries=symlink_unlimited_retries,
                                    **kwargs)
 
 
@@ -175,65 +179,55 @@ def _verify(filename, md5digest):
 
 # [dxid] is a symbolic link. Create a preauthenticated URL,
 # and download it
-def _download_symbolic_link(dxid, md5digest, project, dest_filename):
+def _download_symbolic_link(dxid, md5digest, project, dest_filename, symlink_unlimited_retries=False):
     dxfile = dxpy.DXFile(dxid)
     url, _headers = dxfile.get_download_url(preauthenticated=True,
                                             duration=6*3600,
                                             project=project)
 
-    def call_cmd(cmd, max_retries=6, num_attempts=0):
-        try:
-            if aria2c_exe is not None:
-                print("Downloading symbolic link with aria2c")
-            else:
-                print("Downloading symbolic link with wget")
-            subprocess.check_call(cmd, stderr=subprocess.STDOUT)
-        except subprocess.CalledProcessError as e:
-            msg = ""
-            if e and e.output:
-                msg = e.output.strip()
-            if e.returncode == 22 and num_attempts <= max_retries:  # hotfix, DEVEX-1779
-                time_to_wait = 1 if num_attempts <= 2 else min(randint(2 ** (num_attempts - 2), 2 ** (num_attempts - 1)), 60)
-                print("Download failed with code 22. Retrying after {} seconds... Error details: cmd: {}\nmsg: {}\n".format(str(time_to_wait), str(cmd), msg))
-                sleep(time_to_wait)
-                call_cmd(cmd, max_retries, num_attempts + 1)
-            err_exit("Failed to call download: {cmd}\n{msg}\n".format(cmd=str(cmd), msg=msg))
-
-    # Follow the redirection
-    print('Following redirect for ' + url)
-
-    # Check if aria2 present
-    # Use that instead of wget
+    # Check if aria2 present, if not, error.
     aria2c_exe = _which("aria2c")
-    if aria2c_exe is None:
-        wget_exe = _which("wget")
-        if wget_exe is None:
-            err_exit("wget is not installed on this system")
 
-        cmd = ["wget", "--tries=20", "--quiet"]
-        if os.path.isfile(dxid):
-            # file already exists, resume upload.
-            cmd += ["--continue"]
-        cmd += ["-O", dest_filename, url]
+    if aria2c_exe is None:
+        err_exit("aria2c must be installed on this system to download this data. " + \
+                 "Please see the documentation at https://aria2.github.io/.")
+        return
+
+    # aria2c does not allow more than 16 connections per server
+    max_connections = min(16, multiprocessing.cpu_count())
+    cmd = [
+        "aria2c",
+        "-c",                        # continue downloading a partially downloaded file
+        "-s", str(max_connections),  # number of concurrent downloads (split file)
+        "-x", str(max_connections),  # maximum number of connections to one server for  each  download
+        "--retry-wait=10"            # time to wait before retrying
+    ]
+
+    if symlink_unlimited_retries:
+        # `-m` is the max number of tries parameter. 
+        # Specifying `0` means try infinitely.
+        cmd.extend(["-m", "0"]) 
     else:
-        print("aria2c found in path so using that instead of wget \n")
-        # aria2c does not allow more than 16 connections per server
-        max_connections = min(16, multiprocessing.cpu_count())
-        cmd = ["aria2c", "--check-certificate=false", "-s", str(max_connections), "-x", str(max_connections), "--retry-wait=10", "--max-tries=15"]
-        # Split path properly for aria2c
-        # If '-d' arg not provided, aria2c uses current working directory
-        cwd = os.getcwd()
-        directory, filename = os.path.split(dest_filename)
-        directory = cwd if directory in ["", cwd] else directory
-        cmd += ["-o", filename, "-d", os.path.abspath(directory), url]
-    call_cmd(cmd)
+        cmd.extend(["-m", "15"]) 
+
+    # Split path properly for aria2c
+    # If '-d' arg not provided, aria2c uses current working directory
+    cwd = os.getcwd()
+    directory, filename = os.path.split(dest_filename)
+    directory = cwd if directory in ["", cwd] else directory
+    cmd += ["-o", filename, "-d", os.path.abspath(directory), url]
+
+    try:
+        subprocess.check_call(cmd, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        err_exit("Failed to call download: {cmd}\n{msg}\n".format(cmd=str(cmd), msg=msg))
 
     if md5digest is not None:
         _verify(dest_filename, md5digest)
 
 def _download_dxfile(dxid, filename, part_retry_counter,
                      chunksize=dxfile.DEFAULT_BUFFER_SIZE, append=False, show_progress=False,
-                     project=None, describe_output=None, **kwargs):
+                     project=None, describe_output=None, symlink_unlimited_retries=False, **kwargs):
     '''
     Core of download logic. Download file-id *dxid* and store it in
     a local file *filename*.
@@ -279,13 +273,14 @@ def _download_dxfile(dxid, filename, part_retry_counter,
         dxfile_desc = describe_output
     else:
         dxfile_desc = dxfile.describe(fields={"parts"}, default_fields=True, **kwargs)
+
+    # handling of symlinked files.
     if 'drive' in dxfile_desc:
-        # A symbolic link. Get the MD5 checksum, if we have it
         if 'md5' in dxfile_desc:
             md5 = dxfile_desc['md5']
         else:
             md5 = None
-        _download_symbolic_link(dxid, md5, project, filename)
+        _download_symbolic_link(dxid, md5, project, filename, symlink_unlimited_retries=symlink_unlimited_retries)
         return True
 
     parts = dxfile_desc["parts"]

--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -180,11 +180,6 @@ def _verify(filename, md5digest):
 # [dxid] is a symbolic link. Create a preauthenticated URL,
 # and download it
 def _download_symbolic_link(dxid, md5digest, project, dest_filename, symlink_unlimited_retries=False):
-    dxfile = dxpy.DXFile(dxid)
-    url, _headers = dxfile.get_download_url(preauthenticated=True,
-                                            duration=6*3600,
-                                            project=project)
-
     # Check if aria2 present, if not, error.
     aria2c_exe = _which("aria2c")
 
@@ -192,6 +187,11 @@ def _download_symbolic_link(dxid, md5digest, project, dest_filename, symlink_unl
         err_exit("aria2c must be installed on this system to download this data. " + \
                  "Please see the documentation at https://aria2.github.io/.")
         return
+
+    dxfile = dxpy.DXFile(dxid)
+    url, _headers = dxfile.get_download_url(preauthenticated=True,
+                                            duration=6*3600,
+                                            project=project)
 
     # aria2c does not allow more than 16 connections per server
     max_connections = min(16, multiprocessing.cpu_count())

--- a/src/python/dxpy/cli/download.py
+++ b/src/python/dxpy/cli/download.py
@@ -87,13 +87,15 @@ def download_one_file(project, file_desc, dest_filename, args):
     except AttributeError:
         show_progress = False
 
+
     try:
         dxpy.download_dxfile(
                             file_desc['id'],
                             dest_filename,
                             show_progress=show_progress,
                             project=project,
-                            describe_output=file_desc)
+                            describe_output=file_desc,
+                            symlink_unlimited_retries=args.symlink_unlimited_retries)
         return
     except:
         err_exit()

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -4303,6 +4303,9 @@ parser_download.add_argument('--no-progress', help='Do not show a progress bar',
                              action='store_false', default=sys.stderr.isatty())
 parser_download.add_argument('--lightweight', help='Skip some validation steps to make fewer API calls',
                              action='store_true')
+parser_download.add_argument('--symlink-unlimited-retries', help='For symlinked files, enable unlimited retries using aria2c.',
+                             action='store_true',
+                             default=False)
 parser_download.add_argument('--unicode', help='Display the characters as text/unicode when writing to stdout',
                              dest="unicode_text", action='store_true')
 parser_download.set_defaults(func=download_or_cat)


### PR DESCRIPTION
On the St. Jude Cloud project, we've experienced multiple users having trouble downloading symlinked files using the `dx` command line utility. After extensive debugging, I believe I've isolated the source of the problem. This PR attempts to make a solid improvement by eliminating the use of `wget` for downloading symlinked files.

## Description

In the way that the DNAnexus API currently works, GET-ing a download link for a symlinked file returns a 302 response with a `Location` header (see example below). The `Location` header contains a signed link that points to the actual storage location (for us, in Azure) that lasts for 5 minutes. After 5 minutes, the intent is that you should rerequest the original URI and receive an updated signed link. This is consistent with the [spec](https://datatracker.ietf.org/doc/html/rfc2068#section-10.3.3), and I personally feel it's the safest too (signed links that expire quickly).

```HTTP/1.1 302 Moved Temporarily
...
Location: [SIGNED URL THAT LASTS 5 MINUTES]
Server: nginx/1.18.0

...
```

Unfortunately, it appears that some versions of `wget` do not follow this process effectively. I'm still not sure whether this is because `wget` doesn’t support going back to the original request URI after 5 minutes or not, but [this StackOverflow question](https://stackoverflow.com/questions/38273828/make-wget-retry-original-url-after-3xx-redirect) suggests that there are conditions under which it does not work correctly. This has been my experience as well for various users of St. Jude Cloud.

## Solution

Thus, I'm proposing we just limit the downloading of symlinks to `aria2c` and improve some of the options around this. `aria2c` should be available on all DNAnexus nodes (as far as I am aware), and I think it's reasonable to ask users to install this if the tradeoff is that they have the best possible experience downloading. Again, I don't think it's a clear-cut case that we couldn't fix using `wget` or even introduce `curl`, but I didn't consider that within scope as it could be a rabbit hole of time invested.

If someone from DNAnexus wants to (a) try to get it to work with `wget` or `curl` more effectively or (b) just support the in-tool downloading of symlinks as any other "normal" file in DNAnexus, then feel free to reject this PR.

## Details

- Removes `wget` altogether, and clarifies how to install `aria2c`.
- Removes `--check-certificate=false`, I'm not sure why we would have introduced this in the first place and considered it unneccesarily insecure.
- I've moved the check to ensure `aria2c` is in the `$PATH` to the front of the download. This ensures we don't generate any signed links if `aria2c` isn't installed. Just an extra safety measure.
- Introduced `--symlink-unlimited-retries` option. This will set `-m 0` on `aria2c`, translating to unlimited retries on the download.
- Added missing `-c` argument on `aria2c` command that is generated to continue existing downloads.
- Given the removal of `wget`, the new `aria2c` arguments, and the `--symlink-unlimited-retries` option, I believe the entire structure around the `call_cmd` function is unnecessary now.
  - First, I don't believe this was operating as intended fully regardless. Exit code 22 only applies to `aria2c` ([exit codes for wget](https://www.gnu.org/software/wget/manual/html_node/Exit-Status.html)), and it was being thrown when `aria2c` encountered a 403 response. The 403 was being thrown when the signature on the signed link expired, so it wasn't a scenario where a back-off timer would help the situation.
  - Second, with the new options, this can be handled much more sanely by exposing arguments that use the facilities provided by `aria2c` to accomplish this goal.
- Remove the print about following redirect (most users are confused as to what this means or if things are working correctly in my experience).

## Assumptions

- `aria2c` should be available on every DNAnexus node (need someone from DNAnexus to confirm in the comments).
  - Confirmed that `aria2c` is supported in the default image and there are no plans to remove it by Geet through email on July 30, 2021.

## TODO

- I cannot get the tests to work on my local machine, even on `master`. So I'm hoping there is CI set up where the environment is configured correctly to get them to run. After that, I possibly need to update them.

FWIW, this is the error I'm getting.

```
❯ python build/run_python_integration_tests.py --tests test_dx_symlink
test_symlinks (test_dx_symlink.TestSymlink) ... ERROR

======================================================================
ERROR: test_symlinks (test_dx_symlink.TestSymlink)
----------------------------------------------------------------------
...
PermissionDenied: Cannot create a new project as an anonymous user, code 401. Request Time=1627666473.16, Request ID=1627666473307-400755

----------------------------------------------------------------------
Ran 1 test in 0.169s

FAILED (errors=1)
*** unittest invocation failed with code 1
```