### PR TITLE
APPS-1285 add all SSL error types as retryable exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 
 * Reduce the number of API calls for `dx run applet-xxxx` and `dx run workflow-xxxx`
 * `dx upload f1 f2 --visibility hidden` now correctly marks both files as hidden
+* retry uploading on all types of SSL errors 
 
 ## [327.0] - beta
 

--- a/src/python/dxpy/__init__.py
+++ b/src/python/dxpy/__init__.py
@@ -335,9 +335,11 @@ def _is_retryable_exception(e):
     if isinstance(e, urllib3.exceptions.NewConnectionError):
         return True
     if isinstance(e, requests.exceptions.SSLError):
-        errmsg = str(e)
-        if "EOF occurred in violation of protocol" in errmsg:
-            return True
+        return True
+    if isinstance(e, urllib3.exceptions.SSLError):
+        return True
+    if isinstance(e, ssl.SSLError): 
+        return True
     return False
 
 def _extract_msg_from_last_exception():

--- a/src/python/dxpy/exceptions.py
+++ b/src/python/dxpy/exceptions.py
@@ -25,6 +25,8 @@ import requests
 from requests.exceptions import HTTPError
 
 import dxpy
+import urllib3
+import ssl
 
 EXPECTED_ERR_EXIT_STATUS = 3
 
@@ -225,6 +227,8 @@ network_exceptions = (requests.packages.urllib3.exceptions.ProtocolError,
                       requests.packages.urllib3.exceptions.ConnectTimeoutError,
                       requests.packages.urllib3.exceptions.ReadTimeoutError,
                       requests.packages.urllib3.connectionpool.HTTPException,
+                      urllib3.exceptions.SSLError,
+                      ssl.SSLError,
                       HTTPError,
                       socket.error)
 


### PR DESCRIPTION
* Different types of SSL errors are raised depending on Python version,
* add all of them to prevent `dx upload` failing with bad internet connection