### PR TITLE
Python 2 compat fix for `os.makedirs()`

### DIFF
--- a/src/python/dxpy/nextflow/nextflow_utils.py
+++ b/src/python/dxpy/nextflow/nextflow_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import os
+import os, errno
 import dxpy
 import json
 from dxpy.exceptions import ResourceNotFound
@@ -27,9 +27,14 @@ def get_importer_name():
 def get_template_dir():
     return os.path.join(os.path.dirname(dxpy.__file__), 'templating', 'templates', 'nextflow')
 
-def write_exec(folder, content):
+def makedirs(folder, content):
     exec_file = "{}/{}".format(folder, get_source_file_name())
-    os.makedirs(os.path.dirname(os.path.abspath(exec_file)), exist_ok=True)
+    try:
+        os.makedirs(os.path.dirname(os.path.abspath(exec_file)))
+    except OSError as exc:
+        if exc.errno != errno.EEXIST:
+            raise
+        pass
     with open(exec_file, "w") as fh:
         fh.write(content)
 

--- a/src/python/dxpy/nextflow/nextflow_utils.py
+++ b/src/python/dxpy/nextflow/nextflow_utils.py
@@ -27,12 +27,12 @@ def get_importer_name():
 def get_template_dir():
     return os.path.join(os.path.dirname(dxpy.__file__), 'templating', 'templates', 'nextflow')
 
-def makedirs(folder, content):
+def write_exec(folder, content):
     exec_file = "{}/{}".format(folder, get_source_file_name())
     try:
         os.makedirs(os.path.dirname(os.path.abspath(exec_file)))
-    except OSError as exc:
-        if exc.errno != errno.EEXIST:
+    except OSError as e:
+        if e.errno != errno.EEXIST:
             raise
         pass
     with open(exec_file, "w") as fh:


### PR DESCRIPTION
The `exist_ok` parameter was added in Python 3.2.

Replicate the behavior of `os.makedirs(exist_ok=True)` by checking if the OSError raised is `EEXIST`.