### PR TITLE
DEVEX-2055 Only query for folder when checking folder exists in `dx cd`

### DIFF
--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -714,7 +714,7 @@ def cd(args):
 
     try:
         dxproj = dxpy.get_handler(dxpy.WORKSPACE_ID)
-        dxproj.list_folder(folder=folderpath)
+        dxproj.list_folder(folder=folderpath, only='folders')
     except:
         err_exit(fill(folderpath + ': No such file or directory found in project ' + dxpy.WORKSPACE_ID), 3)
 


### PR DESCRIPTION
Optimize the `project-xxxx/listFolder` call to only return folders, not objects in case the folder contains thousands of objects. Safe to do as this call is only checking that the folder argument to `dx cd` exists. 