### PR TITLE
Fix help strings wrapping of several "dx run" args

### DIFF
--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -5267,9 +5267,9 @@ parser_run.add_argument('--detach', help=fill("When invoked from a job, detaches
 parser_run.add_argument('--cost-limit', help=fill("Maximum cost of the job before termination. In case of workflows it is cost of the "
                                                   "entire analysis job. For batch run, this limit is applied per job.",
                                               width_adjustment=-24), metavar='cost_limit', type=float)
-parser_run.add_argument('-r', '--rank', type=int, help='Set the rank of the root execution, integer between -1024 and 1023. Requires executionRankEnabled license feature for the billTo. Default is 0.', default=None)
-parser_run.add_argument('--max-tree-spot-wait-time', help='The amount of time allocated to each path in the root execution\'s tree to wait for Spot (in seconds, or use suffix s, m, h, d, w, M, y)')
-parser_run.add_argument('--max-job-spot-wait-time', help='The amount of time allocated to each job in the root execution\'s tree to wait for Spot (in seconds, or use suffix s, m, h, d, w, M, y)')
+parser_run.add_argument('-r', '--rank', type=int, help=fill('Set the rank of the root execution, integer between -1024 and 1023. Requires executionRankEnabled license feature for the billTo. Default is 0.', width_adjustment=-24), default=None)
+parser_run.add_argument('--max-tree-spot-wait-time', help=fill('The amount of time allocated to each path in the root execution\'s tree to wait for Spot (in seconds, or use suffix s, m, h, d, w, M, y)', width_adjustment=-24))
+parser_run.add_argument('--max-job-spot-wait-time', help=fill('The amount of time allocated to each job in the root execution\'s tree to wait for Spot (in seconds, or use suffix s, m, h, d, w, M, y)', width_adjustment=-24))
 parser_run.set_defaults(func=run, verbose=False, help=False, details=None,
                         stage_instance_types=None, stage_folders=None, head_job_on_demand=None)
 register_parser(parser_run, categories='exec')


### PR DESCRIPTION
I noticed that some args are not wrapping properly in `dx run --help` so I fixed them to have everything unified. This patch does NOT affect functionality.

Original:
```
  -r RANK, --rank RANK  Set the rank of the root execution, integer between -1024 and 1023. Requires executionRankEnabled license feature for the billTo. Default is 0.
  --max-tree-spot-wait-time MAX_TREE_SPOT_WAIT_TIME
                        The amount of time allocated to each path in the root execution's tree to wait for Spot (in seconds, or use suffix s, m, h, d, w, M, y)
  --max-job-spot-wait-time MAX_JOB_SPOT_WAIT_TIME
                        The amount of time allocated to each job in the root execution's tree to wait for Spot (in seconds, or use suffix s, m, h, d, w, M, y)
```
Updated:
```
  -r RANK, --rank RANK  Set the rank of the root execution, integer between -1024 and 1023. Requires
                        executionRankEnabled license feature for the billTo. Default is 0.
  --max-tree-spot-wait-time MAX_TREE_SPOT_WAIT_TIME
                        The amount of time allocated to each path in the root execution's tree to
                        wait for Spot (in seconds, or use suffix s, m, h, d, w, M, y)
  --max-job-spot-wait-time MAX_JOB_SPOT_WAIT_TIME
                        The amount of time allocated to each job in the root execution's tree to
                        wait for Spot (in seconds, or use suffix s, m, h, d, w, M, y)
```