### PR TITLE
Sciprod 1277 python 27 compat

### DIFF
--- a/src/python/dxpy/cli/dataset_utilities.py
+++ b/src/python/dxpy/cli/dataset_utilities.py
@@ -40,7 +40,7 @@ from ..exceptions import (
     InvalidInput,
     InvalidState,
     ResourceNotFound,
-    default_expected_exceptions
+    default_expected_exceptions,
 )
 
 from ..dx_extract_utils.filter_to_payload import ValidateJSON, FinalPayload
@@ -487,19 +487,20 @@ def extract_assay_germline(args):
         else:
             if args.json_help:
                 print(
-                    "# Filters and respective definitions\n#\n#  allele_id: ID of an allele for which annotations should be returned. If multiple values are provided, annotations for any alleles that match one of the values specified will be listed. For example, [\"1_1000_A_T\", \"1_1010_C_T\"], will search for annotations of alleles which match either \"1_1000_A_T\" or \"\"1_1010_C_T\". String match is case insensitive.\n#  gene_name: Gene name of the annotation. A list of gene names whose annotations will be returned. If multiple values are provided, the conditional search will be, \"OR.\" For example, [\"BRCA2\", \"ASPM\"], will search for annotations which match either \"BRCA2\" or \"ASPM\". String match is case insensitive.\n#  gene_id: Ensembl gene ID (ENSG) of the annotation. If multiple values are provided, the conditional search will be, \"OR.\" For example, [\"ENSG00000302118\", \"ENSG00004000504\"], will search for annotations which match either \"ENSG00000302118\" or \"ENSG00004000504\". String match is case insensitive.\n#  feature_id: Ensembl feature id (ENST) where the range overlaps with the variant. Currently, only  coding transcript IDs are searched. If multiple values are provided, the conditional search will be, \"OR.\" For example, [\"ENST00000302118.5\", \"ENST00004000504.1\"], will search for annotations which match either \"ENST00000302118.5\" or \"ENST00004000504.1\". String match is case insensitive.\n#  consequences: Consequence as recorded in the annotation. If multiple values are provided, the conditional search will be, \"OR.\" For example, [\"5_prime_UTR_variant\", \"3_prime_UTR_variant\"], will search for annotations which match either \"5 prime UTR variant\" or \"3 prime UTR variant\". String match is case sensitive. For all supported consequences terms, please refer to snpeff: http://pcingola.github.io/SnpEff/se_inputoutput/#effect-prediction-details (Effect Seq. Ontology column). This filter cannot be specified by itself, and must be included with at least one of the following filters: \"gene_id\", \"gene_name\",or \"feature_id\".\n#  putative_impact: Putative impact as recorded in the annotation. Possible values are [ \"HIGH\", \"MODERATE\", \"LOW\", \"MODIFIER\"]. If multiple values are provided, the conditional search will be, \"OR.\" For example, [\"MODIFIER\", \"HIGH\"], will search for annotations which match either \"MODIFIER\" or \"HIGH\". String match is case insensitive. For all supported terms, please refer to snpeff: http://pcingola.github.io/SnpEff/se_inputoutput/#impact-prediction. This filter cannot be specified by itself, and must be included with at least one of the following filters: \"gene_id\", \"gene_name\", or \"transcript_id\".\n#  hgvs_c: HGVS (DNA) code of the annotation. If multiple values are provided, the conditional search will be, \"OR.\" For example, [\"c.-49A>G\", \"c.-20T>G\"], will search for annotations which match either \"c.-49A>G\" or \"c.-20T>G\". String match is case sensitive.\n#  hgvs_p: HGVS (Protein) code of the annotation. If multiple values are provided, the conditional search will be, \"OR.\" For example, [\"p.Gly2Asp\", \"p.Aps2Gly\"], will search for annotations which match either \"p.Gly2Asp\" or \"p.Aps2Gly\". String match is case sensitive.\n# JSON filter template for --retrieve-annotation\n{\n  \"allele_id\":[\"1_1000_A_T\",\"2_1000_G_C\"],\n  \"gene_name\": [\"BRCA2\"],\n  \"gene_id\": [\"ENST00000302118\"],\n  \"feature_id\": [\"ENST00000302118.5\"],\n  \"consequences\": [\"5 prime UTR variant\"],\n  \"putative_impact\": [\"MODIFIER\"],\n  \"hgvs_c\": [\"c.-49A>G\"],\n  \"hgvs_p\": [\"p.Gly2Asp\"]\n}"
+                    '# Filters and respective definitions\n#\n#  allele_id: ID of an allele for which annotations should be returned. If multiple values are provided, annotations for any alleles that match one of the values specified will be listed. For example, ["1_1000_A_T", "1_1010_C_T"], will search for annotations of alleles which match either "1_1000_A_T" or ""1_1010_C_T". String match is case insensitive.\n#  gene_name: Gene name of the annotation. A list of gene names whose annotations will be returned. If multiple values are provided, the conditional search will be, "OR." For example, ["BRCA2", "ASPM"], will search for annotations which match either "BRCA2" or "ASPM". String match is case insensitive.\n#  gene_id: Ensembl gene ID (ENSG) of the annotation. If multiple values are provided, the conditional search will be, "OR." For example, ["ENSG00000302118", "ENSG00004000504"], will search for annotations which match either "ENSG00000302118" or "ENSG00004000504". String match is case insensitive.\n#  feature_id: Ensembl feature id (ENST) where the range overlaps with the variant. Currently, only  coding transcript IDs are searched. If multiple values are provided, the conditional search will be, "OR." For example, ["ENST00000302118.5", "ENST00004000504.1"], will search for annotations which match either "ENST00000302118.5" or "ENST00004000504.1". String match is case insensitive.\n#  consequences: Consequence as recorded in the annotation. If multiple values are provided, the conditional search will be, "OR." For example, ["5_prime_UTR_variant", "3_prime_UTR_variant"], will search for annotations which match either "5 prime UTR variant" or "3 prime UTR variant". String match is case sensitive. For all supported consequences terms, please refer to snpeff: http://pcingola.github.io/SnpEff/se_inputoutput/#effect-prediction-details (Effect Seq. Ontology column). This filter cannot be specified by itself, and must be included with at least one of the following filters: "gene_id", "gene_name",or "feature_id".\n#  putative_impact: Putative impact as recorded in the annotation. Possible values are [ "HIGH", "MODERATE", "LOW", "MODIFIER"]. If multiple values are provided, the conditional search will be, "OR." For example, ["MODIFIER", "HIGH"], will search for annotations which match either "MODIFIER" or "HIGH". String match is case insensitive. For all supported terms, please refer to snpeff: http://pcingola.github.io/SnpEff/se_inputoutput/#impact-prediction. This filter cannot be specified by itself, and must be included with at least one of the following filters: "gene_id", "gene_name", or "transcript_id".\n#  hgvs_c: HGVS (DNA) code of the annotation. If multiple values are provided, the conditional search will be, "OR." For example, ["c.-49A>G", "c.-20T>G"], will search for annotations which match either "c.-49A>G" or "c.-20T>G". String match is case sensitive.\n#  hgvs_p: HGVS (Protein) code of the annotation. If multiple values are provided, the conditional search will be, "OR." For example, ["p.Gly2Asp", "p.Aps2Gly"], will search for annotations which match either "p.Gly2Asp" or "p.Aps2Gly". String match is case sensitive.\n# JSON filter template for --retrieve-annotation\n{\n  "allele_id":["1_1000_A_T","2_1000_G_C"],\n  "gene_name": ["BRCA2"],\n  "gene_id": ["ENST00000302118"],\n  "feature_id": ["ENST00000302118.5"],\n  "consequences": ["5 prime UTR variant"],\n  "putative_impact": ["MODIFIER"],\n  "hgvs_c": ["c.-49A>G"],\n  "hgvs_p": ["p.Gly2Asp"]\n}'
                 )
                 sys.exit(0)
     elif "--retrieve-genotype" in args_list:
         if args.json_help:
             print(
-                "# Filters and respective definitions\n#  allele_id: ID(s) of one or more alleles for which sample genotypes will be returned. If multiple values are provided, any samples having at least one allele that match any of the values specified will be listed. For example, [\"1_1000_A_T\", \"1_1010_C_T\"], will search for samples with at least one allele matching either \"1_1000_A_T\" or \"1_1010_C_T\". String match is case insensitive.\n#  sample_id: Optional, one or more sample IDs for which sample genotypes will be returned. If the provided object is a cohort, this further intersects the sample ids. If a user has a list of samples more than 1,000, it is recommended to use a cohort id containing all the samples.\n#  genotype_type: Optional, one or more genotype types for which sample genotype types will be returned. One of: hom-alt (homozygous for the non-ref allele), het-ref (heterozygous with a ref allele and alt allele), het-alt (heterozygous with two distinct alt alleles), half (only one alt allele is known, second allele is unknown).\n# JSON filter template for --retrieve-genotype\n{\n  \"sample_id\": [\"s1\", \"s2\"],\n  \"allele_id\": [\"1_1000_A_T\",\"2_1000_G_C\"],\n  \"genotype_type\": [\"het-ref\", \"hom-alt\"]\n}")
+                '# Filters and respective definitions\n#  allele_id: ID(s) of one or more alleles for which sample genotypes will be returned. If multiple values are provided, any samples having at least one allele that match any of the values specified will be listed. For example, ["1_1000_A_T", "1_1010_C_T"], will search for samples with at least one allele matching either "1_1000_A_T" or "1_1010_C_T". String match is case insensitive.\n#  sample_id: Optional, one or more sample IDs for which sample genotypes will be returned. If the provided object is a cohort, this further intersects the sample ids. If a user has a list of samples more than 1,000, it is recommended to use a cohort id containing all the samples.\n#  genotype_type: Optional, one or more genotype types for which sample genotype types will be returned. One of: hom-alt (homozygous for the non-ref allele), het-ref (heterozygous with a ref allele and alt allele), het-alt (heterozygous with two distinct alt alleles), half (only one alt allele is known, second allele is unknown).\n# JSON filter template for --retrieve-genotype\n{\n  "sample_id": ["s1", "s2"],\n  "allele_id": ["1_1000_A_T","2_1000_G_C"],\n  "genotype_type": ["het-ref", "hom-alt"]\n}'
+            )
             sys.exit(0)
 
     #### Validate json filters ####
     def json_validation_function(filter_type, args_list, args):
         filter_arg = "args.retrieve_" + filter_type
