### PR TITLE
TIP-2525: Add support for database path as input to dx list database files

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -61,7 +61,7 @@ toolkit that doesn't require them.
 
     sudo apt install make python-setuptools python-pip python-virtualenv python-dev \
       gcc g++ cmake libboost-all-dev libcurl4-openssl-dev zlib1g-dev libbz2-dev flex bison \
-      openssl libssl-dev autoconf
+      openssl libssl-dev autoconf git curl
 
 If your locale is not configured properly, you might need to run following commands as well (i.e. when working from Cloud Workstation):
     

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -2756,8 +2756,8 @@ def list_database_files(args):
         else:
         # otherwise it was provided as a path, so try and resolve
             project, _folderpath, entity_result = try_call(resolve_existing_path,
-                                                       args.database,
-                                                       expected='entity')
+                                                           args.database,
+                                                           expected='entity')
 
         # if we couldn't resolved the entity, fail
         if entity_result is None:

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -2751,7 +2751,7 @@ def list_database_files(args):
     try:
         # check if database was given as an object hash id
         if is_hashid(args.database):
-            desc = dxpy.api.app_describe(args.database)
+            desc = dxpy.api.database_describe(args.database)
             entity_result = {"id": desc["id"], "describe": desc}
         else:
         # otherwise it was provided as a path, so try and resolve


### PR DESCRIPTION
This PR adds path resolution and support to the `dx list database files` command.  Previously, the command only supported the database input as an object hash ID, but now it also supports database input as a path, e.g. `dx list database files test/edtest18`.

Here is examples from testing locally:

```
root@localhost:/dx-toolkit# dx ls test/
a
edtest18

root@localhost:/dx-toolkit# dx list database files test/doesnt_exist
ResolutionError: Unable to resolve "doesnt_exist" to a data object or folder name in '/test'

root@localhost:/dx-toolkit# dx list database files test/edtest18
                               0 411c7b8f/database-G55pFf00KY15QGJXBg1vVqxz/test_table/

root@localhost:/dx-toolkit# dx list database files database-G55pFf00KY15QGJXBg1vVqxz
                               0 411c7b8f/database-G55pFf00KY15QGJXBg1vVqxz/test_table/

root@localhost:/dx-toolkit# dx list database files test/a       
Error: The given object is of class file but an object of class database was expected

root@localhost:/dx-toolkit# dx list database files file-G594y580KY1BzG478y9KJJxy
Error: The given object is of class file but an object of class database was expected

root@localhost:/dx-toolkit# dx list database files test/edtest18 --folder test_table --recurse
2021-09-22 22:09:37            8 411c7b8f/database-G55pFf00KY15QGJXBg1vVqxz/test_table/part-00000-5557570b-d593-4c13-a2c5-3ed3f57b420f-c000
2021-09-22 22:09:37            7 411c7b8f/database-G55pFf00KY15QGJXBg1vVqxz/test_table/part-00001-5557570b-d593-4c13-a2c5-3ed3f57b420f-c000

root@localhost:/dx-toolkit# dx list database files project-G55pF280KY15QGJXBg1vVqxy:test/edtest18 --folder test_table --recurse
2021-09-22 22:09:37            8 411c7b8f/database-G55pFf00KY15QGJXBg1vVqxz/test_table/part-00000-5557570b-d593-4c13-a2c5-3ed3f57b420f-c000
2021-09-22 22:09:37            7 411c7b8f/database-G55pFf00KY15QGJXBg1vVqxz/test_table/part-00001-5557570b-d593-4c13-a2c5-3ed3f57b420f-c000

root@localhost:/dx-toolkit# dx list database files project-G2KJ4Gj0pk6XQP1VBqXz1ZjX:test/edtest18 --folder test_table --recurse
ResolutionError: The specified folder could not be found in project-G2KJ4Gj0pk6XQP1VBqXz1ZjX

root@localhost:/dx-toolkit# dx list database files project-G55pF280KY15QGJXBg1vVqxy:database-G55pFf00KY15QGJXBg1vVqxz --folder test_table --recurse
2021-09-22 22:09:37            8 411c7b8f/database-G55pFf00KY15QGJXBg1vVqxz/test_table/part-00000-5557570b-d593-4c13-a2c5-3ed3f57b420f-c000
2021-09-22 22:09:37            7 411c7b8f/database-G55pFf00KY15QGJXBg1vVqxz/test_table/part-00001-5557570b-d593-4c13-a2c5-3ed3f57b420f-c000

root@localhost:/dx-toolkit# dx list database files project-G55pF280KY15QGJXBg1vVqxy:edtest18 --folder test_table --recurse
ResolutionError: Unable to resolve "edtest18" to a data object or folder name in '/'

root@localhost:/dx-toolkit# dx ls /
test/
```