### PR TITLE
DEVEX-2226 File (un)archive support in DXJava

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 
 ## Unreleased
 
+### Added
+
+* Added support for file (un)archival in DXJava
+* Added `archivalStatus` field to DXFile describe in DXJava
+* Added `archivalStatus` filtering support to DXSearch in DXJava
+
 ## [343.0] - beta
 
 ### Changed

--- a/build/run_java_integration_tests.py
+++ b/build/run_java_integration_tests.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import print_function, unicode_literals
+
 import argparse
 import os
 import subprocess
@@ -27,10 +29,11 @@ def run():
         subprocess.check_call(["make", "java"], cwd=os.path.join(TOOLKIT_ROOT_DIR, "src"))
         subprocess.check_call(make_cmd, cwd=os.path.join(TOOLKIT_ROOT_DIR, "src", "java"))
     except subprocess.CalledProcessError as e:
-        print "Tests failed, printing out error reports:"
+        print("Tests failed, printing out error reports:")
         for filename in os.listdir(os.path.join(TOOLKIT_ROOT_DIR, "src/java/target/surefire-reports")):
             if filename.startswith("com.dnanexus."):
-                print open(os.path.join(TOOLKIT_ROOT_DIR, "src/java/target/surefire-reports", filename)).read().strip()
+                with open(os.path.join(TOOLKIT_ROOT_DIR, "src/java/target/surefire-reports", filename)) as fh:
+                    print(fh.read().strip())
         raise e
 
 if __name__ == '__main__':

