### PR TITLE
Sciprod 1258 flat allele payload

### DIFF
--- a/src/python/dxpy/dx_extract_utils/retrieve_allele_schema.json
+++ b/src/python/dxpy/dx_extract_utils/retrieve_allele_schema.json
@@ -4,7 +4,7 @@
     "description": "A description of the allele JSON file",
     "type": "object",
     "additionalProperties": false,
-    "anyOf": [
+    "oneOf": [
         {
             "required": [
                 "location"

--- a/src/python/dxpy/dx_extract_utils/retrieve_annotation_schema.json
+++ b/src/python/dxpy/dx_extract_utils/retrieve_annotation_schema.json
@@ -43,6 +43,12 @@
             },
             "maxItems": 100
         },
+        "feature_id": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
         "consequences": {
             "type": "array",
             "items": {

--- a/src/python/dxpy/dx_extract_utils/turbo_filter.py
+++ b/src/python/dxpy/dx_extract_utils/turbo_filter.py
@@ -160,12 +160,12 @@ def GenerateAssayFilter(
     filters_dict = {}
     table = filter_type
 
-    location_aid_filter = None
     for key in full_input_dict.keys():
         # Location needs to be handled slightly differently
         if key == "location":
             location_list = full_input_dict["location"]
             location_aid_filter = LocationFilter(location_list)
+            filters_dict.update(location_aid_filter)
 
         else:
             if not (full_input_dict[key] == "*" or full_input_dict[key] == None):
@@ -178,19 +178,12 @@ def GenerateAssayFilter(
                         genome_reference,
                     )
                 )
-    final_filter_dict = {"assay_filters": {"name": name, "id": id, "compound": []}}
+    final_filter_dict = {"assay_filters": {"name": name, "id": id}}
 
     # Additional structure of the payload
-    final_filter_dict["assay_filters"]["compound"].append({"filters": filters_dict})
+    final_filter_dict["assay_filters"].update({"filters": filters_dict})
     # The general filters are related by "and"
-    final_filter_dict["assay_filters"]["compound"][0]["logic"] = "and"
-    # Add the location filter as a second part of the compound if it exists
-    if location_aid_filter:
-        final_filter_dict["assay_filters"]["compound"].append(
-            {"filters": location_aid_filter}
-        )
-        # The location filter is related to the general filters by "and"
-        final_filter_dict["assay_filters"]["logic"] = "and"
+    final_filter_dict["assay_filters"]["logic"] = "and"
 
     return final_filter_dict
 
@@ -245,6 +238,7 @@ def FinalPayload(
     for f in fields:
         field_names.append(list(f.keys())[0])
 
+    print(json.dumps(final_payload))
     return final_payload, field_names
 
 

--- a/src/python/test/CLIGAM_tests/test_payload.py
+++ b/src/python/test/CLIGAM_tests/test_payload.py
@@ -1,27 +1,19 @@
 # To be run within a docker container that the dxpy package has been build locally in
-import json
-from dxpy.dx_extract_utils.turbo_filter import FinalPayload
+# exucute with: python /dx-toolkit/src/python/test/CLIGAM_tests/test_payload.py
+import subprocess
+import argparse
 
-filter = "/dx-toolkit/src/python/test/CLIGAM_tests/test_input/unit_tests/allele_malformatted.json"
-output = "~/allele_malformatted_output.json"
-type = "allele"
-project_context = "project-FkyXg38071F1vGy2GyXyYYQB"
-name = "veo_demo_dataset_assay"
-id = "da6a4ffc-7571-4b2f-853d-445460a18396"
-ref_genome = "GRCh38.92"
-sql_flag = False
+parser = argparse.ArgumentParser()
+parser.add_argument("--sql", action="store_true")
+args = parser.parse_args()
 
+filter = "/dx-toolkit/src/python/test/CLIGAM_tests/test_input/single_filters/allele/allele_location.json"
+# output = "allele_rsid_output.json"
+dataset = "project-FkyXg38071F1vGy2GyXyYYQB:record-FyFPyz0071F54Zjb32vG82Gj"
 
-with open(filter, "r") as infile:
-    filter_dict = json.load(infile)
-full_payload = FinalPayload(
-    filter_dict, name, id, project_context, ref_genome, type, sql_flag
-)
+command = "dx extract_assay germline {} --retrieve-allele {} ".format(dataset, filter)
 
-print(full_payload)
+if args.sql:
+    command += " --sql"
 
-# Send payload to vizserver
-# response = requests.post("/viz-data/3.0/record-xxxx/raw", json=json.dumps(full_payload))
-
-# print("Status Code: {}".format(response.status_code))
-# print("Response JSON: {}".format(response.json()))
+process = subprocess.run(command, shell=True)

--- a/src/python/test/CLIGAM_tests/test_payload.py
+++ b/src/python/test/CLIGAM_tests/test_payload.py
@@ -7,11 +7,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--sql", action="store_true")
 args = parser.parse_args()
 
-filter = "/dx-toolkit/src/python/test/CLIGAM_tests/test_input/single_filters/allele/allele_location.json"
-# output = "allele_rsid_output.json"
+filter = "/dx-toolkit/src/python/test/CLIGAM_tests/test_input/unit_tests/annotation_full.json"
+output = "annotation_full.json"
 dataset = "project-FkyXg38071F1vGy2GyXyYYQB:record-FyFPyz0071F54Zjb32vG82Gj"
+filter_type = "annotation"
 
-command = "dx extract_assay germline {} --retrieve-allele {} ".format(dataset, filter)
+command = "dx extract_assay germline {} --retrieve-{} {} -o {}".format(
+    dataset, filter_type, filter, output
+)
 
 if args.sql:
     command += " --sql"


### PR DESCRIPTION
This PR removes the "compound" structure from the assay filter object, resulting in a flat filters structure.  All fields are related to each other by "and".  Modified allele input validation to prevent location and rsid being provided together.  This fixes the issue caused by location being provided alone and failing due to an empty fields object, as well as the issue caused by geno_bins only being present in the second part of a compound but not the first.