### PR TITLE
APPS-2138 parse container image ref

### DIFF
--- a/src/python/dxpy/nextflow/ImageRefParser.py
+++ b/src/python/dxpy/nextflow/ImageRefParser.py
@@ -73,7 +73,7 @@ class DxPathParser(ImageRefParser):
         self._parse()
 
     def _parse(self):
-        self.context_id, self.name = self._regex_matcher.group(2)
+        self.context_id = self.name = self._regex_matcher.group(2)
         extracted_path = self._regex_matcher.group(3)
         if self._file_id_regex.search(extracted_path):
             self.file_id = extracted_path
@@ -94,11 +94,11 @@ class DockerImageParser(ImageRefParser):
     def _parse(self):
         self.repository = self._regex_matcher.group(1)
         self.image = self._regex_matcher.group(2)
-        if self._regex_matcher.group(3).startsWith("@sha"):     # last match group is a digest
+        if self._regex_matcher.group(3).startswith("@sha"):     # last match group is a digest
             self.digest = self._regex_matcher.group(3)[1:]
             self.tag = ""
 
-        elif self._regex_matcher.group(3).startsWith(":"):      # last match group is a version tag
+        elif self._regex_matcher.group(3).startswith(":"):      # last match group is a version tag
             self.tag = self._regex_matcher.group(3)[1:]
             self.digest = ""
 

--- a/src/python/dxpy/nextflow/ImageRefParser.py
+++ b/src/python/dxpy/nextflow/ImageRefParser.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+
+import re
+
+class ImageRefParserFactoryError(Exception):
+    """
+    An exception class to handle image reference regex patterns
+    """
+
+
+class ImageRefParserFactory(object):
+    def __init__(self, image_ref):
+        """
+        :param image_ref: Image reference
+        :type image_ref: str
+        A factory class to determine which type of Image reference was used.
+        """
+        self._image_ref = image_ref
+        dx_prefix_scheme = "dx"
+        self._DX_URI_PATTERN = re.compile("^" + dx_prefix_scheme + "://(([^/]+):)?(.*)$")
+
+        # Pattern matching a docker image reference
+        # https://stackoverflow.com/questions/39671641/regex-to-parse-docker-tag with group modifications for regex below
+
+        repository_group = "((?:(?=[^:\\/]{1,253})(?!-)[a-zA-Z0-9-]{1,63}(?<!-)(?:\\.(?!-)[a-zA-Z0-9-]{1,63}(?<!-))*(?::[0-9]{1,5})?/)*)"
+        image_name_group = "((?![._-])(?:[a-z0-9._-]*)(?<![._-])(?:/(?![._-])[a-z0-9._-]*(?<![._-]))*)"
+        tag_or_digest_group = "((?::(?![.-])[a-zA-Z0-9_.-]{1,128})?|(?:@sha256:([0-9a-f]{64})$))"
+        self._DOCKER_IMAGE_PATTERN = re.compile("^" + repository_group + image_name_group + tag_or_digest_group + "$")
+
+        self._tokens = None
+
+    @property
+    def parse(self):
+        if not self._tokens:
+            self._tokens = self._get_tokens()
+        return  self._tokens
+
+    def _get_tokens(self):
+        dx_regex_matcher = self._DX_URI_PATTERN.search(self._image_ref)
+        docker_matcher = self._DOCKER_IMAGE_PATTERN.search(self._image_ref)
+        if dx_regex_matcher:
+            return DxPathParser(dx_regex_matcher)
+        elif docker_matcher:
+            return DockerImageParser(docker_matcher)
+        else:
+            raise ImageRefParserFactoryError(
+                "URI does not match the dx uri pattern, nor the docker image name pattern: {}".format(self._image_ref)
+            )
+
+
+
+class ImageRefParser(object):
+    def __init__(self, regex_matcher):
+        self._regex_matcher = regex_matcher
+
+    def _parse(self):
+        raise NotImplementedError("Abstract class. Method not implemented. Use the concrete implementations.")
+
+
+class DxPathParser(ImageRefParser):
+    def __init__(self, regex_matcher):
+        """
+        :param regex_matcher: regex match of a given image reference
+        :type regex_matcher: re.Pattern
+        A class to represent parts of a dx file path or file ID
+        """
+        super().__init__(regex_matcher)
+        self._file_id_regex = re.compile("file-[A-Za-z0-9]{24}")
+        self.name = None
+        self.context_id = None
+        self.file_path = None
+        self.file_id = None
+        self._parse()
+
+    def _parse(self):
+        self.context_id, self.name = self._regex_matcher.group(2)
+        extracted_path = self._regex_matcher.group(3)
+        if self._file_id_regex.search(extracted_path):
+            self.file_id = extracted_path
+        else:
+            self.file_path = extracted_path
+        return None
+
+
+class DockerImageParser(ImageRefParser):
+    def __init__(self, regex_matcher):
+        super().__init__(regex_matcher)
+        self.repository = None
+        self.image = None
+        self.tag = None
+        self.digest = None
+        self._parse()
+
+    def _parse(self):
+        self.repository = self._regex_matcher.group(1)
+        self.image = self._regex_matcher.group(2)
+        if self._regex_matcher.group(3).startsWith("@sha"):     # last match group is a digest
+            self.digest = self._regex_matcher.group(3)[1:]
+            self.tag = ""
+
+        elif self._regex_matcher.group(3).startsWith(":"):      # last match group is a version tag
+            self.tag = self._regex_matcher.group(3)[1:]
+            self.digest = ""
+
+        else:                                                   # last match group not present
+            self.digest = self._regex_matcher.group(3)
+            self.tag = self._regex_matcher.group(3)
+

