### PR TITLE
DEVEX-2161 Skip tests

### DIFF
--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -9946,6 +9946,7 @@ class TestDXGetAppsAndApplets(DXTestCaseBuildApps):
                     break
             self.assertTrue(seenResources)
 
+    @unittest.skip("skipping per DEVEX-2161")
     def test_get_applet_field_cleanup(self):
         # TODO: not sure why self.assertEqual doesn't consider
         # assertEqual to pass unless the strings here are unicode strings

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -2539,6 +2539,7 @@ class TestHTTPResponses(testutil.DXTestCaseCompat):
         res = dxpy.DXHTTPRequest("/system/whoami", {}, want_full_response=True)
         self.assertTrue("CONTENT-type" in res.headers)
 
+    @unittest.skip("skipping per DEVEX-2161")
     def test_ssl_options(self):
         dxpy.DXHTTPRequest("/system/whoami", {}, verify=False)
         dxpy.DXHTTPRequest("/system/whoami", {}, verify=requests.certs.where())


### PR DESCRIPTION
The result:
```
test_get_applet_field_cleanup (test_dxclient.TestDXGetAppsAndApplets) ... skipped 'skipping per DEVEX-2161'

----------------------------------------------------------------------
Ran 1 test in 0.000s

OK (skipped=1)
```
(it's the same for the other test)