### PR TITLE
DEVEX-2263 Fix ImportError in test_dxpy.py

### DIFF
--- a/src/python/requirements_test.txt
+++ b/src/python/requirements_test.txt
@@ -1,5 +1,5 @@
 pexpect==4.6
-pyopenssl==17.5.0
+pyopenssl==23.1.1
 mock==2.0.0
 pytest==4.6.9
 pytest-xdist==1.31.0

--- a/src/python/requirements_test.txt
+++ b/src/python/requirements_test.txt
@@ -1,5 +1,5 @@
 pexpect==4.6
-pyopenssl==23.1.1
+pyopenssl==22.1.0
 mock==2.0.0
 pytest==4.6.9
 pytest-xdist==1.31.0

--- a/src/python/requirements_test.txt
+++ b/src/python/requirements_test.txt
@@ -1,5 +1,4 @@
 pexpect==4.6
-pyopenssl==22.1.0
 mock==2.0.0
 pytest==4.6.9
 pytest-xdist==1.31.0

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -29,7 +29,6 @@ import re
 
 import requests
 from requests.packages.urllib3.exceptions import SSLError
-#import OpenSSL # Only used by test_ssl_options, which is currently disabled
 
 import dxpy
 import dxpy_testutil as testutil
@@ -2524,6 +2523,8 @@ class TestHTTPResponses(testutil.DXTestCaseCompat):
         self.assertTrue("CONTENT-type" in res.headers)
 
     @unittest.skip("skipping per DEVEX-2161")
+    # NOTE: Re-enabling this test may require adding a recent version of
+    # pyopenssl to requirements_test.txt - see DEVEX-2263 for details.
     def test_ssl_options(self):
         dxpy.DXHTTPRequest("/system/whoami", {}, verify=False)
         dxpy.DXHTTPRequest("/system/whoami", {}, verify=requests.certs.where())

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -29,7 +29,7 @@ import re
 
 import requests
 from requests.packages.urllib3.exceptions import SSLError
-import OpenSSL
+#import OpenSSL # Only used by test_ssl_options, which is currently disabled
 
 import dxpy
 import dxpy_testutil as testutil


### PR DESCRIPTION
Removing pyopenssl from requirements_test.txt for now, since it was only used by the disabled test `test_ssl_options` - and our pinned pyopenssl version was causing an import failure in test_dxpy.py.