### PR TITLE
DEVEX-2186 Use project ID for file-xxxx/describe API calls within dxjava DXFile

### DIFF
--- a/src/java/src/test/java/com/dnanexus/DXFileTest.java
+++ b/src/java/src/test/java/com/dnanexus/DXFileTest.java
@@ -621,4 +621,22 @@ public class DXFileTest {
 
         Assert.assertArrayEquals(uploadBytes, bytesFromDownloadStream);
     }
+
+    @Test
+    public void testDownloadFileWithoutProject() throws IOException {
+        // Initialize file 
+        byte[] uploadBytes = new byte[5 * 1024 * 1024];
+        new Random().nextBytes(uploadBytes);
+
+        DXFile f = DXFile.newFile().setProject(testProject).build();
+        f = DXFile.newFile().setProject(testProject).build();
+        f.uploadChunkSize = 5 * 1024 * 1024;
+        f.upload(uploadBytes);
+        f.closeAndWait();
+        // Initialize file without project ID and download
+        DXFile g = DXFile.getInstance(f.dxId);
+        byte[] downloadBytes = g.downloadBytes();
+        Assert.assertArrayEquals(uploadBytes, downloadBytes);
+    }
+
 }


### PR DESCRIPTION
Use the project-id of `DXFile()` if already known, else retrieve it to use in subsequent `file-xxxx/describe` API calls within `DXFile()`. Also use this project-id in `file-xxxx/download` API calls.

Also retrieve the file size once at the beginning instead of when calculating byte range. 