--- a/src/python/test/test_nextflow_ImageRefParser.py
+++ b/src/python/test/test_nextflow_ImageRefParser.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2013-2016 DNAnexus, Inc.
+#
+# This file is part of dx-toolkit (DNAnexus platform client libraries).
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#   use this file except in compliance with the License. You may obtain a copy
+#   of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+from __future__ import print_function, unicode_literals, division, absolute_import
+
+import os
+
+from parameterized import parameterized
+from dxpy_testutil import DXTestCase
+from dxpy import DXFile
+from dxpy.compat import USING_PYTHON2
+from dxpy.nextflow.ImageRefParser import ImageRefParser, DxPathParser, ImageRefParserFactory
+
+if USING_PYTHON2:
+    spawn_extra_args = {}
+else:
+    # Python 3 requires specifying the encoding
+    spawn_extra_args = {"encoding": "utf-8"}
+
+
+class TestImageRefParser(DXTestCase):
+
+    # for dx path
+    fixture_1 = ['dx:///alpha/beta', None, None, '/alpha/beta']
+    fixture_2 = ['dx://project-123:/alpha/beta', 'project-123', 'project-123', '/alpha/beta']
+    fixture_3 = ['dx://project-123:alpha/beta', 'project-123', 'project-123', 'alpha/beta']
+    fixture_4 = ['dx://project-123:/', 'project-123', 'project-123', '/']
+    fixture_5 = ['dx://project-123:/some/path/*_{1,2}.fq', 'project-123', 'project-123', '/some/path/*_{1,2}.fq']
+    fixture_6 = ['dx://hola:/', 'hola', 'hola', '/']
+    fixture_7 = ['dx://hola:', 'hola', 'hola', '']
+    fixture_8 = ['dx://hola:', 'hola', 'hola', '']
+
+    # for docker image
+    fixture_9 = ['myregistryhost:5000/fedora/httpd:version1.0', 'myregistryhost:5000/fedora/', 'httpd', 'version1.0', '']
+    fixture_10 = ['fedora/httpd:version1.0-alpha', 'fedora/', 'httpd', 'version1.0-alpha', '']
+    fixture_11 = ['fedora/httpd:version1.0', 'fedora/', 'httpd', 'version1.0', '']
+    fixture_12 = ['rabbit:3', '', 'rabbit', '3', '']
+    fixture_13 = ['rabbit', '', 'rabbit', '', '']
+    fixture_14 = ['repository/rabbit:3', 'repository/', 'rabbit', '3', '']
+    fixture_15 = ['repository/rabbit', 'repository/', 'rabbit', '', '']
+    fixture_16 = ['rabbit@sha256:974219f34a18afde9517b27f3b81403c3a08f6908cbf8d7b717097b93b11583d', '', 'rabbit', '', 'sha256:974219f34a18afde9517b27f3b81403c3a08f6908cbf8d7b717097b93b11583d']
+    fixture_17 = ['repository/rabbit@sha256:974219f34a18afde9517b27f3b81403c3a08f6908cbf8d7b717097b93b11583d', 'repository/', 'rabbit', '', 'sha256:974219f34a18afde9517b27f3b81403c3a08f6908cbf8d7b717097b93b11583d']
+
+    @parameterized.expand([
+        fixture_1,
+        fixture_2,
+        fixture_3,
+        fixture_4,
+        fixture_5,
+        fixture_6,
+        fixture_7,
+        fixture_8
+    ])
+    def test_DxPathParser(self, image_ref, name, context_id, file_path):
+        dx_path_parser = ImageRefParserFactory.parse(image_ref)
+        self.assertTrue(isinstance(dx_path_parser, DxPathParser))
+        self.assertTrue(dx_path_parser.name == name)
+        self.assertTrue(dx_path_parser.context_id == context_id)
+        self.assertTrue(dx_path_parser.file_path == file_path)
+
+
+    @parameterized.expand([
+        fixture_7,
+        fixture_8,
+        fixture_9
+    ])
+    def test_bundled_depends(self, image_ref, expected_bundled_depends):
+        docker_image_ref = ImageRefParser(image_ref)
+        self.assertTrue(docker_image_ref.bundled_depends == expected_bundled_depends)
+
+    def test_cache(self):
+        docker_image_ref = ImageRefParser('busybox:1.36')
+        cached_file_id = docker_image_ref.cache()
+        self.assertTrue(cached_file_id.starts_with("file-"))
+        if cached_file_id:
+            dx_file = DXFile(cached_file_id)
+            dx_file.remove()
+

