### PR TITLE
DEVEX-2159 Temporarily revert preserveJobOutputs functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 * Added support for file (un)archival in DXJava
 * Added `archivalStatus` field to DXFile describe in DXJava
 * Added `archivalStatus` filtering support to DXSearch in DXJava
-* `dx run` support for `--preserve-job-outputs` and `--preserve-job-outputs-folder` inputs
-* `dx describe` for jobs and analyses outputs `Preserve Job Outputs Folder` field
 
 ### Changed
 

--- a/src/python/dxpy/bindings/dxapplet.py
+++ b/src/python/dxpy/bindings/dxapplet.py
@@ -114,10 +114,6 @@ class DXExecutable:
         if kwargs.get('max_job_spot_wait_time') is not None:
             run_input["maxJobSpotWaitTime"] = kwargs['max_job_spot_wait_time']
 
-        preserve_job_outputs = kwargs.get('preserve_job_outputs')
-        if preserve_job_outputs is not None and preserve_job_outputs != False:
-            run_input["preserveJobOutputs"] = {} if preserve_job_outputs == True else preserve_job_outputs
-
         return run_input
 
     @staticmethod
@@ -184,7 +180,7 @@ class DXExecutable:
             instance_type=None, stage_instance_types=None, stage_folders=None, rerun_stages=None, cluster_spec=None,
             depends_on=None, allow_ssh=None, debug=None, delay_workspace_destruction=None, priority=None, head_job_on_demand=None,
             ignore_reuse=None, ignore_reuse_stages=None, detach=None, cost_limit=None, rank=None, max_tree_spot_wait_time=None,