-        filter_value = eval(filter_arg)
+        filter_value = str(eval(filter_arg))
         filter = {}
         if filter_value.endswith(".json"):
             if os.path.isfile(filter_value):
@@ -515,8 +516,10 @@ def extract_assay_germline(args):
                         filter = json.load(json_file)
                         json_file.close()
                     except Exception as json_error:
-                        err_exit("JSON for variant filters is malformatted.",
-                                 expected_exceptions=default_expected_exceptions)
+                        err_exit(
+                            "JSON for variant filters is malformatted.",
+                            expected_exceptions=default_expected_exceptions,
+                        )
             else:
                 err_exit(
                     "JSON file {filter_json} provided does not exist".format(
@@ -541,9 +544,11 @@ def extract_assay_germline(args):
                 try:
                     filter = json.loads(filter_value)
                 except Exception as json_error:
-                    err_exit("JSON for variant filters is malformatted.",
-                             expected_exceptions=default_expected_exceptions)
-        
+                    err_exit(
+                        "JSON for variant filters is malformatted.",
+                        expected_exceptions=default_expected_exceptions,
+                    )
+
         ValidateJSON(filter, filter_type)
 
         return filter

--- a/src/python/dxpy/cli/dataset_utilities.py
+++ b/src/python/dxpy/cli/dataset_utilities.py
@@ -775,7 +775,7 @@ def csv_from_json(
 
     csv_writer = csv.DictWriter(
         fields_output,
-        delimiter=sep,
+        delimiter=str(sep),
         doublequote=True,
         escapechar=None,
         lineterminator="\n",

--- a/src/python/dxpy/dx_extract_utils/input_validation.py
+++ b/src/python/dxpy/dx_extract_utils/input_validation.py
@@ -3,6 +3,8 @@ import sys
 
 # Generic error messages
 malformed_filter = "found following invalid filters: {}"
+# An integer equel to 2 if script is run with python2, and 3 if run with python3
+python_version = sys.version_info.major
 
 
 def isListOfStrings(object):
@@ -10,8 +12,12 @@ def isListOfStrings(object):
         return False
     for item in object:
         # Note that in python 2.7 these strings are read in as unicode
-        if not isinstance(str(item), str):
-            return False
+        if python_version == 2:
+            if not isinstance(str(item), str):
+                return False
+        else:
+            if not isinstance(item, str):
+                return False
     return True
 
 
@@ -75,17 +81,22 @@ def validateFilter(filter, filter_type):
                 indiv_loc_keys = indiv_location.keys()
                 # Ensure all keys are there
                 if not (
-                    (str("chromosome") in indiv_loc_keys)
-                    and (str("starting_position") in indiv_loc_keys)
-                    and (str("ending_position") in indiv_loc_keys)
+                    ("chromosome" in indiv_loc_keys)
+                    and ("starting_position" in indiv_loc_keys)
+                    and ("ending_position" in indiv_loc_keys)
                 ):
                     print(malformed_filter.format("location"))
                     exit(1)
                 # Check that each key is a string
                 for val in indiv_location.values():
-                    if not (isinstance(str(val), str)):
-                        print(malformed_filter.format("location"))
-                        exit(1)
+                    if python_version == 2:
+                        if not (isinstance(str(val), str)):
+                            print(malformed_filter.format("location"))
+                            exit(1)
+                    else:
+                        if not (isinstance(val, str)):
+                            print(malformed_filter.format("location"))
+                            exit(1)
     if filter_type == "annotation":
         keys = filter.keys()
         if not (

--- a/src/python/dxpy/dx_extract_utils/input_validation.py
+++ b/src/python/dxpy/dx_extract_utils/input_validation.py
@@ -13,7 +13,7 @@ def isListOfStrings(object):
     for item in object:
         # Note that in python 2.7 these strings are read in as unicode
         if python_version == 2:
-            if not isinstance(str(item), str):
+            if not (isinstance(item, str) or isinstance(item,unicode)):
                 return False
         else:
             if not isinstance(item, str):
@@ -90,7 +90,7 @@ def validateFilter(filter, filter_type):
                 # Check that each key is a string
                 for val in indiv_location.values():
                     if python_version == 2:
-                        if not (isinstance(str(val), str)):
+                        if not (isinstance(val, str) or isinstance(val,unicode)):
                             print(malformed_filter.format("location"))
                             exit(1)
                     else:

--- a/src/python/dxpy/dx_extract_utils/input_validation.py
+++ b/src/python/dxpy/dx_extract_utils/input_validation.py
@@ -1,4 +1,5 @@
 import json
+import sys
 
 # Generic error messages
 malformed_filter = "found following invalid filters: {}"
@@ -8,7 +9,8 @@ def isListOfStrings(object):
     if not isinstance(object, list):
         return False
     for item in object:
-        if not isinstance(item, str):
+        # Note that in python 2.7 these strings are read in as unicode
+        if not isinstance(str(item), str):
             return False
     return True
 
@@ -40,6 +42,7 @@ def validateFilter(filter, filter_type):
                 if item not in ["SNP", "Ins", "Del", "Mixed"]:
                     print(malformed_filter.format("type"))
                     exit(1)
+
         # Check dataset_alt_af
         if "dataset_alt_af" in keys:
             min_val = filter["dataset_alt_af"]["min"]
@@ -72,15 +75,15 @@ def validateFilter(filter, filter_type):
                 indiv_loc_keys = indiv_location.keys()
                 # Ensure all keys are there
                 if not (
-                    ("chromosome" in indiv_loc_keys)
-                    and ("starting_position" in indiv_loc_keys)
-                    and ("ending_position" in indiv_loc_keys)
+                    (str("chromosome") in indiv_loc_keys)
+                    and (str("starting_position") in indiv_loc_keys)
+                    and (str("ending_position") in indiv_loc_keys)
                 ):
                     print(malformed_filter.format("location"))
                     exit(1)
                 # Check that each key is a string
                 for val in indiv_location.values():
-                    if not (isinstance(val, str)):
+                    if not (isinstance(str(val), str)):
                         print(malformed_filter.format("location"))
                         exit(1)
     if filter_type == "annotation":

--- a/src/python/test/test_extract_assay.py
+++ b/src/python/test/test_extract_assay.py
@@ -310,7 +310,7 @@ class TestDXExtractAssay(unittest.TestCase):
                         os.path.join(filter_dir, filter_name),
                         os.path.join(output_folder, output_filename)
                         if write_output
-                        else "- > /dev/null",
+                        else "-",
                     )
                 )
                 process = subprocess.check_call(command, shell=True)
@@ -333,7 +333,7 @@ class TestDXExtractAssay(unittest.TestCase):
                     test_record,
                     filter_type,
                     filter_file,
-                    output_filename if write_output else "- > /dev/null",
+                    output_filename if write_output else "-",
                 )
             )
             process = subprocess.check_call(command, shell=True)
@@ -349,11 +349,11 @@ class TestDXExtractAssay(unittest.TestCase):
                 output_folder, "{}_full_sql_output.tsv".format(filter_type)
             )
 