--- a/src/python/test/test_nextflow_ImageRefParser.py
+++ b/src/python/test/test_nextflow_ImageRefParser.py
@@ -24,7 +24,7 @@ from parameterized import parameterized
 from dxpy_testutil import DXTestCase
 from dxpy import DXFile
 from dxpy.compat import USING_PYTHON2
-from dxpy.nextflow.ImageRefParser import ImageRefParser, DxPathParser, ImageRefParserFactory
+from dxpy.nextflow.ImageRefParser import ImageRefParser, DxPathParser, DockerImageParser, ImageRefParserFactory
 
 if USING_PYTHON2:
     spawn_extra_args = {}
@@ -73,21 +73,21 @@ class TestImageRefParser(DXTestCase):
         self.assertTrue(dx_path_parser.context_id == context_id)
         self.assertTrue(dx_path_parser.file_path == file_path)
 
-
     @parameterized.expand([
-        fixture_7,
-        fixture_8,
-        fixture_9
+        fixture_9,
+        fixture_10,
+        fixture_11,
+        fixture_12,
+        fixture_13,
+        fixture_14,
+        fixture_15,
+        fixture_16,
+        fixture_17
     ])
-    def test_bundled_depends(self, image_ref, expected_bundled_depends):
-        docker_image_ref = ImageRefParser(image_ref)
-        self.assertTrue(docker_image_ref.bundled_depends == expected_bundled_depends)
-
-    def test_cache(self):
-        docker_image_ref = ImageRefParser('busybox:1.36')
-        cached_file_id = docker_image_ref.cache()
-        self.assertTrue(cached_file_id.starts_with("file-"))
-        if cached_file_id:
-            dx_file = DXFile(cached_file_id)
-            dx_file.remove()
-
+    def test_DockerImageParser(self, image_ref, repository, image, tag, digest):
+        dx_path_parser = ImageRefParserFactory.parse(image_ref)
+        self.assertTrue(isinstance(dx_path_parser, DockerImageParser))
+        self.assertTrue(dx_path_parser.repository == repository)
+        self.assertTrue(dx_path_parser.image == image)
+        self.assertTrue(dx_path_parser.tag == tag)
+        self.assertTrue(dx_path_parser.digest == digest)

--- a/src/python/test/test_nextflow_ImageRefParser.py
+++ b/src/python/test/test_nextflow_ImageRefParser.py
@@ -19,12 +19,13 @@
 from __future__ import print_function, unicode_literals, division, absolute_import
 
 import os
+import sys
+import unittest
 
 from parameterized import parameterized
 from dxpy_testutil import DXTestCase
-from dxpy import DXFile
 from dxpy.compat import USING_PYTHON2
