### PR TITLE
DEVEX-2137 Fix TestDXTabCompletion tests

### DIFF
--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -1,4 +1,4 @@
-argcomplete==1.9.4
+argcomplete<2.0.0
 websocket-client==0.54.0
 python-dateutil>=2.5
 psutil>=3.3.0

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -1,4 +1,5 @@
-argcomplete<2.0.0
+argcomplete>=2.0.0; python_version >= "3.10"
+argcomplete>=1.9.4,<2.0.0
 websocket-client==0.54.0
 python-dateutil>=2.5
 psutil>=3.3.0

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -1,4 +1,4 @@
-argcomplete>=1.9.4
+argcomplete==1.9.4
 websocket-client==0.54.0
 python-dateutil>=2.5
 psutil>=3.3.0


### PR DESCRIPTION
Pin to argcomplete version to < 2.0, except for Python >= 3.10