### PR TITLE
DEVEX-2165 Fix dx-app-wizard and tab completion on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 
 ## Unreleased
 
+### Changed
+
+* Tab completion in interactive executions now works with `libedit` bundled in MacOS and does not require externally installed GNU `readline`
+
+### Fixed
+
+* Tab completion in interactive execution of `dx-app-wizard`
+* `dx-app-wizard` script on Windows
+* Tab completion in interactive executions on Windows
+
 ## [344.0] - beta
 
 ### Changed

--- a/src/python/dxpy/cli/exec_io.py
+++ b/src/python/dxpy/cli/exec_io.py
@@ -677,7 +677,7 @@ class ExecutableInputs(object):
     def init_completer(self):
         try:
             import rlcompleter
-            readline.parse_and_bind("bind ^I rl_complete" if 'libedit' in readline.__doc__ else "tab: complete")
+            readline.parse_and_bind("bind ^I rl_complete" if "libedit" in (readline.__doc__ or "") else "tab: complete")
 
             readline.set_completer_delims("")
 

--- a/src/python/dxpy/cli/exec_io.py
+++ b/src/python/dxpy/cli/exec_io.py
@@ -22,7 +22,7 @@ from __future__ import print_function, unicode_literals, division, absolute_impo
 
 # TODO: refactor all dx run helper functions here
 
-import os, sys, json, collections, pipes, platform
+import os, sys, json, collections, pipes
 from ..bindings.dxworkflow import DXWorkflow
 
 import dxpy

--- a/src/python/dxpy/cli/exec_io.py
+++ b/src/python/dxpy/cli/exec_io.py
@@ -34,15 +34,11 @@ from ..utils.resolver import (parse_input_keyval, is_hashid, is_job_id, is_local
                               resolve_existing_path, resolve_multiple_existing_paths, split_unescaped, is_analysis_id)
 from ..utils import OrderedDefaultdict
 from ..compat import input, str, shlex, basestring, USING_PYTHON2
-# Import pyreadline3 on Windows with Python >= 3.5
-if platform.system() == 'Windows' and  sys.version_info >= (3, 5):
-    import pyreadline3 as readline
-else:
-    try:
-        # Import gnureadline if installed for macOS
-        import gnureadline as readline
-    except ImportError as e:
-        import readline
+try:
+    # Import gnureadline if installed for macOS
+    import gnureadline as readline
+except ImportError as e:
+    import readline
 ####################
 # -i Input Parsing #
 ####################
@@ -681,7 +677,7 @@ class ExecutableInputs(object):
     def init_completer(self):
         try:
             import rlcompleter
-            readline.parse_and_bind("tab: complete")
+            readline.parse_and_bind("bind ^I rl_complete" if 'libedit' in readline.__doc__ else "tab: complete")
 
             readline.set_completer_delims("")
 

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -97,15 +97,11 @@ if '_ARGCOMPLETE' not in os.environ:
         if 'TERM' in os.environ and os.environ['TERM'].startswith('xterm'):
             old_term_setting = os.environ['TERM']
             os.environ['TERM'] = 'vt100'
-        # Import pyreadline3 on Windows with Python >= 3.5
-        if platform.system() == 'Windows' and  sys.version_info >= (3, 5):
-            import pyreadline3 as readline
-        else:
-            try:
-                # Import gnureadline if installed for macOS
-                import gnureadline as readline
-            except ImportError as e:
-                import readline
+        try:
+            # Import gnureadline if installed for macOS
+            import gnureadline as readline
+        except ImportError as e:
+            import readline
         if old_term_setting:
             os.environ['TERM'] = old_term_setting
 

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -19,7 +19,7 @@
 
 from __future__ import print_function, unicode_literals, division, absolute_import
 
-import os, sys, datetime, getpass, collections, re, json, argparse, copy, hashlib, io, time, subprocess, glob, logging, functools, platform
+import os, sys, datetime, getpass, collections, re, json, argparse, copy, hashlib, io, time, subprocess, glob, logging, functools
 import shlex # respects quoted substrings when splitting
 
 import requests

--- a/src/python/dxpy/templating/utils.py
+++ b/src/python/dxpy/templating/utils.py
@@ -20,7 +20,7 @@ Miscellaneous utility classes and functions for the dx-app-wizard command-line t
 
 from __future__ import print_function, unicode_literals, division, absolute_import
 
-import os, sys, shutil, subprocess, re, json, platform
+import os, sys, shutil, subprocess, re, json
 import stat
 
 from ..utils.printing import (BOLD, DNANEXUS_LOGO, ENDC, fill)

--- a/src/python/dxpy/templating/utils.py
+++ b/src/python/dxpy/templating/utils.py
@@ -26,15 +26,11 @@ import stat
 from ..utils.printing import (BOLD, DNANEXUS_LOGO, ENDC, fill)
 from ..cli import prompt_for_yn
 from ..compat import input, open
-# Import pyreadline3 on Windows with Python >= 3.5
-if platform.system() == 'Windows' and  sys.version_info >= (3, 5):
-    import pyreadline3 as readline
-else:
-    try:
-        # Import gnureadline if installed for macOS
-        import gnureadline as readline
-    except ImportError as e:
-        import readline
+try:
+    # Import gnureadline if installed for macOS
+    import gnureadline as readline
+except ImportError as e:
+    import readline
 
 from . import python
 from . import bash
@@ -50,7 +46,7 @@ completer_state = {
 
 try:
     import rlcompleter
-    readline.parse_and_bind("tab: complete")
+    readline.parse_and_bind("bind ^I rl_complete" if 'libedit' in readline.__doc__ else "tab: complete")
     readline.set_completer_delims("")
     completer_state['available'] = True
 except ImportError:

--- a/src/python/dxpy/templating/utils.py
+++ b/src/python/dxpy/templating/utils.py
@@ -46,7 +46,7 @@ completer_state = {
 
 try:
     import rlcompleter
-    readline.parse_and_bind("bind ^I rl_complete" if 'libedit' in readline.__doc__ else "tab: complete")
+    readline.parse_and_bind("bind ^I rl_complete" if "libedit" in (readline.__doc__ or "") else "tab: complete")
     readline.set_completer_delims("")
     completer_state['available'] = True
 except ImportError:

--- a/src/python/dxpy/templating/utils.py
+++ b/src/python/dxpy/templating/utils.py
@@ -59,8 +59,8 @@ class Completer():
 
     def complete(self, text, state):
         if state == 0:
-            self.matches = filter(lambda choice: choice.startswith(text),
-                                  self.choices)
+            self.matches = list(filter(lambda choice: choice.startswith(text),
+                                  self.choices))
 
         if self.matches is not None and state < len(self.matches):
             return self.matches[state]


### PR DESCRIPTION
* Fixed `dx-app-wizard` script on Windows
* Fixed non-working tab completion in interactive executions on Windows
* Fixed tab completion in interactive execution of `dx-app-wizard` on all OSs
* In MacOS tab completion in interactive executions now works with `libedit` bundled in the OS and does not require externally installed GNU `readline`