-            command = "dx extract_assay germline {} --retrieve-{} {} --output {} --sql".format(
+            command = "dx extract_assay germline {} --retrieve-{} {} --sql --output {}".format(
                 test_record,
                 filter_type,
                 filter_file,
-                output_filename if write_output else "- > /dev/null",
+                output_filename if write_output else "-",
             )
             process = subprocess.check_call(command, shell=True)
 
@@ -367,7 +367,7 @@ class TestDXExtractAssay(unittest.TestCase):
             test_record,
             "allele",
             filter_file,
-            output_filename if write_output else "- > /dev/null",
+            output_filename if write_output else "-",
         )
         process = subprocess.check_call(command, shell=True)
 
@@ -387,7 +387,7 @@ class TestDXExtractAssay(unittest.TestCase):
         command = "dx extract_assay germline {} --assay-name test01_assay --retrieve-allele {} --output {}".format(
             test_record,
             os.path.join(single_filter_directory, "allele/allele_rsid.json"),
-            output_filename if write_output else "- > /dev/null",
+            output_filename if write_output else "-",
         )
         subprocess.check_call(command, stderr=subprocess.STDOUT, shell=True)
 

--- a/src/python/test/test_extract_assay.py
+++ b/src/python/test/test_extract_assay.py
@@ -26,6 +26,7 @@ import dxpy
 import os
 import subprocess
 import json
