### PR TITLE
SCIPROD-1585: [CLIBCO] error for non-and logic on primary entity and field

### DIFF
--- a/src/python/dxpy/cli/dataset_utilities.py
+++ b/src/python/dxpy/cli/dataset_utilities.py
@@ -1212,7 +1212,10 @@ def create_cohort(args):
     entity = rec_descriptor.model["global_primary_key"]["entity"]
     field = rec_descriptor.model["global_primary_key"]["field"]
     filters = resp.get("filters", {})
-    payload = cohort_final_payload(samples, entity, field, filters, from_project)
+    try:
+        payload = cohort_final_payload(samples, entity, field, filters, from_project)
+    except Exception as e:
+        err_exit("{}: {}".format(entity_result["id"], e))
     sql = cohort_query_api_call(resp, payload)
 
     ### temporary

--- a/src/python/dxpy/dx_extract_utils/cohort_filter_payload.py
+++ b/src/python/dxpy/dx_extract_utils/cohort_filter_payload.py
@@ -56,7 +56,7 @@ def generate_pheno_filter(values, entity, field, filters):
             if other_entity_field.split("$")[0] != entity:
                 continue
             if "logic" in compound_filter and compound_filter["logic"] != "and":
-                raise ValueError("Invalid input cohort. Cohorts must have “and” logic on the primary entity and field.")
+                continue
             # Filter with the entity is valid for addition of field filter
             compound_filter["filters"][entity_field] = [entity_field_filter]
             return filters

--- a/src/python/dxpy/dx_extract_utils/cohort_filter_payload.py
+++ b/src/python/dxpy/dx_extract_utils/cohort_filter_payload.py
@@ -20,8 +20,7 @@ def generate_pheno_filter(values, entity, field, filters):
         # entity field values cannot be selected by adding a filter to the
         # existing compound pheno_filter. Move the existing pheno_filter into a
         # new pheno_filter level compound filter.
-        print("WARNING: pheno_filter compound filter logic is not \"and\", creating a nested compound filter."
-              " The Cohort Browser may not work as expected with this cohort.")
+        raise ValueError("Invalid input cohort. Cohorts must have “and” logic on the primary entity and field.")
         filters["pheno_filters"] = {"compound": [filters["pheno_filters"]], "logic": "and"}
 
     entity_field = "$".join([entity, field])
@@ -29,46 +28,40 @@ def generate_pheno_filter(values, entity, field, filters):
 
     # Search for an existing filter for the entity and field
     for compound_filter in filters["pheno_filters"]["compound"]:
-        try:
-            if "logic" in compound_filter and compound_filter["logic"] != "and":
-                # The entity field filter does not have "and" logic so fall though
-                print("WARNING: found filter for entity \"{}\", field \"{}\" but logic is not \"and\","
-                      " skipping".format(entity, field))
-            else:
-                # The entity field filter is valid for addition of the "in" values condition
-                compound_filter["filters"][entity_field].append(entity_field_filter)
-                return filters
-        except KeyError:
-            pass
+        if "filters" not in compound_filter or entity_field not in compound_filter["filters"]:
+            continue
+        if "logic" in compound_filter and compound_filter["logic"] != "and":
+            raise ValueError("Invalid input cohort. Cohorts must have “and” logic on the primary entity and field.")
+        # The entity field filter is valid for addition of the "in" values condition
+        compound_filter["filters"][entity_field].append(entity_field_filter)
+        return filters
 
     # Search for an existing filter with the entity since no entity and field filter was found
     for compound_filter in filters["pheno_filters"]["compound"]:
         if "entity" not in compound_filter or "name" not in compound_filter["entity"]:
             continue
-        if compound_filter["entity"]["name"] == entity:
-            if "logic" in compound_filter and compound_filter["logic"] != "and":
-                # The entity filter does not have "and" logic so fall though
-                print("WARNING: found filter for entity \"{}\" but logic is not \"and\", skipping".format(entity))
-            else:
-                # The entity filter is valid for addition of field filter
-                compound_filter["filters"][entity_field] = [entity_field_filter]
-                return filters
+        if compound_filter["entity"]["name"] != entity:
+            continue
+        if "logic" in compound_filter and compound_filter["logic"] != "and":
+            raise ValueError("Invalid input cohort. Cohorts must have “and” logic on the primary entity and field.")
+        # The entity filter is valid for addition of field filter
+        compound_filter["filters"][entity_field] = [entity_field_filter]
+        return filters
 
     # Search for an existing filter with the entity in a filter with a different field since no entity was found
     for compound_filter in filters["pheno_filters"]["compound"]:
         if "filters" not in compound_filter:
             continue
         for other_entity_field in compound_filter["filters"]:
