### PR TITLE
DEVEX-2307: add-project-new-external-upload-flag

### DIFF
--- a/src/python/dxpy/bindings/dxproject.py
+++ b/src/python/dxpy/bindings/dxproject.py
@@ -284,6 +284,7 @@ class DXProject(DXContainer):
     def new(self, name, summary=None, description=None, region=None, protected=None,
             restricted=None, download_restricted=None, contains_phi=None,
             tags=None, properties=None, bill_to=None, database_ui_view_only=None,
+            external_upload_restricted=None,
             **kwargs):
         """
         :param name: The name of the project
@@ -310,6 +311,8 @@ class DXProject(DXContainer):
         :type bill_to: string
         :param database_ui_view_only: If provided, whether the viewers on the project can access the database data directly
         :type database_ui_view_only: boolean
+        :param external_upload_restricted: If provided, whether project members can upload data to project from external sources, e.g. outside of job
+        :type external_upload_restricted: boolean
 
         Creates a new project. Initially only the user performing this action
         will be in the permissions/member list, with ADMINISTER access.
@@ -338,6 +341,8 @@ class DXProject(DXContainer):
             input_hash["billTo"] = bill_to
         if database_ui_view_only is not None:
             input_hash["databaseUIViewOnly"] = database_ui_view_only
+        if external_upload_restricted is not None:
+            input_hash["externalUploadRestricted"] = external_upload_restricted
         if tags is not None:
             input_hash["tags"] = tags
         if properties is not None:
@@ -350,7 +355,7 @@ class DXProject(DXContainer):
     def update(self, name=None, summary=None, description=None, protected=None,
                restricted=None, download_restricted=None, version=None,
                allowed_executables=None, unset_allowed_executables=None,
-               database_ui_view_only=None, **kwargs):
+               database_ui_view_only=None, external_upload_restricted=None, **kwargs):
         """
         :param name: If provided, the new project name
         :type name: string
@@ -368,6 +373,8 @@ class DXProject(DXContainer):
         :type allowed_executables: list
         :param database_ui_view_only: If provided, whether the viewers on the project can access the database data directly
         :type database_ui_view_only: boolean
+        :param external_upload_restricted: If provided, whether project members can upload data to project from external sources, e.g. outside of job
+        :type external_upload_restricted: boolean
         :param version: If provided, the update will only occur if the value matches the current project's version number
         :type version: int
 
@@ -399,6 +406,8 @@ class DXProject(DXContainer):
             update_hash["allowedExecutables"] = None
         if database_ui_view_only is not None:
             update_hash["databaseUIViewOnly"] = database_ui_view_only
+        if external_upload_restricted is not None:
+            update_hash["externalUploadRestricted"] = external_upload_restricted
         dxpy.api.project_update(self._dxid, update_hash, **kwargs)
 
     def invite(self, invitee, level, send_email=True, **kwargs):

--- a/src/python/dxpy/utils/describe.py
+++ b/src/python/dxpy/utils/describe.py
@@ -411,7 +411,8 @@ def print_project_desc(desc, verbose=False):
         'id', 'class', 'name', 'summary', 'description', 'protected', 'restricted', 'created', 'modified',
         'dataUsage', 'sponsoredDataUsage', 'tags', 'level', 'folders', 'objects', 'permissions', 'properties',
         'appCaches', 'billTo', 'version', 'createdBy', 'totalSponsoredEgressBytes', 'consumedSponsoredEgressBytes',
-        'containsPHI', 'databaseUIViewOnly', 'region', 'storageCost', 'pendingTransfer','atSpendingLimit',
+        'containsPHI', 'databaseUIViewOnly', 'externalUploadRestricted', 'region', 'storageCost', 'pendingTransfer',
+        'atSpendingLimit',
         # Following are app container-specific
         'destroyAt', 'project', 'type', 'app', 'appName'
     ]
@@ -446,7 +447,9 @@ def print_project_desc(desc, verbose=False):
     if 'containsPHI' in desc:
         print_json_field('Contains PHI', desc['containsPHI'])
     if 'databaseUIViewOnly' in desc and desc['databaseUIViewOnly']:
-        print_json_field('Database UI View Only', desc['databaseUIViewOnly'])
+        print_json_field('External Upload Restricted', desc['databaseUIViewOnly'])
+    if 'externalUploadRestricted' in desc and desc['externalUploadRestricted']:
+        print_json_field('E', desc['externalUploadRestricted'])
 
     # Usage
     print_field("Created", render_timestamp(desc['created']))

--- a/src/python/dxpy/utils/describe.py
+++ b/src/python/dxpy/utils/describe.py
@@ -447,9 +447,9 @@ def print_project_desc(desc, verbose=False):
     if 'containsPHI' in desc:
         print_json_field('Contains PHI', desc['containsPHI'])
     if 'databaseUIViewOnly' in desc and desc['databaseUIViewOnly']:
-        print_json_field('External Upload Restricted', desc['databaseUIViewOnly'])
+        print_json_field('Database UI View Only', desc['databaseUIViewOnly'])
     if 'externalUploadRestricted' in desc and desc['externalUploadRestricted']:
-        print_json_field('E', desc['externalUploadRestricted'])
+        print_json_field('External Upload Restricted', desc['externalUploadRestricted'])
 
     # Usage
     print_field("Created", render_timestamp(desc['created']))

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -137,6 +137,7 @@ class TestDXProject(unittest.TestCase):
             self.assertEqual(desc["downloadRestricted"], False)
             self.assertEqual(desc["containsPHI"], False)
             self.assertEqual(desc["databaseUIViewOnly"], False)
+            self.assertEqual(desc["externalUploadRestricted"], False)
             self.assertEqual(desc["tags"], [])
             prop = dxpy.api.project_describe(dxproject.get_id(),
                                              {'fields': {'properties': True}})
@@ -189,6 +190,7 @@ class TestDXProject(unittest.TestCase):
                          protected=True,
                          restricted=True,
                          download_restricted=True,
+                         external_upload_restricted=False,
                          allowed_executables=["applet-abcdefghijklmnopqrstuzwx"],
                          description="new description")
         desc = dxproject.describe()
@@ -198,6 +200,7 @@ class TestDXProject(unittest.TestCase):
         self.assertEqual(desc["protected"], True)
         self.assertEqual(desc["restricted"], True)
         self.assertEqual(desc["downloadRestricted"], True)
+        self.assertEqual(desc["externalUploadRestricted"], False)
         self.assertEqual(desc["description"], "new description")
         self.assertEqual(desc["allowedExecutables"][0], "applet-abcdefghijklmnopqrstuzwx")
         self.assertTrue("created" in desc)


### PR DESCRIPTION
DEVEX-2307
APPS-1462

* added support for externalUploadRestricted to DXProject.new(), .update()
* added it among recognized fields
* extended existing tests with this parameter