--- a/src/java/src/main/java/com/dnanexus/ArchivalState.java
+++ b/src/java/src/main/java/com/dnanexus/ArchivalState.java
@@ -1,0 +1,41 @@
+package com.dnanexus;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+
+public enum ArchivalState {
+    ARCHIVED("archived"),
+    LIVE("live"),
+    ARCHIVAL("archival"),
+    UNARCHIVING("unarchiving");
+
+    private static Map<String, ArchivalState> createMap;
+
+    static {
+        Map<String, ArchivalState> result = Maps.newHashMap();
+        for (ArchivalState state : ArchivalState.values()) {
+            result.put(state.getValue(), state);
+        }
+        createMap = ImmutableMap.copyOf(result);
+    }
+
+    @JsonCreator
+    private static ArchivalState create(String value) {
+        return createMap.get(value);
+    }
+
+    private String value;
+
+    private ArchivalState(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    private String getValue() {
+        return this.value;
+    }
+}

--- a/src/java/src/main/java/com/dnanexus/ArchivalState.java
+++ b/src/java/src/main/java/com/dnanexus/ArchivalState.java
@@ -7,10 +7,26 @@ import com.google.common.collect.Maps;
 
 import java.util.Map;
 
+/**
+ * Archival states of file object.
+ */
 public enum ArchivalState {
+    /**
+     * The file is in archival storage, such as AWS S3 Glacier or Azure Blob ARCHIVE.
+     */
     ARCHIVED("archived"),
+    /**
+     * The file is in standard storage, such as AWS S3 or Azure Blob.
+     */
     LIVE("live"),
+    /**
+     * Archival requested on the current file, but other copies of the same file are in the live state in multiple
+     * projects with the same billTo entity. The file is still in standard storage.
+     */
     ARCHIVAL("archival"),
+    /**
+     * Unarchival requested on the current file. The file is in transition from archival storage to standard storage.
+     */
     UNARCHIVING("unarchiving");
 
     private static Map<String, ArchivalState> createMap;

--- a/src/java/src/main/java/com/dnanexus/DXEnvironment.java
+++ b/src/java/src/main/java/com/dnanexus/DXEnvironment.java
@@ -67,7 +67,7 @@ public class DXEnvironment implements AutoCloseable {
 
         /**
          * Creates a Builder object using the JSON config in the file
-         * <tt>~/.dnanexus_config/environment.json</tt>.
+         * <code>~/.dnanexus_config/environment.json</code>.
          *
          * @return new Builder object
          */
@@ -115,7 +115,7 @@ public class DXEnvironment implements AutoCloseable {
 
         /**
          * Initializes a Builder object using JSON config in the file
-         * <tt>~/.dnanexus_config/environment.json</tt>.
+         * <code>~/.dnanexus_config/environment.json</code>.
          *
          * @deprecated Use {@link #fromDefaults()} instead
          */
@@ -386,8 +386,6 @@ public class DXEnvironment implements AutoCloseable {
 
         /**
          * Disables automatic retry of HTTP requests.
-         *
-         * @param disableRetryLogic boolean
          *
          * @return the same Builder object
          */

--- a/src/java/src/main/java/com/dnanexus/DXFile.java
+++ b/src/java/src/main/java/com/dnanexus/DXFile.java
@@ -175,6 +175,8 @@ public class DXFile extends DXDataObject {
         private Map<Integer, PartValue> parts;
         @JsonProperty
         private Long size;
+        @JsonProperty
+        private ArchivalState archivalState;
 
         private Describe() {
             super();
@@ -245,6 +247,17 @@ public class DXFile extends DXDataObject {
             Preconditions.checkState(this.size != null,
                     "file size is not accessible because it was not retrieved with the describe call");
             return size;
+        }
+
+        /**
+         * Returns the archival state of the file.
+         *
+         * @return archival state of file
+         */
+        public ArchivalState getArchivalState() {
+            Preconditions.checkState(this.archivalState != null,
+                    "archival state is not accessible because it was not retrieved with the describe call");
+            return archivalState;
         }
     }
 

--- a/src/java/src/main/java/com/dnanexus/DXJSON.java
+++ b/src/java/src/main/java/com/dnanexus/DXJSON.java
@@ -65,7 +65,7 @@ public class DXJSON {
      *                     .addAllStrings(ImmutableList.of("Bar", "Baz"))
      *                     .build()}</pre>
      *
-     * when serialized, produces the JSON array <tt>["Foo", "Bar", "Baz"]</tt>.
+     * when serialized, produces the JSON array <code>["Foo", "Bar", "Baz"]</code>.
      */
     public static class ArrayBuilder {
         private final boolean isEmpty;
@@ -165,7 +165,7 @@ public class DXJSON {
      *                      .put("key2", 12321)
      *                      .build()}</pre>
      *
-     * when serialized, produces the JSON object <tt>{"key1": "a-string", "key2": 12321}</tt>.
+     * when serialized, produces the JSON object <code>{"key1": "a-string", "key2": 12321}</code>.
      */
     public static class ObjectBuilder {
         private final boolean isEmpty;

--- a/src/java/src/main/java/com/dnanexus/DXProject.java
+++ b/src/java/src/main/java/com/dnanexus/DXProject.java
@@ -302,7 +302,7 @@ public class DXProject extends DXContainer {
          * Adds the file to the list of files for archival.
          *
          * <p>
-         * This method may be called multiple time during the construction of a request, and is mutually exclusive
+         * This method may be called multiple times during the construction of a request, and is mutually exclusive
          * with {@link #setFolder(String)} and {@link #setFolder(String, Boolean)}.
          * </p>
          *
@@ -322,7 +322,7 @@ public class DXProject extends DXContainer {
          * Adds the files to the list of files for archival.
          *
          * <p>
-         * This method may be called multiple time during the construction of a request, and is mutually exclusive
+         * This method may be called multiple times during the construction of a request, and is mutually exclusive
          * with {@link #setFolder(String)} and {@link #setFolder(String, Boolean)}.
          * </p>
          *
@@ -339,7 +339,7 @@ public class DXProject extends DXContainer {
          * Adds the files to the list of files for archival.
          *
          * <p>
-         * This method may be called multiple time during the construction of a request, and is mutually exclusive
+         * This method may be called multiple times during the construction of a request, and is mutually exclusive
          * with {@link #setFolder(String)} and {@link #setFolder(String, Boolean)}.
          * </p>
          *
@@ -487,7 +487,7 @@ public class DXProject extends DXContainer {
          * Adds the file to the list of files for unarchiving.
          *
          * <p>
-         * This method may be called multiple time during the construction of a request, and is mutually exclusive
+         * This method may be called multiple times during the construction of a request, and is mutually exclusive
          * with {@link #setFolder(String)} and {@link #setFolder(String, Boolean)}.
          * </p>
          *
@@ -507,7 +507,7 @@ public class DXProject extends DXContainer {
          * Adds the files to the list of files for unarchiving.
          *
          * <p>
-         * This method may be called multiple time during the construction of a request, and is mutually exclusive
+         * This method may be called multiple times during the construction of a request, and is mutually exclusive
          * with {@link #setFolder(String)} and {@link #setFolder(String, Boolean)}.
          * </p>
          *
@@ -524,7 +524,7 @@ public class DXProject extends DXContainer {
          * Adds the files to the list of files for unarchiving.
          *
          * <p>
-         * This method may be called multiple time during the construction of a request, and is mutually exclusive
+         * This method may be called multiple times during the construction of a request, and is mutually exclusive
          * with {@link #setFolder(String)} and {@link #setFolder(String, Boolean)}.
          * </p>
          *

--- a/src/java/src/main/java/com/dnanexus/DXProject.java
+++ b/src/java/src/main/java/com/dnanexus/DXProject.java
@@ -227,7 +227,7 @@ public class DXProject extends DXContainer {
      * Move specified files or folder to an archive storage to save on storage costs.
      *
      * <p>
-     * Example uses:
+     * Example use:
      * </p>
      *
      * <pre>
@@ -236,7 +236,7 @@ public class DXProject extends DXContainer {
      * DXFile f2 = DXFile.getInstance(&quot;file-yyyy&quot;);
      * ArchiveResults r = project.archive().addFiles(f1, f2).execute();
      * // Archive folder
-     * ArchiveResults r = project.archive().setFolder(&quot;/folder&quot;).setRecurse(true).execute();
+     * ArchiveResults r = project.archive().setFolder(&quot;/folder&quot;, true).execute();
      * </pre>
      *
      * @return a newly initialized {@code ArchiveRequestBuilder}
@@ -247,6 +247,19 @@ public class DXProject extends DXContainer {
 
     /**
      * Retrieve specified files or folder from an archive storage.
+     *
+     * <p>
+     * Example use:
+     * </p>
+     *
+     * <pre>
+     * // Unarchive using file id
+     * DXFile f1 = DXFile.getInstance(&quot;file-xxxx&quot;);
+     * DXFile f2 = DXFile.getInstance(&quot;file-yyyy&quot;);
+     * ArchiveResults r = project.unarchive().addFiles(f1, f2).execute();
+     * // Unarchive folder
+     * ArchiveResults r = project.unarchive().setFolder(&quot;/folder&quot;, true).execute();
+     * </pre>
      *
      * @return a newly initialized {@code UnarchiveRequestBuilder}
      */

--- a/src/java/src/main/java/com/dnanexus/DXProject.java
+++ b/src/java/src/main/java/com/dnanexus/DXProject.java
@@ -256,9 +256,9 @@ public class DXProject extends DXContainer {
      * // Unarchive using file id
      * DXFile f1 = DXFile.getInstance(&quot;file-xxxx&quot;);
      * DXFile f2 = DXFile.getInstance(&quot;file-yyyy&quot;);
-     * ArchiveResults r = project.unarchive().addFiles(f1, f2).execute();
+     * UnarchiveResults r = project.unarchive().addFiles(f1, f2).execute();
      * // Unarchive folder
-     * ArchiveResults r = project.unarchive().setFolder(&quot;/folder&quot;, true).execute();
+     * UnarchiveResults r = project.unarchive().setFolder(&quot;/folder&quot;, true).execute();
      * </pre>
      *
      * @return a newly initialized {@code UnarchiveRequestBuilder}

--- a/src/java/src/main/java/com/dnanexus/DXProject.java
+++ b/src/java/src/main/java/com/dnanexus/DXProject.java
@@ -224,7 +224,7 @@ public class DXProject extends DXContainer {
     }
 
     /**
-     * Move specified files or folder to an archive storage to save on storage costs.
+     * Request specified files or folder to be archived.
      *
      * <p>
      * Example use:
@@ -246,7 +246,7 @@ public class DXProject extends DXContainer {
     }
 
     /**
-     * Retrieve specified files or folder from an archive storage.
+     * Request specified files or folder to be unarchived.
      *
      * <p>
      * Example use:

--- a/src/java/src/main/java/com/dnanexus/DXSearch.java
+++ b/src/java/src/main/java/com/dnanexus/DXSearch.java
@@ -589,8 +589,8 @@ public final class DXSearch {
          * specified, the default is to return all objects regardless their archival state.
          *
          * <p>
-         * Please note archival states are support only for "file" class (use {@link #withClassFile()}) and
-         * requires specified project and folder (use either {@link #inFolder(DXContainer, String)} or
+         * Please note archival states are supported only for "file" class (use {@link #withClassFile()}). This filter
+         * requires project and folder (can be root "/") to be specified (use either {@link #inFolder(DXContainer, String)} or
          * {@link #inFolderOrSubfolders(DXContainer, String)}).
          * </p>
          *

--- a/src/java/src/main/java/com/dnanexus/DXSearch.java
+++ b/src/java/src/main/java/com/dnanexus/DXSearch.java
@@ -1107,7 +1107,7 @@ public final class DXSearch {
         /**
          * Returns a subsequent page of the {@code findDataObjects} results starting from the specified item.
          *
-         * @param starting result of {@link DXSearch.FindDataObjectsResult.Page#getNext()} call on previous page
+         * @param starting result of {@link DXSearch.FindDataObjectsResult.FindDataObjectsResultPage#getNext()} call on previous page
          * @param pageSize number of elements to retrieve
          *
          * @return result set

--- a/src/java/src/main/java/com/dnanexus/DXSearch.java
+++ b/src/java/src/main/java/com/dnanexus/DXSearch.java
@@ -594,7 +594,7 @@ public final class DXSearch {
          * {@link #inFolderOrSubfolders(DXContainer, String)}).
          * </p>
          *
-         * @param archivalState enum value specifying what files archival states can be returned.
+         * @param archivalState enum value specifying what files archival states can be returned
          *
          * @return the same builder object
          */

--- a/src/java/src/main/java/com/dnanexus/DXSearch.java
+++ b/src/java/src/main/java/com/dnanexus/DXSearch.java
@@ -125,6 +125,8 @@ public final class DXSearch {
         private final TimeIntervalQuery modified;
         @JsonProperty
         private final TimeIntervalQuery created;
+        @JsonProperty
+        private final ArchivalState archivalState;
 
         @JsonProperty
         private final DescribeParameters describe;
@@ -159,6 +161,7 @@ public final class DXSearch {
             this.level = previousQuery.level;
             this.modified = previousQuery.modified;
             this.created = previousQuery.created;
+            this.archivalState = previousQuery.archivalState;
             this.describe = previousQuery.describe;
 
             this.starting = (starting == null || starting.isNull()) ? null : starting;
@@ -197,6 +200,7 @@ public final class DXSearch {
             this.scope = builder.scopeQuery;
             this.sortBy = builder.sortByQuery;
             this.level = builder.level;
+            this.archivalState = builder.archivalState;
 
             if (builder.modifiedBefore != null || builder.modifiedAfter != null) {
                 this.modified =
@@ -243,6 +247,7 @@ public final class DXSearch {
         private Date createdBefore;
         private Date createdAfter;
         private DescribeParameters describe;
+        private ArchivalState archivalState;
 
         private final DXEnvironment env;
 
@@ -576,6 +581,28 @@ public final class DXSearch {
             this.nameQuery =
                     new NameQuery.RegexpNameQuery(Preconditions.checkNotNull(regexp,
                             "regexp may not be null"), caseInsensitive ? "i" : null);
+            return this;
+        }
+
+        /**
+         * Only returns files with the specified archival state. If not
+         * specified, the default is to return all objects regardless their archival state.
+         *
+         * <p>
+         * Please note archival states are support only for "file" class (use {@link #withClassFile()}) and
+         * requires specified project and folder (use either {@link #inFolder(DXContainer, String)} or
+         * {@link #inFolderOrSubfolders(DXContainer, String)}).
+         * </p>
+         *
+         * @param archivalState enum value specifying what files archival states can be returned.
+         *
+         * @return the same builder object
+         */
+        public FindDataObjectsRequestBuilder<T> withArchivalState(ArchivalState archivalState) {
+            Preconditions.checkState(this.archivalState == null,
+                    "Cannot call withArchivalState more than once");
+            this.archivalState =
+                    Preconditions.checkNotNull(archivalState, "archivalState may not be null");
             return this;
         }
 

--- a/src/java/src/main/java/com/dnanexus/RunSpecification.java
+++ b/src/java/src/main/java/com/dnanexus/RunSpecification.java
@@ -41,7 +41,7 @@ public class RunSpecification {
         private Builder(String interpreter, String code, String distribution, String release) {
             this.interpreter = interpreter;
             this.code = code;
-            this. distribution = distribution;
+            this.distribution = distribution;
             this.release = release;
         }
 
@@ -59,7 +59,7 @@ public class RunSpecification {
 
     /**
      * Returns a builder initialized to create a run specification with the given interpreter,
-     * entry point code, distribution and releae.
+     * entry point code, distribution and release.
      *
      * @param interpreter interpreter name, e.g. "bash" or "python2.7"
      * @param code entry point code

--- a/src/java/src/main/java/com/dnanexus/UnarchivingRate.java
+++ b/src/java/src/main/java/com/dnanexus/UnarchivingRate.java
@@ -1,0 +1,40 @@
+package com.dnanexus;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+
+public enum UnarchivingRate {
+    EXPEDITED("Expedited"),
+    STANDARD("Standard"),
+    BULK("Bulk");
+
+    private static Map<String, UnarchivingRate> createMap;
+
+    static {
+        Map<String, UnarchivingRate> result = Maps.newHashMap();
+        for (UnarchivingRate state : UnarchivingRate.values()) {
+            result.put(state.getValue(), state);
+        }
+        createMap = ImmutableMap.copyOf(result);
+    }
+
+    @JsonCreator
+    private static UnarchivingRate create(String value) {
+        return createMap.get(value);
+    }
+
+    private String value;
+
+    private UnarchivingRate(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    private String getValue() {
+        return this.value;
+    }
+}

--- a/src/java/src/test/java/com/dnanexus/DXProjectTest.java
+++ b/src/java/src/test/java/com/dnanexus/DXProjectTest.java
@@ -534,6 +534,7 @@ public class DXProjectTest {
             sleep(5000);
         }
 
+        sleep(5000);
         Assert.assertEquals(2, testProject.unarchive().setFolder("/folder", true).execute().getFiles());
     }
 

--- a/src/java/src/test/java/com/dnanexus/DXProjectTest.java
+++ b/src/java/src/test/java/com/dnanexus/DXProjectTest.java
@@ -352,14 +352,13 @@ public class DXProjectTest {
             // Expected
         }
 
-        DXFile file1 = createMinimalFile("archiveFile1");
-        DXFile file2 = createMinimalFile("archiveFile2");
+        createMinimalFile("archiveFile1");
+        createMinimalFile("archiveFile2");
         testProject.newFolder("/folder");
         testProject.newFolder("/folder/subfolder");
         createMinimalFile("archiveFile10", "/folder");
         createMinimalFile("archiveFile11", "/folder/subfolder");
 
-        Assert.assertEquals(2, testProject.archive().addFiles(file1, file2).execute().getCount());
         Assert.assertEquals(2, testProject.archive().setFolder("/folder", true).execute().getCount());
     }
 
@@ -516,7 +515,7 @@ public class DXProjectTest {
         }
 
         DXFile file1 = createMinimalFile("archiveFile1");
-        DXFile file2 = createMinimalFile("archiveFile2");
+        createMinimalFile("archiveFile2");
         testProject.newFolder("/folder");
         testProject.newFolder("/folder/subfolder");
         createMinimalFile("archiveFile10", "/folder");
@@ -535,7 +534,6 @@ public class DXProjectTest {
             sleep(5000);
         }
 
-        Assert.assertEquals(2, testProject.unarchive().addFiles(file1, file2).execute().getFiles());
         Assert.assertEquals(2, testProject.unarchive().setFolder("/folder", true).execute().getFiles());
     }
 

--- a/src/java/src/test/java/com/dnanexus/DXProjectTest.java
+++ b/src/java/src/test/java/com/dnanexus/DXProjectTest.java
@@ -514,18 +514,18 @@ public class DXProjectTest {
             // Expected
         }
 
-        DXFile file1 = createMinimalFile("archiveFile1");
+        createMinimalFile("archiveFile1");
         createMinimalFile("archiveFile2");
         testProject.newFolder("/folder");
         testProject.newFolder("/folder/subfolder");
-        createMinimalFile("archiveFile10", "/folder");
-        createMinimalFile("archiveFile11", "/folder/subfolder");
+        DXFile file1 = createMinimalFile("archiveFile10", "/folder");
+        DXFile file2 = createMinimalFile("archiveFile11", "/folder/subfolder");
         testProject.archive().setFolder("/", true).execute();
 
         // Wait for archival to complete
         final int maxRetries = 24;
         for (int i = 1; i <= maxRetries; ++i) {
-            if (file1.describe().getArchivalState() == ArchivalState.ARCHIVED) {
+            if (file1.describe().getArchivalState() == ArchivalState.ARCHIVED && file2.describe().getArchivalState() == ArchivalState.ARCHIVED) {
                 break;
             }
             if (i == maxRetries) {

--- a/src/java/src/test/java/com/dnanexus/DXProjectTest.java
+++ b/src/java/src/test/java/com/dnanexus/DXProjectTest.java
@@ -354,25 +354,13 @@ public class DXProjectTest {
 
         DXFile file1 = createMinimalFile("archiveFile1");
         DXFile file2 = createMinimalFile("archiveFile2");
-        DXFile file3 = createMinimalFile("archiveFile3");
         testProject.newFolder("/folder");
         testProject.newFolder("/folder/subfolder");
-        DXFile file4 = createMinimalFile("archiveFile10", "/folder");
-        DXFile file5 = createMinimalFile("archiveFile11", "/folder/subfolder");
-        List<ArchivalState> targetStates = ImmutableList.of(ArchivalState.ARCHIVAL, ArchivalState.ARCHIVED);
+        createMinimalFile("archiveFile10", "/folder");
+        createMinimalFile("archiveFile11", "/folder/subfolder");
 
         Assert.assertEquals(2, testProject.archive().addFiles(file1, file2).execute().getCount());
-        sleep(5000);
-        Assert.assertTrue(targetStates.contains(file1.describe().getArchivalState()));
-        Assert.assertTrue(targetStates.contains(file2.describe().getArchivalState()));
-        Assert.assertFalse(targetStates.contains(file3.describe().getArchivalState()));
-        Assert.assertFalse(targetStates.contains(file4.describe().getArchivalState()));
-        Assert.assertFalse(targetStates.contains(file5.describe().getArchivalState()));
         Assert.assertEquals(2, testProject.archive().setFolder("/folder", true).execute().getCount());
-        sleep(5000);
-        Assert.assertFalse(targetStates.contains(file3.describe().getArchivalState()));
-        Assert.assertTrue(targetStates.contains(file4.describe().getArchivalState()));
-        Assert.assertTrue(targetStates.contains(file5.describe().getArchivalState()));
     }
 
     @Test
@@ -529,28 +517,26 @@ public class DXProjectTest {
 
         DXFile file1 = createMinimalFile("archiveFile1");
         DXFile file2 = createMinimalFile("archiveFile2");
-        DXFile file3 = createMinimalFile("archiveFile3");
         testProject.newFolder("/folder");
         testProject.newFolder("/folder/subfolder");
-        DXFile file4 = createMinimalFile("archiveFile10", "/folder");
-        DXFile file5 = createMinimalFile("archiveFile11", "/folder/subfolder");
+        createMinimalFile("archiveFile10", "/folder");
+        createMinimalFile("archiveFile11", "/folder/subfolder");
         testProject.archive().setFolder("/", true).execute();
-        sleep(5000);
 
-        List<ArchivalState> targetStates = ImmutableList.of(ArchivalState.LIVE, ArchivalState.UNARCHIVING);
+        // Wait for archival to complete
+        final int maxRetries = 24;
+        for (int i = 1; i <= maxRetries; ++i) {
+            if (file1.describe().getArchivalState() == ArchivalState.ARCHIVED) {
+                break;
+            }
+            if (i == maxRetries) {
+                Assert.fail("Could not archive test files. Test cannot proceed...");
+            }
+            sleep(5000);
+        }
 
         Assert.assertEquals(2, testProject.unarchive().addFiles(file1, file2).execute().getFiles());
-        sleep(5000);
-        Assert.assertTrue(targetStates.contains(file1.describe().getArchivalState()));
-        Assert.assertTrue(targetStates.contains(file2.describe().getArchivalState()));
-        Assert.assertFalse(targetStates.contains(file3.describe().getArchivalState()));
-        Assert.assertFalse(targetStates.contains(file4.describe().getArchivalState()));
-        Assert.assertFalse(targetStates.contains(file5.describe().getArchivalState()));
         Assert.assertEquals(2, testProject.unarchive().setFolder("/folder", true).execute().getFiles());
-        sleep(5000);
-        Assert.assertFalse(targetStates.contains(file3.describe().getArchivalState()));
-        Assert.assertTrue(targetStates.contains(file4.describe().getArchivalState()));
-        Assert.assertTrue(targetStates.contains(file5.describe().getArchivalState()));
     }
 
     // Internal tests

--- a/src/java/src/test/java/com/dnanexus/DXProjectTest.java
+++ b/src/java/src/test/java/com/dnanexus/DXProjectTest.java
@@ -54,11 +54,11 @@ public class DXProjectTest {
         }
     }
 
-    private DXFile createMinimalFile(String name) {
-        return createMinimalFile(name, null);
+    private DXFile uploadMinimalFile(String name) {
+        return uploadMinimalFile(name, null);
     }
 
-    private DXFile createMinimalFile(String name, String folder) {
+    private DXFile uploadMinimalFile(String name, String folder) {
         DXFile.Builder fileBuilder = DXFile.newFile()
                 .setProject(testProject)
                 .setName(name);
@@ -352,12 +352,12 @@ public class DXProjectTest {
             // Expected
         }
 
-        createMinimalFile("archiveFile1");
-        createMinimalFile("archiveFile2");
+        uploadMinimalFile("archiveFile1");
+        uploadMinimalFile("archiveFile2");
         testProject.newFolder("/folder");
         testProject.newFolder("/folder/subfolder");
-        createMinimalFile("archiveFile10", "/folder");
-        createMinimalFile("archiveFile11", "/folder/subfolder");
+        uploadMinimalFile("archiveFile10", "/folder");
+        uploadMinimalFile("archiveFile11", "/folder/subfolder");
 
         Assert.assertEquals(2, testProject.archive().setFolder("/folder", true).execute().getCount());
     }
@@ -514,12 +514,12 @@ public class DXProjectTest {
             // Expected
         }
 
-        createMinimalFile("archiveFile1");
-        createMinimalFile("archiveFile2");
+        uploadMinimalFile("archiveFile1");
+        uploadMinimalFile("archiveFile2");
         testProject.newFolder("/folder");
         testProject.newFolder("/folder/subfolder");
-        DXFile file1 = createMinimalFile("archiveFile10", "/folder");
-        DXFile file2 = createMinimalFile("archiveFile11", "/folder/subfolder");
+        DXFile file1 = uploadMinimalFile("archiveFile10", "/folder");
+        DXFile file2 = uploadMinimalFile("archiveFile11", "/folder/subfolder");
         testProject.archive().setFolder("/", true).execute();
 
         // Wait for archival to complete

--- a/src/java/src/test/java/com/dnanexus/DXSearchTest.java
+++ b/src/java/src/test/java/com/dnanexus/DXSearchTest.java
@@ -360,6 +360,18 @@ public class DXSearchTest {
         DXFile fileArchived = createMinimalFile("fileArchived");
         testProject.archive().addFile(fileArchived).execute();
 
+        // Wait for archival to complete
+        final int maxRetries = 24;
+        for (int i = 1; i <= maxRetries; ++i) {
+            if (fileArchived.describe().getArchivalState() == ArchivalState.ARCHIVED) {
+                break;
+            }
+            if (i == maxRetries) {
+                Assert.fail("Could not archive test file. Test cannot proceed...");
+            }
+            sleep(5000);
+        }
+
         // Empty archival state does not affect file retrieval
         assertEqualsAnyOrder(DXSearch.findDataObjects().withClassFile().inFolder(testProject, "/")
                 .execute().asList(), fileLive1, fileLive2, fileArchived);

--- a/src/java/src/test/java/com/dnanexus/DXSearchTest.java
+++ b/src/java/src/test/java/com/dnanexus/DXSearchTest.java
@@ -353,7 +353,7 @@ public class DXSearchTest {
         assertEqualsAnyOrder(DXSearch.findDataObjects().withIdsIn(ImmutableList.of(moo, invisible))
                 .withVisibility(VisibilityQuery.EITHER).execute().asList(), moo, invisible);
 
-        // withArchiveState
+        // withArchivalState
 
         DXFile fileLive1 = createMinimalFile("fileLive1");
         DXFile fileLive2 = createMinimalFile("fileLive2");
@@ -377,7 +377,7 @@ public class DXSearchTest {
         try {
             DXSearch.findDataObjects().inFolder(testProject, "/")
                     .withArchivalState(ArchivalState.LIVE).execute().asList();
-            Assert.fail("Search should not work without class 'file' --> check API spec and update javadoc!");
+            Assert.fail("Expected search to fail due to missing 'class=File'");
         } catch (Exception ex) {
             // Expected
         }
@@ -385,7 +385,7 @@ public class DXSearchTest {
         try {
             DXSearch.findDataObjects().withClassFile()
                     .withArchivalState(ArchivalState.LIVE).execute().asList();
-            Assert.fail("Search should not work without 'project' and 'folder' --> check API spec and update javadoc!");
+            Assert.fail("Expected search to fail due to missing 'project' and 'folder' fields");
         } catch (Exception ex) {
             // Expected
         }

--- a/src/java/src/test/java/com/dnanexus/DXSearchTest.java
+++ b/src/java/src/test/java/com/dnanexus/DXSearchTest.java
@@ -107,7 +107,7 @@ public class DXSearchTest {
         return applet;
     }
 
-    private DXFile createMinimalFile(String name) {
+    private DXFile uploadMinimalFile(String name) {
         DXFile file = DXFile.newFile()
                 .setProject(testProject)
                 .setName(name)
@@ -355,9 +355,9 @@ public class DXSearchTest {
 
         // withArchivalState
 
-        DXFile fileLive1 = createMinimalFile("fileLive1");
-        DXFile fileLive2 = createMinimalFile("fileLive2");
-        DXFile fileArchived = createMinimalFile("fileArchived");
+        DXFile fileLive1 = uploadMinimalFile("fileLive1");
+        DXFile fileLive2 = uploadMinimalFile("fileLive2");
+        DXFile fileArchived = uploadMinimalFile("fileArchived");
         testProject.archive().addFile(fileArchived).execute();
 
         // Wait for archival to complete


### PR DESCRIPTION
**Java binding changes:**
* new field in `dx describe`
* possibility to search using `archivalState` field
* possibility to (un)archive files
* suitable tests
* minor fixes in javadoc strings to be compatible with Java 11 and HTML5

**Other changes:**
* make `build/run_java_integration_tests.py` compatible with Python 3
