### PR TITLE
SCIPROD-1334 Update somatic assay meta info query and output

### DIFF
--- a/src/python/dxpy/cli/dataset_utilities.py
+++ b/src/python/dxpy/cli/dataset_utilities.py
@@ -478,13 +478,15 @@ def json_validation_function(filter_type, args):
         validate_somatic_filter(filter, filter_type)
 
     return filter
-    
+   
+
 def retrieve_meta_info(resp, project_id, assay_id, assay_name, print_to_stdout, out_file_name):
-    table, column = "vcf_meta_information_unique", "info_format_fields"
+    table = "vcf_meta_information_unique"
+    columns = ["Field", "ID", "Type", "Number", "Description"]
     payload = {
         "project_context": project_id,
         "fields": [
-            {column: "$".join((table, column))},
+            {column: "$".join((table, column))} for column in columns
         ],
         "is_cohort": False,
         "variant_browser": {
@@ -494,16 +496,14 @@ def retrieve_meta_info(resp, project_id, assay_id, assay_name, print_to_stdout, 
     }
     resp_raw = raw_api_call(resp, payload, sql_message=False)
 
-    if print_to_stdout:
-        fields_output = sys.stdout
-    else:
-        fields_output = open(out_file_name, "w")
+    csv_from_json(
+        out_file_name=out_file_name,
+        print_to_stdout=print_to_stdout,
+        sep="\t",
+        raw_results=resp_raw["results"],
+        column_names=columns,
+    )
 
-    for entry in resp_raw["results"]:
-        fields_output.write(entry[column] + '\n')
-
-    if not print_to_stdout:
-        fields_output.close()
 
 def assign_output_method(args, record_name, friendly_assay_type):
     #### Decide output method based on --output and --sql ####


### PR DESCRIPTION
The `vcf_meta_information_unique` table and descriptor no longer have the `info_format_fields` column used to extract the meta information. It has been replaced by `Field, ID, Type, Number, Description`. The `extract_assay somatic --retrieve-meta-info` option has been updated around the table changes.
- `vcf_meta_information_unique` `Field, ID, Type, Number, Description` columns are used to query the meta information.
- Meta information is output as a tab-delimited table.