### PR TITLE
DEVEX-2035 Remove unused match_hostname import

### DIFF
--- a/src/python/dxpy/__init__.py
+++ b/src/python/dxpy/__init__.py
@@ -148,7 +148,6 @@ from .utils.printing import BOLD, BLUE, YELLOW, GREEN, RED, WHITE
 from random import randint
 from requests.auth import AuthBase
 from requests.packages import urllib3
-from requests.packages.urllib3.packages.ssl_match_hostname import match_hostname
 from threading import Lock
 from . import ssh_tunnel_app_support
 
@@ -174,14 +173,6 @@ def configure_urllib3():
     # Disable verbose urllib3 warnings and log messages
     urllib3.disable_warnings(category=urllib3.exceptions.InsecurePlatformWarning)
     logging.getLogger('dxpy.packages.requests.packages.urllib3.connectionpool').setLevel(logging.ERROR)
-
-    # Trust DNAnexus S3 upload tunnel
-    def _match_hostname(cert, hostname):
-        if hostname == "ul.cn.dnanexus.com":
-            hostname = "s3.amazonaws.com"
-        match_hostname(cert, hostname)
-
-    urllib3.connection.match_hostname = _match_hostname
 
 configure_urllib3()
 


### PR DESCRIPTION
Remove no longer used `match_hostname` import which fails to import as of urllib3 1.26.8 https://github.com/urllib3/urllib3/releases/tag/1.26.8.

https://github.com/dnanexus/dx-toolkit/issues/746