### PR TITLE
DEVEX-2023 Fix recursive folder download

### DIFF
--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -638,7 +638,7 @@ def list_subfolders(project, path, recurse=True):
     '''
     project_folders = dxpy.get_handler(project).describe(input_params={'folders': True})['folders']
     # If path is '/', return all folders
-    # If path is '/foo', return '/foo' and all subfolders of '/foo/
+    # If path is '/foo', return '/foo' and all subfolders of '/foo/'
     if recurse:
         return (f for f in project_folders if path == '/' or (f == path or f.startswith(path + '/')))
     else:

--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -637,10 +637,10 @@ def list_subfolders(project, path, recurse=True):
 
     '''
     project_folders = dxpy.get_handler(project).describe(input_params={'folders': True})['folders']
-    # TODO: support shell-style path globbing (i.e. /a*/c matches /ab/c but not /a/b/c)
-    # return pathmatch.filter(project_folders, os.path.join(path, '*'))
+    # If path is '/', return all folders
+    # If path is '/foo', return '/foo' and all subfolders of '/foo/
     if recurse:
-        return (f for f in project_folders if f == path or f.startswith(path + '/'))
+        return (f for f in project_folders if path == '/' or (f == path or f.startswith(path + '/')))
     else:
         return (f for f in project_folders if f.startswith(path) and '/' not in f[len(path)+1:])
 

--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -640,7 +640,7 @@ def list_subfolders(project, path, recurse=True):
     # TODO: support shell-style path globbing (i.e. /a*/c matches /ab/c but not /a/b/c)
     # return pathmatch.filter(project_folders, os.path.join(path, '*'))
     if recurse:
-        return (f for f in project_folders if f.startswith(path))
+        return (f for f in project_folders if f == path or f.startswith(os.path.join(path, '/')))
     else:
         return (f for f in project_folders if f.startswith(path) and '/' not in f[len(path)+1:])
 

--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -640,7 +640,7 @@ def list_subfolders(project, path, recurse=True):
     # TODO: support shell-style path globbing (i.e. /a*/c matches /ab/c but not /a/b/c)
     # return pathmatch.filter(project_folders, os.path.join(path, '*'))
     if recurse:
-        return (f for f in project_folders if f == path or f.startswith(os.path.join(path, '/')))
+        return (f for f in project_folders if f == path or f.startswith(path + '/'))
     else:
         return (f for f in project_folders if f.startswith(path) and '/' not in f[len(path)+1:])
 

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -918,6 +918,9 @@ class TestFolder(unittest.TestCase):
             self.assertTrue(os.path.isfile(filename))
             self.assertEqual("{}-th\n file\n content\n".format(i + 3), self.read_entire_file(filename))
 
+        # DEVEX-2023 Do not create incorrect empty folders that share the same prefix for recursive download
+        # Check that /a/lpha does not exist
+        dxproject.new_folder("/alpha", parents=True)
         # Checking download to existing structure
         dxpy.download_folder(self.proj_id, a_dest_dir, folder="/a", overwrite=True)
         path = []
@@ -926,6 +929,8 @@ class TestFolder(unittest.TestCase):
             filename = os.path.join(os.path.join(*path), "file_{}.txt".format(i + 2))
             self.assertTrue(os.path.isfile(filename))
             self.assertEqual("{}-th\n file\n content\n".format(i + 2), self.read_entire_file(filename))
+        self.assertFalse(os.path.isdir(os.path.join(a_dest_dir, 'pha')))
+        
 
         # Checking download to existing structure fails w/o overwrite flag
         with self.assertRaises(DXFileError):


### PR DESCRIPTION
Fix recursive folder download. Current broken behavior example where an empty subfolder is created for folders sharing the same prefix. 
```
$ dx ls -l |grep xyz
xyz/
xyz123/
$ dx download -r xyz
$ tree xyz
xyz
└── 23

```