-            if other_entity_field.split("$")[0] == entity:
-                if "logic" in compound_filter and compound_filter["logic"] != "and":
-                    # The filter with entity does not have "and" logic so fall though
-                    print("WARNING: found filter with entity \"{}\" but logic is not \"and\", skipping".format(entity))
-                else:
-                    # Filter with the entity is valid for addition of field filter
-                    compound_filter["filters"][entity_field] = [entity_field_filter]
-                    return filters
+            if other_entity_field.split("$")[0] != entity:
+                continue
+            if "logic" in compound_filter and compound_filter["logic"] != "and":
+                raise ValueError("Invalid input cohort. Cohorts must have “and” logic on the primary entity and field.")
+            # Filter with the entity is valid for addition of field filter
+            compound_filter["filters"][entity_field] = [entity_field_filter]
+            return filters
 
-    # No existing filters for the entity were foudn so create the entity filter
+    # No existing filters for the entity were found so create the entity filter
     filters["pheno_filters"]["compound"].append({
         "name": "phenotype",
         "logic": "and",
@@ -82,7 +75,7 @@ def generate_pheno_filter(values, entity, field, filters):
 
 def cohort_final_payload(values, entity, field, filters, project_context):
     if "logic" in filters and filters["logic"] != "and":
-        raise NotImplementedError("cannot filter cohort when top-level logic is not \"and\"")
+        raise ValueError("Invalid input cohort. Cohorts must have “and” logic on the primary entity and field.")
     final_payload = {}
     final_payload["project_context"] = project_context
     final_payload["filters"] = generate_pheno_filter(values, entity, field, filters)

--- a/src/python/dxpy/dx_extract_utils/cohort_filter_payload.py
+++ b/src/python/dxpy/dx_extract_utils/cohort_filter_payload.py
@@ -21,7 +21,6 @@ def generate_pheno_filter(values, entity, field, filters):
         # existing compound pheno_filter. Move the existing pheno_filter into a
         # new pheno_filter level compound filter.
         raise ValueError("Invalid input cohort. Cohorts must have “and” logic on the primary entity and field.")
-        filters["pheno_filters"] = {"compound": [filters["pheno_filters"]], "logic": "and"}
 
     entity_field = "$".join([entity, field])
     entity_field_filter = {"condition": "in", "values": values}

--- a/src/python/dxpy/dx_extract_utils/cohort_filter_payload.py
+++ b/src/python/dxpy/dx_extract_utils/cohort_filter_payload.py
@@ -33,6 +33,15 @@ def generate_pheno_filter(values, entity, field, filters):
         if "logic" in compound_filter and compound_filter["logic"] != "and":
             raise ValueError("Invalid input cohort. Cohorts must have “and” logic on the primary entity and field.")
         # The entity field filter is valid for addition of the "in" values condition
+        # Add to an existing "in" condition if one exists for the entity and field
+        for condition in compound_filter["filters"][entity_field]:
+            if condition["condition"] == "in":
+                for value in values:
+                    if value in condition["values"]:
+                        continue
+                    condition["values"].append(value)
+                return filters
+        # Create a new "in" condition for the entity and field
         compound_filter["filters"][entity_field].append(entity_field_filter)
         return filters
 

--- a/src/python/dxpy/dx_extract_utils/cohort_filter_payload.py
+++ b/src/python/dxpy/dx_extract_utils/cohort_filter_payload.py
@@ -31,15 +31,6 @@ def generate_pheno_filter(values, entity, field, filters):
         if "logic" in compound_filter and compound_filter["logic"] != "and":
             raise ValueError("Invalid input cohort. Cohorts must have “and” logic on the primary entity and field.")
         # The entity field filter is valid for addition of the "in" values condition
-        # Add to an existing "in" condition if one exists for the entity and field
-        for condition in compound_filter["filters"][entity_field]:
-            if condition["condition"] == "in":
-                for value in values:
-                    if value in condition["values"]:
-                        continue
-                    condition["values"].append(value)
-                return filters
-        # Create a new "in" condition for the entity and field
         compound_filter["filters"][entity_field].append(entity_field_filter)
         return filters
 

--- a/src/python/dxpy/dx_extract_utils/cohort_filter_payload.py
+++ b/src/python/dxpy/dx_extract_utils/cohort_filter_payload.py
@@ -18,8 +18,7 @@ def generate_pheno_filter(values, entity, field, filters):
     elif "logic" in filters["pheno_filters"] and filters["pheno_filters"]["logic"] != "and":
         # pheno_filter is a compound filter, but the logic is not "and" so
         # entity field values cannot be selected by adding a filter to the
-        # existing compound pheno_filter. Move the existing pheno_filter into a
-        # new pheno_filter level compound filter.
+        # existing compound pheno_filter.
         raise ValueError("Invalid input cohort. Cohorts must have “and” logic on the primary entity and field.")
 
     entity_field = "$".join([entity, field])


### PR DESCRIPTION
Raise exception and exit with error when a cohort filter has primary entity and field logic that is not "and".