### PR TITLE
APPS-1316 add --on-behalf-of parameter for `dx new user`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 
 ## [327.1]
 
+### Added
+
+* `--on-behalf-of <org>` argument for `dx new user`
+
 ## Fixed
 
 * Reduce the number of API calls for `dx run applet-xxxx` and `dx run workflow-xxxx`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 
 ## Unreleased
 
-## [327.1]
-
 ### Added
 
 * `--on-behalf-of <org>` argument for `dx new user`
+
+## [327.1]
 
 ## Fixed
 

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -1355,6 +1355,8 @@ def _get_user_new_args(args):
         user_new_args["occupation"] = args.occupation
     if args.set_bill_to is True:
         user_new_args["billTo"] = args.org
+    if args.on_behalf_of is not None:
+        user_new_args["provisioningOrg"] = args.on_behalf_of
     return user_new_args
 
 
@@ -5305,6 +5307,7 @@ parser_new_user_user_opts.add_argument("--middle", help="Middle name")
 parser_new_user_user_opts.add_argument("--last", help="Last name")
 parser_new_user_user_opts.add_argument("--token-duration", help='Time duration for which the newly generated auth token for the new user will be valid (default 30 days; max 30 days). An integer will be interpreted as seconds; you can append a suffix (s, m, h, d) to indicate different units (e.g. "--token-duration 10m" to indicate 10 minutes).')
 parser_new_user_user_opts.add_argument("--occupation", help="Occupation")
+parser_new_user_user_opts.add_argument("--on-behalf-of", help="On behalf of which org is the account provisioned")
 parser_new_user_org_opts = parser_new_user.add_argument_group("Org options", "Optionally invite the new user to an org with the specified parameters")
 parser_new_user_org_opts.add_argument("--org", help="ID of the org")
 parser_new_user_org_opts.add_argument("--level", choices=["ADMIN", "MEMBER"], default="MEMBER", action=DXNewUserOrgArgsAction, help="Org membership level that will be granted to the new user; default MEMBER")

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -6274,6 +6274,14 @@ class TestDXClientNewUser(DXTestCase):
         first = "Asset"
         cmd = "dx new user"
         baseargs = "--username {u} --email {e} --first {f}".format(u=username, e=email, f=first)
+        user_id = run(" ".join([cmd, baseargs,"--on-behalf-of {o} --brief".format(o=self.org_id)])).strip()
+        self._assert_user_desc(user_id, {"first": first})
+    
+    def test_create_user_on_behalf_of_negative(self):
+        username, email = generate_unique_username_email()
+        first = "Asset2"
+        cmd = "dx new user"
+        baseargs = "--username {u} --email {e} --first {f}".format(u=username, e=email, f=first)
     
         # no org specified
         with self.assertRaisesRegex(subprocess.CalledProcessError,
@@ -6287,10 +6295,6 @@ class TestDXClientNewUser(DXTestCase):
         with self.assertRaisesRegex(subprocess.CalledProcessError,
                                     "(PermissionDenied)|(ResourceNotFound)"):
             run(" ".join([cmd, baseargs,"--on-behalf-of org-dnanexus"]))
-
-        # creating user on behalf of org that does exist and has ADMIN permissions, this should not raise 
-        user_id = run(" ".join([cmd, baseargs,"--on-behalf-of {o} --brief".format(o=self.org_id)])).strip()
-        self._assert_user_desc(user_id, {"first": first})
 
 
     def test_self_signup_negative(self):

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2013-2016 DNAnexus, Inc.

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -6273,18 +6273,23 @@ class TestDXClientNewUser(DXTestCase):
         username, email = generate_unique_username_email()
         first = "Asset"
         cmd = "dx new user"
-        baseargs = "--username {u} --email {e} --first {f} --set-bill-to".format(u=username, e=email, f=first)
+        baseargs = "--username {u} --email {e} --first {f}".format(u=username, e=email, f=first)
+    
+        # no org specified
+        with self.assertRaisesRegex(subprocess.CalledProcessError,
+                                    "error: argument --on-behalf-of: expected one argument"):   
+            run(" ".join([cmd, baseargs,"--on-behalf-of" ]))
         # creating user on behalf of org that does not exist 
         with self.assertRaisesRegex(subprocess.CalledProcessError,
                                         "ResourceNotFound"):
-            run(" ".join([cmd, baseargs,"--on-behalf-of does_not_exist"]))
+            run(" ".join([cmd, baseargs,"--on-behalf-of org-does_not_exist"]))
         # creating user for org in which the adder does not have ADMIN permissions
         with self.assertRaisesRegex(subprocess.CalledProcessError,
                                     "(PermissionDenied)|(ResourceNotFound)"):
             run(" ".join([cmd, baseargs,"--on-behalf-of org-dnanexus"]))
-        
+
         # creating user on behalf of org that does exist and has ADMIN permissions, this should not raise 
-        user_id = run(" ".join([cmd, baseargs,"--on-behalf-of {o}".format(o=self.org_id)])).strip()
+        user_id = run(" ".join([cmd, baseargs,"--on-behalf-of {o} --brief".format(o=self.org_id)])).strip()
         self._assert_user_desc(user_id, {"first": first})
 
 


### PR DESCRIPTION
* add `--on-behalf-of <org>` optional parameter for `dx new user`; the API is passed the org in the "provisioningOrg" field, which causes the welcome email to contain the correct org id.
* add a test