### PR TITLE
DEVEX-2080 Set project argument for executable launched from a job in`--detach` mode

### DIFF
--- a/src/python/dxpy/bindings/dxapplet.py
+++ b/src/python/dxpy/bindings/dxapplet.py
@@ -91,8 +91,8 @@ class DXExecutable:
 
         if kwargs.get('ignore_reuse') is not None:
             run_input["ignoreReuse"] = kwargs['ignore_reuse']
-
-        if dxpy.JOB_ID is None:
+            
+        if dxpy.JOB_ID is None or kwargs.get('detach') is True:
             run_input["project"] = project
 
         if kwargs.get('extra_args') is not None:

--- a/src/python/dxpy/bindings/dxapplet.py
+++ b/src/python/dxpy/bindings/dxapplet.py
@@ -91,7 +91,7 @@ class DXExecutable:
 
         if kwargs.get('ignore_reuse') is not None:
             run_input["ignoreReuse"] = kwargs['ignore_reuse']
-            
+
         if dxpy.JOB_ID is None or kwargs.get('detach') is True:
             run_input["project"] = project
 


### PR DESCRIPTION
Previously by default the `project` parameter was ignored in `dx run` since it was not possible to launch jobs in another project, this is now possible if `--detach` is specified. 