-from dxpy.nextflow.ImageRefParser import ImageRefParser, DxPathParser, DockerImageParser, ImageRefParserFactory
+from dxpy.nextflow.ImageRefParser import DxPathParser, DockerImageParser, ImageRefParserFactory
 
 if USING_PYTHON2:
     spawn_extra_args = {}
@@ -35,61 +36,47 @@ else:
 
 class TestImageRefParser(DXTestCase):
 
-    # for dx path
-    fixture_1 = ['dx:///alpha/beta', None, None, '/alpha/beta']
-    fixture_2 = ['dx://project-123:/alpha/beta', 'project-123', 'project-123', '/alpha/beta']
-    fixture_3 = ['dx://project-123:alpha/beta', 'project-123', 'project-123', 'alpha/beta']
-    fixture_4 = ['dx://project-123:/', 'project-123', 'project-123', '/']
-    fixture_5 = ['dx://project-123:/some/path/*_{1,2}.fq', 'project-123', 'project-123', '/some/path/*_{1,2}.fq']
-    fixture_6 = ['dx://hola:/', 'hola', 'hola', '/']
-    fixture_7 = ['dx://hola:', 'hola', 'hola', '']
-    fixture_8 = ['dx://hola:', 'hola', 'hola', '']
-
-    # for docker image
-    fixture_9 = ['myregistryhost:5000/fedora/httpd:version1.0', 'myregistryhost:5000/fedora/', 'httpd', 'version1.0', '']
-    fixture_10 = ['fedora/httpd:version1.0-alpha', 'fedora/', 'httpd', 'version1.0-alpha', '']
-    fixture_11 = ['fedora/httpd:version1.0', 'fedora/', 'httpd', 'version1.0', '']
-    fixture_12 = ['rabbit:3', '', 'rabbit', '3', '']
-    fixture_13 = ['rabbit', '', 'rabbit', '', '']
-    fixture_14 = ['repository/rabbit:3', 'repository/', 'rabbit', '3', '']
-    fixture_15 = ['repository/rabbit', 'repository/', 'rabbit', '', '']
-    fixture_16 = ['rabbit@sha256:974219f34a18afde9517b27f3b81403c3a08f6908cbf8d7b717097b93b11583d', '', 'rabbit', '', 'sha256:974219f34a18afde9517b27f3b81403c3a08f6908cbf8d7b717097b93b11583d']
-    fixture_17 = ['repository/rabbit@sha256:974219f34a18afde9517b27f3b81403c3a08f6908cbf8d7b717097b93b11583d', 'repository/', 'rabbit', '', 'sha256:974219f34a18afde9517b27f3b81403c3a08f6908cbf8d7b717097b93b11583d']
-
     @parameterized.expand([
-        fixture_1,
-        fixture_2,
-        fixture_3,
-        fixture_4,
-        fixture_5,
-        fixture_6,
-        fixture_7,
-        fixture_8
+        ['dx:///alpha/beta', None, None, '/alpha/beta'],
+        ['dx://project-123:/alpha/beta', 'project-123', 'project-123', '/alpha/beta'],
+        ['dx://project-123:alpha/beta', 'project-123', 'project-123', 'alpha/beta'],
+        ['dx://project-123:/', 'project-123', 'project-123', '/'],
+        ['dx://project-123:/some/path/*_{1,2}.fq', 'project-123', 'project-123', '/some/path/*_{1,2}.fq'],
+        ['dx://hola:/', 'hola', 'hola', '/'],
+        ['dx://hola:', 'hola', 'hola', ''],
+        ['dx://hola:', 'hola', 'hola', '']
     ])
     def test_DxPathParser(self, image_ref, name, context_id, file_path):
         dx_path_parser = ImageRefParserFactory(image_ref)
