### PR TITLE
APPS-1431 Fix to reading a file in py2 environment

### DIFF
--- a/src/python/dxpy/scripts/dx_build_app.py
+++ b/src/python/dxpy/scripts/dx_build_app.py
@@ -298,7 +298,10 @@ def _check_file_syntax(filename, temp_dir, override_lang=None, enforce=True):
         checker_fn = check_python
         # don't enforce and ignore if the shebang is ambiguous and we're not sure
         # that the file version is the same as the one we're running
-        with open(filename, 'rb') as f:
+        read_mode = "r"
+        if USING_PYTHON2:
+            read_mode = "rb"
+        with open(filename, read_mode) as f:
             first_line = f.readline()
             if not (('python3' in first_line and not USING_PYTHON2) or
                     ('python2' in first_line and USING_PYTHON2)):

--- a/src/python/dxpy/scripts/dx_build_app.py
+++ b/src/python/dxpy/scripts/dx_build_app.py
@@ -298,7 +298,7 @@ def _check_file_syntax(filename, temp_dir, override_lang=None, enforce=True):
         checker_fn = check_python
         # don't enforce and ignore if the shebang is ambiguous and we're not sure
         # that the file version is the same as the one we're running
-        with open(filename, 'r') as f:
+        with open(filename, 'rb') as f:
             first_line = f.readline()
             if not (('python3' in first_line and not USING_PYTHON2) or
                     ('python2' in first_line and USING_PYTHON2)):


### PR DESCRIPTION
This fixes a test failure due to [UnicodeDecodeError](https://jenkins-vstg.internal.dnanexus.com/view/dx-toolkit%20release%20board/job/dx-toolkit/job/dxpy-master-integration-tests-on-staging-16.04-python2/1728/console).

Successful tests:
- [py3](https://jenkins-vstg.internal.dnanexus.com/view/dx-toolkit%20release%20board/job/dx-toolkit/job/dxpy-branch-integration-tests-on-staging-20.04-python3/202/)
- [py2](https://jenkins-vstg.internal.dnanexus.com/view/dx-toolkit%20release%20board/job/dx-toolkit/job/dxpy-master-integration-tests-on-staging-16.04-python2/1731/)