### PR TITLE
DEVEX-2109 Do not use job's workspace cotnainer-id in /run for detached jobs

### DIFF
--- a/src/python/dxpy/bindings/dxapplet.py
+++ b/src/python/dxpy/bindings/dxapplet.py
@@ -29,6 +29,7 @@ from __future__ import print_function, unicode_literals, division, absolute_impo
 import dxpy
 from . import DXDataObject, DXJob
 from ..utils import merge
+from ..utils.resolver import is_project_id
 from ..system_requirements import SystemRequirementsDict
 from ..exceptions import DXError
 from ..compat import basestring
@@ -92,7 +93,7 @@ class DXExecutable:
         if kwargs.get('ignore_reuse') is not None:
             run_input["ignoreReuse"] = kwargs['ignore_reuse']
 
-        if dxpy.JOB_ID is None or kwargs.get('detach') is True:
+        if dxpy.JOB_ID is None or (project is not None and kwargs.get('detach') is True and is_project_id(project)):
             run_input["project"] = project
 
         if kwargs.get('extra_args') is not None:

--- a/src/python/dxpy/utils/resolver.py
+++ b/src/python/dxpy/utils/resolver.py
@@ -159,6 +159,9 @@ def is_data_obj_id(string):
 def is_container_id(string):
     return is_hashid(string) and (string.startswith('project-') or string.startswith('container-'))
 
+def is_project_id(string):
+    return is_hashid(string) and string.startswith('project-')
+
 def is_analysis_id(string):
     return is_hashid(string) and string.startswith('analysis-')
 


### PR DESCRIPTION
Check that when passing `project` for `/run` for a detached job that it is an actual project-id (to allow for running in another project as of https://github.com/dnanexus/dx-toolkit/commit/4320067aeaa07efeeeeaeece3503776b2c44df1c) and not the default of a job's temporary workspace container-id. 