-        tokens = dx_path_parser.parse()
+        tokens = dx_path_parser.parse
         self.assertTrue(isinstance(tokens, DxPathParser))
         self.assertTrue(tokens.name == name)
         self.assertTrue(tokens.context_id == context_id)
         self.assertTrue(tokens.file_path == file_path)
 
     @parameterized.expand([
-        fixture_9,
-        fixture_10,
-        fixture_11,
-        fixture_12,
-        fixture_13,
-        fixture_14,
-        fixture_15,
-        fixture_16,
-        fixture_17
+        ['myregistryhost:5000/fedora/httpd:version1.0', 'myregistryhost:5000/fedora/', 'httpd', 'version1.0', ''],
+        ['fedora/httpd:version1.0-alpha', 'fedora/', 'httpd', 'version1.0-alpha', ''],
+        ['fedora/httpd:version1.0', 'fedora/', 'httpd', 'version1.0', ''],
+        ['rabbit:3', '', 'rabbit', '3', ''],
+        ['rabbit', '', 'rabbit', '', ''],
+        ['repository/rabbit:3', 'repository/', 'rabbit', '3', ''],
+        ['repository/rabbit', 'repository/', 'rabbit', '', ''],
+        ['rabbit@sha256:974219f34a18afde9517b27f3b81403c3a08f6908cbf8d7b717097b93b11583d', '', 'rabbit', '', 'sha256:974219f34a18afde9517b27f3b81403c3a08f6908cbf8d7b717097b93b11583d'],
+        ['repository/rabbit@sha256:974219f34a18afde9517b27f3b81403c3a08f6908cbf8d7b717097b93b11583d', 'repository/', 'rabbit', '', 'sha256:974219f34a18afde9517b27f3b81403c3a08f6908cbf8d7b717097b93b11583d']
     ])
     def test_DockerImageParser(self, image_ref, repository, image, tag, digest):
         docker_parser = ImageRefParserFactory(image_ref)
-        tokens = docker_parser.parse()
+        tokens = docker_parser.parse
         self.assertTrue(isinstance(tokens, DockerImageParser))
         self.assertTrue(tokens.repository == repository)
         self.assertTrue(tokens.image == image)
         self.assertTrue(tokens.tag == tag)
         self.assertTrue(tokens.digest == digest)
+
+
+if __name__ == '__main__':
+    if 'DXTEST_FULL' not in os.environ:
+        sys.stderr.write(
+            'WARNING: env var DXTEST_FULL is not set; tests that create apps or run jobs will not be run\n')
+    unittest.main()

--- a/src/python/test/test_nextflow_ImageRefParser.py
+++ b/src/python/test/test_nextflow_ImageRefParser.py
@@ -67,11 +67,12 @@ class TestImageRefParser(DXTestCase):
         fixture_8
     ])
     def test_DxPathParser(self, image_ref, name, context_id, file_path):
-        dx_path_parser = ImageRefParserFactory.parse(image_ref)
-        self.assertTrue(isinstance(dx_path_parser, DxPathParser))
-        self.assertTrue(dx_path_parser.name == name)
-        self.assertTrue(dx_path_parser.context_id == context_id)
-        self.assertTrue(dx_path_parser.file_path == file_path)
+        dx_path_parser = ImageRefParserFactory(image_ref)
+        tokens = dx_path_parser.parse()
+        self.assertTrue(isinstance(tokens, DxPathParser))
+        self.assertTrue(tokens.name == name)
+        self.assertTrue(tokens.context_id == context_id)
+        self.assertTrue(tokens.file_path == file_path)
 
     @parameterized.expand([
         fixture_9,
@@ -85,9 +86,10 @@ class TestImageRefParser(DXTestCase):
         fixture_17
     ])
     def test_DockerImageParser(self, image_ref, repository, image, tag, digest):
-        dx_path_parser = ImageRefParserFactory.parse(image_ref)
-        self.assertTrue(isinstance(dx_path_parser, DockerImageParser))
-        self.assertTrue(dx_path_parser.repository == repository)
-        self.assertTrue(dx_path_parser.image == image)
-        self.assertTrue(dx_path_parser.tag == tag)
-        self.assertTrue(dx_path_parser.digest == digest)
+        docker_parser = ImageRefParserFactory(image_ref)
+        tokens = docker_parser.parse()
+        self.assertTrue(isinstance(tokens, DockerImageParser))
+        self.assertTrue(tokens.repository == repository)
+        self.assertTrue(tokens.image == image)
+        self.assertTrue(tokens.tag == tag)
+        self.assertTrue(tokens.digest == digest)


### PR DESCRIPTION
For `dx build nextflow` functionality enabling caching of docker images on the platform at compile time.
This PR adds classes to parse docker image reference in the forms of dx file path/ID or docker image/tag/digest and combinations thereof