+import sys
 
 from dxpy_testutil import cd, chdir
 from dxpy.dx_extract_utils.filter_to_payload import (
@@ -36,6 +37,11 @@ from dxpy.dx_extract_utils.filter_to_payload import (
     FinalPayload,
     ValidateJSON,
 )
+
+python_version = sys.version_info.major
+# TODO remove
+working_dir = os.getcwd()
+print("executing directory: {}".format(working_dir))
 
 test_project = "dx-toolkit_test_data"
 test_record = "{}:Extract_Assay_Germline/test01_dataset".format(test_project)

--- a/src/python/test/test_extract_assay.py
+++ b/src/python/test/test_extract_assay.py
@@ -40,8 +40,11 @@ test_project = "dx-toolkit_test_data"
 test_record = "{}:Extract_Assay_Germline/test01_dataset".format(test_project)
 test_filter_directory = "/dx-toolkit/src/python/test/extract_assay_germline/test_input/"
 output_folder = "/dx-toolkit/src/python/test/extract_assay_germline/test_output/"
-if not os.path.exists(output_folder):
-    os.makedirs(output_folder)
+# Controls whether output files for the end to end tests are written to file or stdout
+write_output = False
+if write_output:
+    if not os.path.exists(output_folder):
+        os.makedirs(output_folder)
 
 
 class TestDXExtractAssay(unittest.TestCase):
@@ -305,7 +308,9 @@ class TestDXExtractAssay(unittest.TestCase):
                         test_record,
                         filter_type,
                         os.path.join(filter_dir, filter_name),
-                        os.path.join(output_folder, output_filename),
+                        os.path.join(output_folder, output_filename)
+                        if write_output
+                        else "- > /dev/null",
                     )
                 )
                 process = subprocess.check_call(command, shell=True)
