### PR TITLE
APPS-1250 nextflow - Added file or directory support.

### DIFF
--- a/src/python/dxpy/nextflow/nextflow_builder.py
+++ b/src/python/dxpy/nextflow/nextflow_builder.py
@@ -65,7 +65,7 @@ def prepare_nextflow(resources_dir, profile):
     Creates files necessary for creating an applet on the Platform, such as dxapp.json and a source file. These files are created in '.dx.nextflow' directory.
     """
     assert os.path.exists(resources_dir)
-    if not glob.glob('*.nf'):
+    if not glob(os.path.join(resources_dir, "*.nf")):
         raise dxpy.app_builder.AppBuilderException("Directory %s does not contain Nextflow file (*.nf): not a valid Nextflow directory" % resources_dir)
     inputs = []
     os.makedirs(".dx.nextflow", exist_ok=True)

--- a/src/python/dxpy/nextflow/nextflow_builder.py
+++ b/src/python/dxpy/nextflow/nextflow_builder.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 
 import os
+import dxpy
+import json
+import argparse
+from glob import glob
 
 from dxpy.nextflow.nextflow_templates import (get_nextflow_dxapp, get_nextflow_src)
 from dxpy.nextflow.nextflow_utils import (get_template_dir, write_exec, write_dxapp)
 from dxpy.utils.resolver import parse_obj
-import dxpy
-import json
-import argparse
 from distutils.dir_util import copy_tree
 parser = argparse.ArgumentParser(description="Uploads a DNAnexus App.")
 
@@ -64,6 +65,8 @@ def prepare_nextflow(resources_dir, profile):
     Creates files necessary for creating an applet on the Platform, such as dxapp.json and a source file. These files are created in '.dx.nextflow' directory.
     """
     assert os.path.exists(resources_dir)
+    if not glob.glob('*.nf'):
+        raise dxpy.app_builder.AppBuilderException("Directory %s does not contain Nextflow file (*.nf): not a valid Nextflow directory" % resources_dir)
     inputs = []
     os.makedirs(".dx.nextflow", exist_ok=True)
     dxapp_dir = os.path.join(resources_dir, '.dx.nextflow')

--- a/src/python/dxpy/nextflow/nextflow_templates.py
+++ b/src/python/dxpy/nextflow/nextflow_templates.py
@@ -40,11 +40,14 @@ def get_nextflow_src(inputs=None, profile=None):
 
     run_inputs = ""
     for i in inputs:
