### PR TITLE
SCIPROD-1602 creating test for cohort query api

### DIFF
--- a/src/python/test/test_create_cohort.py
+++ b/src/python/test/test_create_cohort.py
@@ -35,6 +35,7 @@ from dxpy.cli.dataset_utilities import (
     get_assay_name_info,
     resolve_validate_record_path,
     DXDataset,
+    cohort_query_api_call
 )
 
 
@@ -60,7 +61,7 @@ class TestCreateCohort(unittest.TestCase):
         cls.test_record_geno = "{}:/Create_Cohort/create_cohort_geno_dataset".format(proj_name)
         cls.test_record_pheno = "{}:/Create_Cohort/create_cohort_pheno_dataset".format(proj_name)
         with open(
-            os.path.join(cls.general_input_dir, "usage_message.txt"), "r"
+            os.path.join(dirname,"create_cohort_test_files", "usage_message.txt"), "r"
         ) as infile:
             cls.usage_message = infile.read()
 
@@ -305,7 +306,46 @@ class TestCreateCohort(unittest.TestCase):
         # removing all whitespace before comparing
         self.assertEqual("".join(expected_error_message.split()), "".join(err_msg.split()))
 
-    
+    # EM-11 The vizserver returns an error when attempting to validate cohort IDs
+    def test_vizserver_error(self):
+        pass
+
+    def test_cohort_query_api(self):
+        test_payload = {
+            "filters": {
+                "pheno_filters": {
+                    "compound": [
+                        {
+                            "name": "phenotype",
+                            "logic": "and",
+                            "filters": {
+                                "patient$patient_id": [
+                                    {
+                                        "condition": "in",
+                                        "values": [
+                                            "patient_1",
+                                            "patient_2",
+                                            "patient_3"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "logic": "and"
+                },
+                "logic": "and"
+            },
+            "project_context": "project-G9j1pX00vGPzF2XQ7843k2Jq"
+        }
+
+        expected_results = "SELECT `patient_1`.`patient_id` AS `patient_id` FROM `database_gyk2yg00vgppzj7ygy3vjxb9__create_cohort_pheno_database`.`patient` AS `patient_1` WHERE `patient_1`.`patient_id` IN ('patient_1', 'patient_2', 'patient_3');"
+
+        from_project, entity_result, resp, dataset_project = resolve_validate_record_path(self.test_record_pheno)
+        sql = cohort_query_api_call(resp, test_payload)
+        self.assertEqual(expected_results,sql)
+
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi Folks,
This is a quick test of the resolve_validate_record_path function.  It compares the returned sql to an expected output.  It would be able to detect if there is any change to that output caused by anything merged in the future.  It isn't an exhaustive test of all possible configurations of the payload, however.