@@ -328,7 +333,7 @@ class TestDXExtractAssay(unittest.TestCase):
                     test_record,
                     filter_type,
                     filter_file,
-                    output_filename,
+                    output_filename if write_output else "- > /dev/null",
                 )
             )
             process = subprocess.check_call(command, shell=True)
@@ -348,7 +353,7 @@ class TestDXExtractAssay(unittest.TestCase):
                 test_record,
                 filter_type,
                 filter_file,
-                output_filename,
+                output_filename if write_output else "- > /dev/null",
             )
             process = subprocess.check_call(command, shell=True)
 
@@ -362,7 +367,7 @@ class TestDXExtractAssay(unittest.TestCase):
             test_record,
             "allele",
             filter_file,
-            output_filename,
+            output_filename if write_output else "- > /dev/null",
         )
         process = subprocess.check_call(command, shell=True)
 
@@ -382,7 +387,7 @@ class TestDXExtractAssay(unittest.TestCase):
         command = "dx extract_assay germline {} --assay-name test01_assay --retrieve-allele {} --output {}".format(
             test_record,
             os.path.join(single_filter_directory, "allele/allele_rsid.json"),
-            output_filename,
+            output_filename if write_output else "- > /dev/null",
         )
         subprocess.check_call(command, stderr=subprocess.STDOUT, shell=True)
 

