### PR TITLE
SCIPROD-1522 extract_assay somatic --retrieve-variant output fix

### DIFF
--- a/src/python/dxpy/cli/dataset_utilities.py
+++ b/src/python/dxpy/cli/dataset_utilities.py
@@ -1045,6 +1045,7 @@ def extract_assay_somatic(args):
                 sep="\t",
                 raw_results=resp_raw["results"],
                 column_names=fields_list,
+                quote_char=str("\t"),
                 quoting=csv.QUOTE_NONE,
             )
 

--- a/src/python/dxpy/cli/dataset_utilities.py
+++ b/src/python/dxpy/cli/dataset_utilities.py
@@ -1045,7 +1045,6 @@ def extract_assay_somatic(args):
                 sep="\t",
                 raw_results=resp_raw["results"],
                 column_names=fields_list,
-                quote_char=str(""),
                 quoting=csv.QUOTE_NONE,
             )
 


### PR DESCRIPTION
`extract_assay somatic --retrieve-variant` fails in Python 3.11. Removed empty quotechar string parameter value.