### PR TITLE
DEVEX-2240 Bump allowed cryptography dxpy dependency version to 40.0.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 
 ### Changed
 
+* Bump allowed cryptography dxpy dependency version to 40.0.x
 * Tab completion in interactive executions now works with `libedit` bundled in MacOS and does not require externally installed GNU `readline`
 
 ### Fixed

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -6,7 +6,7 @@ psutil>=5.9.3
 requests>=2.8.0,<=2.27.1
 cryptography==3.3.2; python_version < "3"
 cryptography==3.2.1; python_version > "3" and python_version < "3.6"
-cryptography>=3.4.2,<37; python_version > "3.5"
+cryptography>=3.4.2,<41; python_version > "3.5"
 gnureadline==8.0.0; sys_platform == "darwin" and python_version < "3.9" and platform_machine == "x86_64"
 pyreadline==2.1; sys_platform == "win32" and python_version < "3.5"
 pyreadline3==3.4.1; sys_platform == "win32" and python_version >= "3.5"


### PR DESCRIPTION
Closes #949.