+        value = "${%s}" % (i['name'])
+        if i.get("class") == "file":
+            value = "dx://$(jq .[$dnanexus_link] -r <<< ${%s})" % i['name']
         run_inputs = run_inputs + '''
         if [ -n "$%s" ]; then
-            filtered_inputs+=(--%s="${%s}")
+            filtered_inputs+=(--%s="%s")
         fi
-        ''' % (i['name'], i['name'], i['name'])
+        ''' % (i['name'], i['name'], value)
     profile_arg = "-profile {}".format(profile) if profile else ""
     src = src.replace("@@RUN_INPUTS@@", run_inputs)
     src = src.replace("@@PROFILE_ARG@@", profile_arg)

--- a/src/python/dxpy/scripts/dx_build_app.py
+++ b/src/python/dxpy/scripts/dx_build_app.py
@@ -1000,55 +1000,53 @@ def _build_app(args, extra_args):
         worker_resources_subpath = get_resources_subpath()
     if args._from:
         # BUILD FROM EXISTING APPLET
-        try:
-            output = build_app_from(
-                args._from,
-                [args.version_override],
-                publish=args.publish,
-                do_try_update=args.update,
-                bill_to_override=args.bill_to,
-                confirm=args.confirm,
-                return_object_dump=args.json,
-                brief=args.brief,
-                **extra_args
-            )
-            if output is not None and args.run is None:
-                print(json.dumps(output))
+        output = build_app_from(
+            args._from,
+            [args.version_override],
+            publish=args.publish,
+            do_try_update=args.update,
+            bill_to_override=args.bill_to,
+            confirm=args.confirm,
+            return_object_dump=args.json,
+            brief=args.brief,
+            **extra_args
+        )
+        if output is not None and args.run is None:
+            print(json.dumps(output))
 
         return output['id']
 
     if not args.remote and not args.repository:  # building with NF repository is implicitly remote
         # LOCAL BUILD
-        try:
-            output = build_and_upload_locally(
-                source_dir,
-                args.mode,
-                overwrite=args.overwrite,
-                archive=args.archive,
-                publish=args.publish,
-                destination_override=args.destination,
-                version_override=args.version_override,
-                bill_to_override=args.bill_to,
-                use_temp_build_project=args.use_temp_build_project,
-                do_parallel_build=args.parallel_build,
-                do_version_autonumbering=args.version_autonumbering,
-                do_try_update=args.update,
-                do_check_syntax=args.check_syntax,
-                ensure_upload=args.ensure_upload,
-                force_symlinks=args.force_symlinks,
-                dry_run=args.dry_run,
-                confirm=args.confirm,
-                return_object_dump=args.json,
-                region=args.region,
-                brief=args.brief,
-                resources_dir=resources_dir,
-                worker_resources_subpath=worker_resources_subpath,
-                types=types,
-                **extra_args
-                )
+        output = build_and_upload_locally(
+            source_dir,
+            args.mode,
+            overwrite=args.overwrite,
+            archive=args.archive,
+            publish=args.publish,
+            destination_override=args.destination,
+            version_override=args.version_override,
+            bill_to_override=args.bill_to,
+            use_temp_build_project=args.use_temp_build_project,
+            do_parallel_build=args.parallel_build,
+            do_version_autonumbering=args.version_autonumbering,
+            do_try_update=args.update,
+            do_check_syntax=args.check_syntax,
+            ensure_upload=args.ensure_upload,
+            force_symlinks=args.force_symlinks,
+            dry_run=args.dry_run,
+            confirm=args.confirm,
+            return_object_dump=args.json,
+            region=args.region,
+            brief=args.brief,
+            resources_dir=resources_dir,
+            worker_resources_subpath=worker_resources_subpath,
+            types=types,
+            **extra_args
+            )
 
-            if output is not None and args.run is None:
-                print(json.dumps(output))
+        if output is not None and args.run is None:
+            print(json.dumps(output))
 
         if args.dry_run:
             return None
@@ -1093,12 +1091,12 @@ def _build_app(args, extra_args):
             more_kwargs['do_check_syntax'] = False
         if args.nextflow and args.repository is not None:
             return build_pipeline_from_repository(args.repository, args.tag, args.profile, args.github_credentials, args.brief)
-        try:
-            app_json = _parse_app_spec(source_dir)
-            _check_suggestions(app_json, publish=args.publish)
-            _verify_app_source_dir(source_dir, args.mode)
-            if args.mode == "app" and not args.dry_run:
-                dxpy.executable_builder.verify_developer_rights('app-' + app_json['name'])
+
+        app_json = _parse_app_spec(source_dir)
+        _check_suggestions(app_json, publish=args.publish)
+        _verify_app_source_dir(source_dir, args.mode)
+        if args.mode == "app" and not args.dry_run:
+            dxpy.executable_builder.verify_developer_rights('app-' + app_json['name'])
 
         return _build_app_remote(args.mode, source_dir, destination_override=args.destination,
                                  publish=args.publish,

--- a/src/python/dxpy/scripts/dx_build_app.py
+++ b/src/python/dxpy/scripts/dx_build_app.py
@@ -993,7 +993,7 @@ def _build_app(args, extra_args):
     types = []
     source_dir = args.src_dir
     worker_resources_subpath = ""  # no subpath, files will be saved to root directory by default.
-    if args.nextflow and args.repository:
+    if args.nextflow and not args.repository:
         source_dir = prepare_nextflow(args.src_dir, args.profile)
         types = ["nextflow"]
         resources_dir = args.src_dir

--- a/src/python/dxpy/scripts/dx_build_app.py
+++ b/src/python/dxpy/scripts/dx_build_app.py
@@ -993,10 +993,10 @@ def _build_app(args, extra_args):
     types = []
     source_dir = args.src_dir
     worker_resources_subpath = ""  # no subpath, files will be saved to root directory by default.
-    if args.nextflow:
+    if args.nextflow and args.repository:
+        source_dir = prepare_nextflow(args.src_dir, args.profile)
         types = ["nextflow"]
         resources_dir = args.src_dir
-        source_dir = prepare_nextflow(args.src_dir, args.profile)
         worker_resources_subpath = get_resources_subpath()
     if args._from:
         # BUILD FROM EXISTING APPLET

--- a/src/python/dxpy/templating/templates/nextflow/dxapp.json
+++ b/src/python/dxpy/templating/templates/nextflow/dxapp.json
@@ -37,6 +37,7 @@
   "outputSpec": [
   ],
   "runSpec": {
+    "headJobOnDemand": true,
     "interpreter": "bash",
     "execDepends": [],
     "distribution": "Ubuntu",
@@ -47,7 +48,7 @@
     "aws:us-east-1": {
       "systemRequirements": {
         "*": {
-          "instanceType": "mem1_ssd1_v2_x8"
+          "instanceType": "mem1_ssd1_v2_x2"
         }
       },
       "assetDepends": [

--- a/src/python/dxpy/templating/templates/nextflow/src/nextflow.sh
+++ b/src/python/dxpy/templating/templates/nextflow/src/nextflow.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -f
+
 on_exit() {
   ret=$?
   # upload log file
@@ -32,10 +34,10 @@ on_exit() {
 }
     
 main() {
-    set -f
-
-    [[ $debug ]] && set -x && env | sort
-    [[ $debug ]] && export NXF_DEBUG=2
+    if $debug ; then
+      set -x && env | sort
+      export NXF_DEBUG=2
+    fi
     
     if [ -n "$docker_creds" ]; then
         dx download "$docker_creds" -o /home/dnanexus/credentials


### PR DESCRIPTION
Added file or directory support.

In order to use file, we can specify file as an input, but in case the input is string (happen when defined argument can be file or directory) we can use string:
 dx://project-yyyy:file-zzzz
or dx://project-yyyy:/path/to/file

In order to use directory, string must contain path to a directory:
 dx://project-xxxx:/path/to/folder/ 
 
in order to have multiple files in input, we can use wild cards: dx://project-wwww:/data/*.fa