--- a/src/python/test/test_extract_assay.py
+++ b/src/python/test/test_extract_assay.py
@@ -36,7 +36,8 @@ from dxpy.dx_extract_utils.filter_to_payload import (
     ValidateJSON,
 )
 
-test_record = "project-G9j1pX00vGPzF2XQ7843k2Jq:record-GQGF8x80qYFQxv7gz49ZP7Y7"
+test_project = "dx-toolkit_test_data"
+test_record = "{}:Extract_Assay_Germline/test01_dataset".format(test_project)
 test_filter_directory = "/dx-toolkit/src/python/test/extract_assay_germline/test_input/"
 output_folder = "/dx-toolkit/src/python/test/extract_assay_germline/test_output/"
 if not os.path.exists(output_folder):

--- a/src/python/test/test_extract_assay.py
+++ b/src/python/test/test_extract_assay.py
@@ -39,6 +39,8 @@ from dxpy.dx_extract_utils.filter_to_payload import (
 test_record = "project-G9j1pX00vGPzF2XQ7843k2Jq:record-GQGF8x80qYFQxv7gz49ZP7Y7"
 test_filter_directory = "/dx-toolkit/src/python/test/extract_assay_germline/test_input/"
 output_folder = "/dx-toolkit/src/python/test/extract_assay_germline/test_output/"
+if not os.path.exists(output_folder):
+    os.makedirs(output_folder)
 
 
 class TestDXExtractAssay(unittest.TestCase):

--- a/src/python/test/test_extract_assay.py
+++ b/src/python/test/test_extract_assay.py
@@ -43,12 +43,15 @@ python_version = sys.version_info.major
 working_dir = os.getcwd()
 print("executing directory: {}".format(working_dir))
 
+dirname = os.path.dirname(__file__)
+
 test_project = "dx-toolkit_test_data"
 test_record = "{}:Extract_Assay_Germline/test01_dataset".format(test_project)
-test_filter_directory = "./src/python/test/extract_assay_germline/test_input/"
-output_folder = "./src/python/test/extract_assay_germline/test_output/"
-malformed_json_dir = (
-    "./src/python/test/extract_assay_germline/test_input/malformed_json"
+
+test_filter_directory = os.path.join(dirname, "extract_assay_germline/test_input/")
+output_folder = os.path.join(dirname, "extract_assay_germline/test_output/")
+malformed_json_dir = os.path.join(
+    dirname, "extract_assay_germline/test_input/malformed_json"
 )
 
 # Controls whether output files for the end to end tests are written to file or stdout

--- a/src/python/test/test_extract_assay.py
+++ b/src/python/test/test_extract_assay.py
@@ -26,7 +26,7 @@ import dxpy
 import os
 import subprocess
 import json
-import sys
+
 from dxpy_testutil import cd, chdir
 from dxpy.dx_extract_utils.filter_to_payload import (
     retrieve_geno_bins,
@@ -37,21 +37,14 @@ from dxpy.dx_extract_utils.filter_to_payload import (
     ValidateJSON,
 )
 
-python_version = sys.version_info.major
 test_project = "dx-toolkit_test_data"
 test_record = "{}:Extract_Assay_Germline/test01_dataset".format(test_project)
-if python_version == 3:
-    test_filter_directory = (
-        "/dx-toolkit/src/python/test/extract_assay_germline/test_input/"
-    )
-    output_folder = "/dx-toolkit/src/python/test/extract_assay_germline/test_output/"
-else:
-    test_filter_directory = (
-        "/hostdir/dx-toolkit/src/python/test/extract_assay_germline/test_input/"
-    )
-    output_folder = (
-        "/hostdir/dx-toolkit/src/python/test/extract_assay_germline/test_output/"
-    )
+test_filter_directory = "./src/python/test/extract_assay_germline/test_input/"
+output_folder = "./src/python/test/extract_assay_germline/test_output/"
+malformed_json_dir = (
+    "./src/python/test/extract_assay_germline/test_input/malformed_json"
+)
+
 # Controls whether output files for the end to end tests are written to file or stdout
 write_output = False
 if write_output:
@@ -280,7 +273,6 @@ class TestDXExtractAssay(unittest.TestCase):
         ValidateJSON(filter, type)
 
     def test_malformed_json(self):
-        malformed_json_dir = "/dx-toolkit/src/python/test/extract_assay_germline/test_input/malformed_json"
         for filter_type in ["allele", "annotation", "genotype"]:
             malformed_json_filenames = os.listdir(
                 os.path.join(malformed_json_dir, filter_type)
@@ -322,7 +314,7 @@ class TestDXExtractAssay(unittest.TestCase):
                         os.path.join(filter_dir, filter_name),
                         os.path.join(output_folder, output_filename)
                         if write_output
-                        else "-",
+                        else "- > /dev/null",
                     )
                 )
                 process = subprocess.check_call(command, shell=True)
@@ -345,7 +337,7 @@ class TestDXExtractAssay(unittest.TestCase):
                     test_record,
                     filter_type,
                     filter_file,
-                    output_filename if write_output else "-",
+                    output_filename if write_output else "- > /dev/null",
                 )
             )
             process = subprocess.check_call(command, shell=True)
