### PR TITLE
APPS-2076 add default fields to dx describe analysis json verbose

### DIFF
--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -1283,6 +1283,9 @@ def describe(args):
             if len(entity_results) > 0:
                 found_match = True
             for result in entity_results:
+                if is_analysis_id(result['id']) and args.verbose:
+                    default_analysis_desc = dxpy.DXAnalysis(result['id']).describe()
+                    result['describe'].update(default_analysis_desc)
                 if args.json:
                     json_output.append(result['describe'])
                 elif args.name:

--- a/src/python/dxpy/utils/describe.py
+++ b/src/python/dxpy/utils/describe.py
@@ -819,10 +819,6 @@ def print_execution_desc(desc, verbose=False):
         print_field("Try", str(desc['try']))
     print_field("Class", desc["class"])
 
-    if desc['class'] == 'analysis' and verbose:
-        default_analysis_desc = dxpy.DXAnalysis(desc['id']).describe()
-        desc.update(default_analysis_desc)
-
     if "name" in desc and desc['name'] is not None:
         print_field("Job name", desc['name'])
     if "executableName" in desc and desc['executableName'] is not None:

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -2353,8 +2353,11 @@ class TestDXClientDescribe(DXTestCaseBuildWorkflows):
         analysis_desc_json = run("dx describe {} --json".format(dxanalysis.get_id()))
         analysis_desc_verbose_json = run("dx describe {} --verbose --json".format(dxanalysis.get_id()))
         self.assertTrue(all(key in analysis_desc_verbose for key in ["Run Sys Reqs", "Run Sys Reqs by Exec", "Merged Sys Reqs By Exec", "Run Stage Sys Reqs"]))
+        self.assertTrue(all(key in analysis_desc_verbose for key in ["ID", "Job name", "Executable name", "Class", "Workspace", "Project context"]))
         self.assertFalse(any(key in json.loads(analysis_desc_json) for key in ['runSystemRequirements', 'runSystemRequirementsByExecutable', 'mergedSystemRequirementsByExecutable', 'runStageSystemRequirements']))
+        self.assertTrue(all(key in json.loads(analysis_desc_json) for key in ['id','name','executable','class','workspace','project']))
         self.assertTrue(all(key in json.loads(analysis_desc_verbose_json) for key in ['runSystemRequirements', 'runSystemRequirementsByExecutable', 'mergedSystemRequirementsByExecutable', 'runStageSystemRequirements']))
+        self.assertTrue(all(key in json.loads(analysis_desc_verbose_json) for key in ['id','name','executable','class','workspace','project']))
 
     @unittest.skipUnless(testutil.TEST_RUN_JOBS,
                          'skipping test that would run jobs')


### PR DESCRIPTION
This PR is to amend the workaround for PTFM-35818 added in [pull/1007](https://github.com/dnanexus/dx-toolkit/pull/1007) 
With changes in this PR, when doing `dx describe analysis --json --verbose`, default description fields will also be included along with the newly added fields related to system requirements, same as when doing `dx describe analysis --verbose`