-            max_job_spot_wait_time=None, preserve_job_outputs=None, extra_args=None, **kwargs):
+            max_job_spot_wait_time=None, extra_args=None, **kwargs):
         '''
         :param executable_input: Hash of the executable's input arguments
         :type executable_input: dict
@@ -228,8 +224,6 @@ class DXExecutable:
         :type max_tree_spot_wait_time: int
         :param max_job_spot_wait_time: Number of seconds allocated to each job in the root execution's tree to wait for Spot
         :type max_job_spot_wait_time: int
-        :param preserve_job_outputs: Copy cloneable outputs of every non-reused job entering "done" state in this root execution to a folder in the project. If value is True it will place job outputs into the "intermediateJobOutputs" subfolder under the output folder for the root execution. If the value is dict, it may contains "folder" key with desired folder path. If the folder path starts with '/' it refers to an absolute path within the project, otherwise, it refers to a subfolder under root execution's output folder.
-        :type preserve_job_outputs: boolean or dict
         :param extra_args: If provided, a hash of options that will be merged into the underlying JSON given for the API call
         :type extra_args: dict
         :returns: Object handler of the newly created job
@@ -268,7 +262,6 @@ class DXExecutable:
                                         rank=rank,
                                         max_tree_spot_wait_time=max_tree_spot_wait_time,
                                         max_job_spot_wait_time=max_job_spot_wait_time,
-                                        preserve_job_outputs=preserve_job_outputs,
                                         extra_args=extra_args)
         return self._run_impl(run_input, **kwargs)
 

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -3039,12 +3039,6 @@ def run_body(args, executable, dest_proj, dest_path, preset_inputs=None, input_n
         if 'All' in args.debug_on:
             args.debug_on = ['AppError', 'AppInternalError', 'ExecutionError']
 
-    preserve_job_outputs = None
-    if args.preserve_job_outputs:
-        preserve_job_outputs = True
-    elif args.preserve_job_outputs_folder is not None:
-        preserve_job_outputs = {"folder": args.preserve_job_outputs_folder}
-
     run_kwargs = {
         "project": dest_proj,
         "folder": dest_path,
@@ -3069,7 +3063,6 @@ def run_body(args, executable, dest_proj, dest_path, preset_inputs=None, input_n
         "rank": args.rank,
         "max_tree_spot_wait_time": normalize_timedelta(args.max_tree_spot_wait_time)//1000 if args.max_tree_spot_wait_time else None,
         "max_job_spot_wait_time": normalize_timedelta(args.max_job_spot_wait_time)//1000 if args.max_job_spot_wait_time else None,
-        "preserve_job_outputs": preserve_job_outputs,
         "extra_args": args.extra_args
     }
 
@@ -5277,20 +5270,6 @@ parser_run.add_argument('--cost-limit', help=fill("Maximum cost of the job befor
 parser_run.add_argument('-r', '--rank', type=int, help=fill('Set the rank of the root execution, integer between -1024 and 1023. Requires executionRankEnabled license feature for the billTo. Default is 0.', width_adjustment=-24), default=None)
 parser_run.add_argument('--max-tree-spot-wait-time', help=fill('The amount of time allocated to each path in the root execution\'s tree to wait for Spot (in seconds, or use suffix s, m, h, d, w, M, y)', width_adjustment=-24))
 parser_run.add_argument('--max-job-spot-wait-time', help=fill('The amount of time allocated to each job in the root execution\'s tree to wait for Spot (in seconds, or use suffix s, m, h, d, w, M, y)', width_adjustment=-24))
-
-preserve_outputs = parser_run.add_mutually_exclusive_group()
-preserve_outputs.add_argument('--preserve-job-outputs', action='store_true',
-                              help=fill("Copy cloneable outputs of every non-reused job entering \"done\" state in this "
-                                        "root execution into the \"intermediateJobOutputs\" subfolder under the output "
-                                        "folder for the root execution.",
-                                        width_adjustment=-24))
-preserve_outputs.add_argument('--preserve-job-outputs-folder', metavar="JOB_OUTPUTS_FOLDER",
-                              help=fill("Copy cloneable outputs of every non-reused job entering \"done\" state in this "
-                                        "root execution to a folder in the project. JOB_OUTPUTS_FOLDER starting with '/' "
-                                        "refers to an absolute path within the project, otherwise, it refers to a subfolder "
-                                        "under root execution's output folder.",
-                                        width_adjustment=-24))
-
 parser_run.set_defaults(func=run, verbose=False, help=False, details=None,
                         stage_instance_types=None, stage_folders=None, head_job_on_demand=None)
 register_parser(parser_run, categories='exec')

--- a/src/python/dxpy/utils/describe.py
+++ b/src/python/dxpy/utils/describe.py
@@ -780,7 +780,7 @@ def print_execution_desc(desc):
                          'startedRunning', 'stoppedRunning', 'stateTransitions',
                          'delayWorkspaceDestruction', 'stages', 'totalPrice', 'isFree', 'invoiceMetadata',
                          'priority', 'sshHostKey', 'internetUsageIPs', 'spotWaitTime', 'maxTreeSpotWaitTime',
-                         'maxJobSpotWaitTime', 'spotCostSavings', 'preserveJobOutputs']
+                         'maxJobSpotWaitTime', 'spotCostSavings']
 
     print_field("ID", desc["id"])
     print_field("Class", desc["class"])
@@ -849,7 +849,6 @@ def print_execution_desc(desc):
     print_nofill_field("Output", get_io_field(desc["output"]))
     if 'folder' in desc:
         print_field('Output folder', desc['folder'])
-    print_field('Preserve Job Outputs Folder', desc['preserveJobOutputs']['folder'] if desc.get('preserveJobOutputs') and 'folder' in desc['preserveJobOutputs'] else '-')
     print_field("Launched by", desc["launchedBy"][5:])
     print_field("Created", render_timestamp(desc['created']))
     if 'startedRunning' in desc:


### PR DESCRIPTION
For the time being the feature is not yet fully ready on backend side and it should be temporarily reverted from dx-toolkit.

This reverts commit 99ae98f325ba50490cb90b2d0049927e3a5efaa2.