### PR TITLE
forcing quotechar to be interpeted as a string by python 2

### DIFF
--- a/src/python/dxpy/cli/dataset_utilities.py
+++ b/src/python/dxpy/cli/dataset_utilities.py
@@ -487,8 +487,8 @@ def extract_assay_germline(args):
                 if os.stat(filter_value).st_size == 0:
                     err_exit(
                         'No filter given for --retrieve-{filter_type} or JSON for "--retrieve-{filter_type}" does not contain valid filter information.'.format(
-                        filter_type=filter_type
-                    )
+                            filter_type=filter_type
+                        )
                     )
                 else:
                     with open(filter_value, "r") as json_file:
@@ -698,7 +698,7 @@ def extract_assay_germline(args):
                 sep="\t",
                 raw_results=resp_raw["results"],
                 column_names=fields_list,
-                quote_char="|",
+                quote_char=str("|"),
             )
 
 


### PR DESCRIPTION
Hi Folks,
This change forces the python2 interpreter to interpret the quotechar in the csv_from_json function to be interpreted as a str type and not as unicode.  I tested both python2 and python3 and all unit tests pass.
More details in the ticket description [here](https://jira.internal.dnanexus.com/browse/SCIPROD-1413)
