### PR TITLE
Sciprod 1232 validate consequences and putative_impact

### DIFF
--- a/src/python/dxpy/dx_extract_utils/input_validation.py
+++ b/src/python/dxpy/dx_extract_utils/input_validation.py
@@ -85,44 +85,53 @@ def validateFilter(filter, filter_type, sql=False):
                         print(malformed_filter.format("location"))
                         exit(1)
     if filter_type == "annotation":
-        keys = filter.keys()
         # Check for required fields if sql flag is not given
         if not sql:
             if not (
-                ("allele_id" in filter.keys())
-                or ("gene_name" in filter.keys())
-                or ("gene_id" in filter.keys())
+                ("allele_id" in keys) or ("gene_name" in keys) or ("gene_id" in keys)
             ):
                 print(
                     "allele_id, gene_name, or gene_id is required in annotation_filters"
                 )
                 exit(1)
         # Ensure only one of the required fields is given
-        if "allele_id" in filter.keys():
-            if ("gene_name" in filter.keys()) or ("gene_id" in filter.keys()):
+        if "allele_id" in keys:
+            if ("gene_name" in keys) or ("gene_id" in keys):
                 print(
                     "Only one of allele_id, gene_name, and gene_id can be provided in an annotation filter"
                 )
                 exit(1)
-        elif "gene_id" in filter.keys():
-            if ("gene_name" in filter.keys()) or ("allele_id" in filter.keys()):
+        elif "gene_id" in keys:
+            if ("gene_name" in keys) or ("allele_id" in keys):
                 print(
                     "Only one of allele_id, gene_name, and gene_id can be provided in an annotation filter"
                 )
                 exit(1)
-        elif "gene_name" in filter.keys():
-            if ("gene_id" in filter.keys()) or ("allele_id" in filter.keys()):
+        elif "gene_name" in keys:
+            if ("gene_id" in keys) or ("allele_id" in keys):
                 print(
                     "Only one of allele_id, gene_name, and gene_id can be provided in an annotation filter"
                 )
                 exit(1)
+        # Consequences and putative impact cannot be provided without at least one of gene_id, gene_name, feature_id
+        if ("consequences" in keys) or ("putative_impact" in keys):
+            if (
+                ("gene_id" not in keys)
+                and ("gene_name" not in keys)
+                and ("feature_id" not in keys)
+            ):
+                print(
+                    "consequences and putative impact fields may not be specified without "
+                    + "at least one of gene_id, gene_name, or feature_id"
+                )
+                exit(1)
+
         # All annotation fields are lists of strings
         for key in keys:
             if not isListOfStrings(filter[key]):
                 print(malformed_filter.format(key))
                 exit(1)
     if filter_type == "genotype":
-        keys = filter.keys()
         # Check for required fields if sql flag is not given
         if not sql:
             if not "allele_id" in keys:

--- a/src/python/test/extract_assay_germline/test_input/malformed_json/annotation/consequences_no_required.json
+++ b/src/python/test/extract_assay_germline/test_input/malformed_json/annotation/consequences_no_required.json
@@ -1,0 +1,14 @@
+{
+    "allele_id": [
+        "18_47408_G_A"
+    ],
+    "consequences": [
+        "synonymous_variant"
+    ],
+    "hgvs_c": [
+        "c.1317C>T"
+    ],
+    "hgvs_p": [
+        "p.Ala439Ala"
+    ]
+}

--- a/src/python/test/extract_assay_germline/test_input/malformed_json/annotation/putative_no_required.json
+++ b/src/python/test/extract_assay_germline/test_input/malformed_json/annotation/putative_no_required.json
@@ -1,0 +1,14 @@
+{
+    "allele_id": [
+        "18_47408_G_A"
+    ],
+    "putative_impact": [
+        "LOW"
+    ],
+    "hgvs_c": [
+        "c.1317C>T"
+    ],
+    "hgvs_p": [
+        "p.Ala439Ala"
+    ]
+}

--- a/src/python/test/test_extract_assay.py
+++ b/src/python/test/test_extract_assay.py
@@ -273,7 +273,11 @@ class TestDXExtractAssay(unittest.TestCase):
                     filter = json.load(infile)
                     try:
                         ValidateJSON(filter, filter_type)
-                        print("Uh oh, malformed JSON passed detection")
+                        print(
+                            "Uh oh, malformed JSON passed detection, file is {}".format(
+                                file_path
+                            )
+                        )
                     except:
                         print("task failed succesfully")
 


### PR DESCRIPTION
Hi folks,
This PR addresses a gap in the input validation for the consequences and putative_impact fields in the annotation filters.  The spec specifies that these fields cannot be provided without at least one of gene_name, gene_id, or feature_id, which means there was an edge case where allele_id was provided with consequences or putative_impact, but none of the three mentioned above, and would fail to be blocked by input validation.  This change adds that validation, and also adds a test for each of the two fields