### PR TITLE
DEVEX-2094 Supply default 15 symlink_max_tries if not present in args

### DIFF
--- a/src/python/dxpy/cli/download.py
+++ b/src/python/dxpy/cli/download.py
@@ -89,13 +89,14 @@ def download_one_file(project, file_desc, dest_filename, args):
 
 
     try:
+        symlink_max_tries = args.symlink_max_tries if vars(args).get('symlink_max_tries') is not None else 15
         dxpy.download_dxfile(
                             file_desc['id'],
                             dest_filename,
                             show_progress=show_progress,
                             project=project,
                             describe_output=file_desc,
-                            symlink_max_tries=args.symlink_max_tries)
+                            symlink_max_tries=symlink_max_tries)
         return
     except:
         err_exit()


### PR DESCRIPTION
Not recommended, but `dx get file-xxxx` does work to download files. 
```
$ dx get file-xxxx
Traceback (most recent call last):
  File "/Users/kjensen/Library/Python/3.8/lib/python/site-packages/dxpy/cli/download.py", line 98, in download_one_file
    symlink_max_tries=args.symlink_max_tries)
AttributeError: 'Namespace' object has no attribute 'symlink_max_tries'
```