@@ -365,7 +357,7 @@ class TestDXExtractAssay(unittest.TestCase):
                 test_record,
                 filter_type,
                 filter_file,
-                output_filename if write_output else "-",
+                output_filename if write_output else "- > /dev/null",
             )
             process = subprocess.check_call(command, shell=True)
 
@@ -379,7 +371,7 @@ class TestDXExtractAssay(unittest.TestCase):
             test_record,
             "allele",
             filter_file,
-            output_filename if write_output else "-",
+            output_filename if write_output else "- > /dev/null",
         )
         process = subprocess.check_call(command, shell=True)
 
@@ -399,7 +391,7 @@ class TestDXExtractAssay(unittest.TestCase):
         command = "dx extract_assay germline {} --assay-name test01_assay --retrieve-allele {} --output {}".format(
             test_record,
             os.path.join(single_filter_directory, "allele/allele_rsid.json"),
-            output_filename if write_output else "-",
+            output_filename if write_output else "- > /dev/null",
         )
         subprocess.check_call(command, stderr=subprocess.STDOUT, shell=True)
 

--- a/src/python/test/test_extract_assay.py
+++ b/src/python/test/test_extract_assay.py
@@ -26,6 +26,7 @@ import dxpy
 import os
 import subprocess
 import json
+import sys
 from dxpy_testutil import cd, chdir
 from dxpy.dx_extract_utils.filter_to_payload import (
     retrieve_geno_bins,
@@ -36,10 +37,21 @@ from dxpy.dx_extract_utils.filter_to_payload import (
     ValidateJSON,
 )
 
+python_version = sys.version_info.major
 test_project = "dx-toolkit_test_data"
 test_record = "{}:Extract_Assay_Germline/test01_dataset".format(test_project)
-test_filter_directory = "/dx-toolkit/src/python/test/extract_assay_germline/test_input/"
-output_folder = "/dx-toolkit/src/python/test/extract_assay_germline/test_output/"
+if python_version == 3:
+    test_filter_directory = (
+        "/dx-toolkit/src/python/test/extract_assay_germline/test_input/"
+    )
+    output_folder = "/dx-toolkit/src/python/test/extract_assay_germline/test_output/"
+else:
+    test_filter_directory = (
+        "/hostdir/dx-toolkit/src/python/test/extract_assay_germline/test_input/"
+    )
+    output_folder = (
+        "/hostdir/dx-toolkit/src/python/test/extract_assay_germline/test_output/"
+    )
 # Controls whether output files for the end to end tests are written to file or stdout
 write_output = False
 if write_output:


### PR DESCRIPTION
Hi Folks,
This PR fixes issues with python 2.7 compatibility that we discovered during testing.  Essentially, python 2 has a unicode type that is distinct from the string type, so some type checks were failing in python 2 because isinstance(<unicode string>,str) returns false in python 2.  The code now checks if the python major version is 2 or 3, and in the case where it is 2, checks if the object is either a string or unicode object