### PR TITLE
SCIPROD-1583 Logic added to create_cohort to validate cohort ids via vizserver search

### DIFF
--- a/src/python/dxpy/cli/dataset_utilities.py
+++ b/src/python/dxpy/cli/dataset_utilities.py
@@ -1127,7 +1127,10 @@ def create_cohort(args):
 
     # Compare the discovered cohort ids to the user-provided cohort ids
     if discovered_samples != set(samples):
-        err_exit("cohort ids provided in input do not match cohort ids found in dataset")
+        # Find which given samples are not present in the dataset
+        missing_samples = set(samples).difference(discovered_samples)
+        err_msg = "The following supplied IDs do not match IDs in the main entity of dataset, {dataset_name}: {ids}".format(dataset_name = from_project,ids = missing_samples)
+        err_exit(err_msg)
     # Input cohort IDs have been succesfully validated    
 
 

--- a/src/python/dxpy/cli/dataset_utilities.py
+++ b/src/python/dxpy/cli/dataset_utilities.py
@@ -1063,6 +1063,46 @@ def resolve_validate_dx_path(path):
     
     return project, folder, name
 
+def validate_cohort_ids(descriptor,project,resp,ids):
+    # Usually the name of the table
+    entity_name = descriptor.model["global_primary_key"]["entity"]
+    # The name of the column or field in the table
+    field_name = descriptor.model["global_primary_key"]["field"] 
+
+    # Prepare a payload to find entries matching the input ids in the dataset
+    table_column_name = "{}${}".format(entity_name, field_name)
+    fields_list = [{field_name: table_column_name}]
+    
+    # Note that pheno filters do not need name or id fields
+    payload = {
+        "project_context": project,
+        "fields": fields_list,
+        "raw_filters": {
+            "pheno_filters": {
+                "filters": {
+                    table_column_name: [
+                        {"condition": "in", "values": ids}
+                    ]
+                }
+            }
+        },
+    }
+
+    # Use the dxpy raw_api_function to send a POST request to the server with our payload
+    resp_raw = raw_api_call(resp, payload)
+    # Order of samples doesn't matter so using set here
+    discovered_samples = set()
+    # Parse the results objects for the cohort ids
+    for result in resp_raw["results"]:
+        discovered_samples.add(result[field_name])
+
+    # Compare the discovered cohort ids to the user-provided cohort ids
+    if discovered_samples != set(ids):
+        # Find which given samples are not present in the dataset
+        missing_samples = set(ids).difference(discovered_samples)
+        err_msg = "The following supplied IDs do not match IDs in the main entity of dataset, {dataset_name}: {ids}".format(dataset_name = from_project,ids = missing_samples)
+        err_exit(err_msg)
+
 def create_cohort(args): 
     """
     Create a cohort from dataset/cohort and specified list of samples. 
@@ -1092,49 +1132,10 @@ def create_cohort(args):
     
     #### Validate the input cohort IDs ####
     # Get the table/entity and field/column of the dataset from the descriptor
-    rec_descriptor = DXDataset(entity_result["id"], project=from_project).get_descriptor()
+    rec_descriptor = DXDataset(entity_result["id"], project=dataset_project).get_descriptor()
 
-    # Usually the name of the table
-    entity_name = rec_descriptor.model["global_primary_key"]["entity"]
-    # The name of the column or field in the table
-    field_name = rec_descriptor.model["global_primary_key"]["field"] 
-
-    # Prepare a payload to find entries matching the input ids in the dataset
-    table_column_name = "{}${}".format(entity_name, field_name)
-    fields_list = [{field_name: table_column_name}]
-    
-    # Note that pheno filters do not need name or id fields
-    payload = {
-        "project_context": from_project,
-        "fields": fields_list,
-        "raw_filters": {
-            "pheno_filters": {
-                "filters": {
-                    table_column_name: [
-                        {"condition": "in", "values": samples}
-                    ]
-                }
-            }
-        },
-    }
-
-    # Use the dxpy raw_api_function to send a POST request to the server with our payload
-    resp_raw = raw_api_call(resp, payload)
-    # Order of samples doesn't matter so using set here
-    discovered_samples = set()
-    # Parse the results objects for the cohort ids
-    for result in resp_raw["results"]:
-        discovered_samples.add(result[field_name])
-
-    # Compare the discovered cohort ids to the user-provided cohort ids
-    if discovered_samples != set(samples):
-        # Find which given samples are not present in the dataset
-        missing_samples = set(samples).difference(discovered_samples)
-        err_msg = "The following supplied IDs do not match IDs in the main entity of dataset, {dataset_name}: {ids}".format(dataset_name = from_project,ids = missing_samples)
-        err_exit(err_msg)
+    validate_cohort_ids(rec_descriptor,dataset_project,resp,samples)
     # Input cohort IDs have been succesfully validated    
-
-   
 
 
 class DXDataset(DXRecord):

--- a/src/python/dxpy/cli/dataset_utilities.py
+++ b/src/python/dxpy/cli/dataset_utilities.py
@@ -1083,8 +1083,9 @@ def create_cohort(args):
     samples=[]
     # from file
     if args.cohort_ids_file:
-        for line in args.cohort_ids_file:
-            samples.append(line)
+        with open(args.cohort_ids_file,"r") as infile:
+            for line in infile:
+                samples.append(line)
     # from string
     if args.cohort_ids:
         samples = args.cohort_ids.split(",")
@@ -1132,13 +1133,6 @@ def create_cohort(args):
         err_msg = "The following supplied IDs do not match IDs in the main entity of dataset, {dataset_name}: {ids}".format(dataset_name = from_project,ids = missing_samples)
         err_exit(err_msg)
     # Input cohort IDs have been succesfully validated    
-
-
-
-
-
-
-
 
    
 

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -6620,7 +6620,7 @@ parser_create_cohort.add_argument('PATH', type=str, help='DNAnexus path for the 
 parser_create_cohort.add_argument('--from', type=str, help='v3.0 Dataset or Cohort object ID, project-id:record-id, where ":record-id" indicates the record-id in current selected project, or name')
 parser_create_c_mutex_group = parser_create_cohort.add_mutually_exclusive_group(required=True)
 parser_create_c_mutex_group.add_argument('--cohort-ids', type=str, help='A set of IDs used to subset the Dataset or Cohort object as a comma-separated string. IDs must match identically in the supplied Dataset. Ifa Cohort is supplied instead of a Dataset, the intersection of supplied and existing cohort IDs will be used to create the new cohort.')
-parser_create_c_mutex_group.add_argument('--cohort-ids-file', type=argparse.FileType('r'), help='A set of IDs used to subset the Dataset or Cohort object in a file with one ID per line and no header. IDs must match identically in the supplied Dataset. If a Cohort is supplied instead of a Dataset, the intersection of supplied and existing cohort IDs will be used to create the new cohort.')
+parser_create_c_mutex_group.add_argument('--cohort-ids-file', type=str, help='A set of IDs used to subset the Dataset or Cohort object in a file with one ID per line and no header. IDs must match identically in the supplied Dataset. If a Cohort is supplied instead of a Dataset, the intersection of supplied and existing cohort IDs will be used to create the new cohort.')
 parser_create_cohort.add_argument('-h','--help', help='Return the docstring and exit', action='help')
 
 parser_create_cohort.set_defaults(func=create_cohort)


### PR DESCRIPTION
Hi Folks,
This PR adds validation of the input cohort ids.  It finds the main entity of the dataset (generally referred to as the cohort ID because the main entity and field can be different for different types of dataset) and creates a vizserver payload to search the dataset for entries with matching cohort IDs, returning the discovered cohort IDs.  If the user has provided ids that are not found in the dataset, an error message is displayed specifying which IDs were not found.