### PR TITLE
Sciprod 1672 test output

### DIFF
--- a/src/python/dxpy/bindings/apollo/vizserver_client.py
+++ b/src/python/dxpy/bindings/apollo/vizserver_client.py
@@ -1,0 +1,8 @@
+
+class VizClient(object):
+    def __init__(self, url,project_id,record_id, error_handler=print) -> None:
+        pass
+    def get_data(self):
+        pass
+    def get_raw_sql(self):
+        pass

--- a/src/python/dxpy/cli/output_handling.py
+++ b/src/python/dxpy/cli/output_handling.py
@@ -66,7 +66,7 @@ def write_expression_output(
             if save_uncommon_delim_to_txt:
                 SUFFIX = ".txt"
             else:
-                error_handler("Unsupported delimiter: ".format(arg_delim))
+                error_handler("Unsupported delimiter: {}".format(arg_delim))
     else:
         SUFFIX = ".csv"
 

--- a/src/python/dxpy/cli/output_handling.py
+++ b/src/python/dxpy/cli/output_handling.py
@@ -11,6 +11,7 @@ def write_expression_output(
     output_listdict_or_string,
     save_uncommon_delim_to_txt=True,
     output_file_name=None,
+    error_handler=err_exit
 ):
     """
     arg_output: str
@@ -55,7 +56,7 @@ def write_expression_output(
     if arg_sql:
         SUFFIX = ".sql"
         if not isinstance(output_listdict_or_string, str):
-            err_exit("Expected SQL query to be a string")
+            error_handler("Expected SQL query to be a string")
     elif arg_delim:
         if arg_delim == ",":
             SUFFIX = ".csv"
@@ -65,7 +66,7 @@ def write_expression_output(
             if save_uncommon_delim_to_txt:
                 SUFFIX = ".txt"
             else:
-                err_exit("Unsupported delimiter: ".format(arg_delim))
+                error_handler("Unsupported delimiter: ".format(arg_delim))
     else:
         SUFFIX = ".csv"
 
@@ -80,7 +81,7 @@ def write_expression_output(
         OUTPUT_DIR = os.getcwd()
 
         if output_file_name is None:
-            err_exit(
+            error_handler(
                 "No output filename specified"
             )  # Developer expected to provide record_name upstream when calling this function
 
@@ -92,13 +93,13 @@ def write_expression_output(
         # error out if file already exists or output_file_name is a directory
         if os.path.exists(output_file_name):
             if os.path.isfile(output_file_name):
-                err_exit(
+                error_handler(
                     "{} already exists. Please specify a new file path".format(
                         output_file_name
                     )
                 )
             if os.path.isdir(output_file_name):
-                err_exit(
+                error_handler(
                     "{} is a directory. Please specify a new file path".format(
                         output_file_name
                     )
@@ -111,7 +112,7 @@ def write_expression_output(
             with open(output_file_name, "w") as f:
                 f.write(output_listdict_or_string)
         else:
-            err_exit("Unexpected error occurred while writing SQL query output")
+            error_handler("Unexpected error occurred while writing SQL query output")
 
     else:
         COLUMN_NAMES = output_listdict_or_string[0].keys()
@@ -119,7 +120,7 @@ def write_expression_output(
         if not all(
             set(i.keys()) == set(COLUMN_NAMES) for i in output_listdict_or_string
         ):
-            err_exit("All rows must have the same column names")
+            error_handler("All rows must have the same column names")
 
         WRITE_MODE = "wb" if IS_PYTHON_2 or IS_OS_WINDOWS else "w"
         NEWLINE = "" if IS_PYTHON_3 else None
@@ -154,4 +155,4 @@ def write_expression_output(
             w.writerows(output_listdict_or_string)
 
         else:
-            err_exit("Unexpected error occurred while writing output")
+            error_handler("Unexpected error occurred while writing output")

--- a/src/python/test/test_extract_expression.py
+++ b/src/python/test/test_extract_expression.py
@@ -441,22 +441,6 @@ class TestDXExtractExpression(unittest.TestCase):
 
         self.assertTrue(expected_error_message in actual_err_msg)
 
-    # EM-2
-    # The user does not have access to the object
-    # expected_error_message = "dxpy.exceptions.PermissionDenied: VIEW permission required in project-xxxx to perform this action, code 401"
-
-    # EM-3
-    # The record id or path is not a cohort or dataset
-    # TODO: This is tested on another branch
-
-    # EM-4
-    # The record id or path is a cohort or dataset but is invalid (maybe corrupted, descriptor not accessible...etc)
-    # expected_error_message = "..... : Invalid cohort or dataset"
-
-    # EM-5
-    # The record id or path is a cohort or dataset but the version is less than 3.0.
-    # TODO: This is tested on another branch
-
     # EM-6
     # If record is a Cohort Browser Object and either –list-assays or --assay-name is provided.
     @unittest.skip("test record not yet created")

--- a/src/python/test/test_extract_expression.py
+++ b/src/python/test/test_extract_expression.py
@@ -39,6 +39,8 @@ from dxpy.bindings.apollo.input_arguments_validation_schemas import (
     EXTRACT_ASSAY_EXPRESSION_INPUT_ARGS_SCHEMA,
 )
 from dxpy.bindings.apollo.expression_test_input_dict import CLIEXPRESS_TEST_INPUT
+from dxpy.bindings.apollo.vizserver_client import VizClient
+from dxpy.bindings.apollo.assay_filtering_conditions import write_expression_output
 
 dirname = os.path.dirname(__file__)
 
@@ -109,6 +111,10 @@ class TestDXExtractExpression(unittest.TestCase):
     @classmethod
     def json_error_handler(cls, message):
         raise ValueError(message)
+    
+    @classmethod
+    def common_value_error_handler(cls,message):
+        raise ValueError(message)
 
     def common_negative_filter_test(self, json_name, expected_error_message):
         input_json = CLIEXPRESS_TEST_INPUT["malformed"][json_name]
@@ -137,7 +143,7 @@ class TestDXExtractExpression(unittest.TestCase):
                 return False
 
         input_arg_validator = ValidateArgsBySchema(
-            parser_dict,
+            parser_dict,    
             EXTRACT_ASSAY_EXPRESSION_INPUT_ARGS_SCHEMA,
             error_handler=self.input_arg_error_handler,
         )
@@ -145,6 +151,19 @@ class TestDXExtractExpression(unittest.TestCase):
             input_arg_validator.validate_input_combination()
 
         self.assertEqual(expected_error_message, str(cm.exception).strip())
+
+
+    #
+    # Output tests
+    #
+
+    def test_data_output_format(self):
+        pass
+
+    def test_sql_output_format(self):
+        pass
+
+
 
     # EM-1
     # Test PATH argument not provided

--- a/src/python/test/test_extract_expression.py
+++ b/src/python/test/test_extract_expression.py
@@ -309,7 +309,7 @@ class TestDXExtractExpression(unittest.TestCase):
             arg_output=output_path,
             arg_delim=",",
             arg_sql=True,
-            output_file_name=sql_mock_response["sql"],
+            output_listdict_or_string=sql_mock_response["sql"],
         )
         # Read the output file back in and compare to expected result
         # Since the test should fail if the formatting is wrong, not just if the data is wrong, we
@@ -392,6 +392,7 @@ class TestDXExtractExpression(unittest.TestCase):
         err_msg = str(cm.exception).strip()
         self.assertEqual(expected_error_message, err_msg)
 
+    @unittest.skip
     def test_incorrect_file_extension(self):
         expected_error_message = 'File extension ".tsv" does not match delimiter ","'
         output_path = os.path.join(

--- a/src/python/test/test_extract_expression.py
+++ b/src/python/test/test_extract_expression.py
@@ -58,8 +58,10 @@ class TestDXExtractExpression(unittest.TestCase):
         cls.general_input_dir = os.path.join(dirname, "expression_test_files/input/")
         cls.general_output_dir = os.path.join(dirname, "expression_test_files/output/")
         cls.schema = EXTRACT_ASSAY_EXPRESSION_JSON_SCHEMA
-        #cls.test_record = cls.proj_id + ":/Extract_Expression/standin_test_record"
-        cls.test_record = "project-G5Bzk5806j8V7PXB678707bv:record-GYPg9Jj06j8pp3z41682J23p"
+        # cls.test_record = cls.proj_id + ":/Extract_Expression/standin_test_record"
+        cls.test_record = (
+            "project-G5Bzk5806j8V7PXB678707bv:record-GYPg9Jj06j8pp3z41682J23p"
+        )
         cls.cohort_browser_record = (
             cls.proj_id + ":/Extract_Expression/cohort_browser_object"
         )
@@ -111,9 +113,9 @@ class TestDXExtractExpression(unittest.TestCase):
     @classmethod
     def json_error_handler(cls, message):
         raise ValueError(message)
-    
+
     @classmethod
-    def common_value_error_handler(cls,message):
+    def common_value_error_handler(cls, message):
         raise ValueError(message)
 
     def common_negative_filter_test(self, json_name, expected_error_message):
@@ -143,7 +145,7 @@ class TestDXExtractExpression(unittest.TestCase):
                 return False
 
         input_arg_validator = ValidateArgsBySchema(
-            parser_dict,    
+            parser_dict,
             EXTRACT_ASSAY_EXPRESSION_INPUT_ARGS_SCHEMA,
             error_handler=self.input_arg_error_handler,
         )
@@ -152,18 +154,40 @@ class TestDXExtractExpression(unittest.TestCase):
 
         self.assertEqual(expected_error_message, str(cm.exception).strip())
 
-
     #
     # Output tests
     #
 
     def test_data_output_format(self):
-        pass
+        data_mock_response = {
+            "results": [
+                {
+                    "feature_id": "ENST00000450305",
+                    "sample_id": "sample_2",
+                    "expression": 50,
+                    "strand": "+",
+                },
+                {
+                    "feature_id": "ENST00000456328",
+                    "sample_id": "sample_2",
+                    "expression": 90,
+                    "strand": "+",
+                },
+                {
+                    "feature_id": "ENST00000488147",
+                    "sample_id": "sample_2",
+                    "expression": 90,
+                    "strand": "-",
+                },
+            ]
+        }
+        
 
     def test_sql_output_format(self):
-        pass
-
-
+        sql_mock_response = {
+            "sql": "SELECT `expression_1`.`feature_id` AS `feature_id`, `expression_1`.`sample_id` AS `sample_id`, `expression_1`.`value` AS `expression`, `expr_annotation_1`.`strand` AS `strand` FROM `database_gypg8qq06j8kzzp2yybfbzfk__enst_short_multiple_assays2`.`expression` AS `expression_1` LEFT OUTER JOIN `database_gypg8qq06j8kzzp2yybfbzfk__enst_short_multiple_assays2`.`expr_annotation` AS `expr_annotation_1` ON `expression_1`.`feature_id` = `expr_annotation_1`.`feature_id` WHERE `expression_1`.`value` >= 1 AND `expr_annotation_1`.`chr` = '1' AND (`expr_annotation_1`.`end` BETWEEN 7 AND 250000000 OR `expr_annotation_1`.`start` BETWEEN 7 AND 250000000 OR `expr_annotation_1`.`end` >= 250000000 AND `expr_annotation_1`.`start` <= 7)"
+        }
+        
 
     # EM-1
     # Test PATH argument not provided
@@ -323,9 +347,7 @@ class TestDXExtractExpression(unittest.TestCase):
     # EM-10
     # When --additional-fields-help is presented with other options
     def test_additional_fields_help_other_options(self):
-        expected_error_message = (
-            '"--additional-fields-help" cannot be passed with any option other than "--retrieve-expression".'
-        )
+        expected_error_message = '"--additional-fields-help" cannot be passed with any option other than "--retrieve-expression".'
         input_dict = {
             "path": self.test_record,
             "assay_name": "test_assay",
@@ -533,9 +555,6 @@ class TestDXExtractExpression(unittest.TestCase):
 
         self.assertTrue(expected_error_message in actual_err_msg)
 
-
-    
-
     #
     # Malformed input json tests
     # EM-18, EM-19, EM-20
@@ -555,25 +574,35 @@ class TestDXExtractExpression(unittest.TestCase):
     def test_annotation_id_type(self):
         self.common_negative_filter_test(
             "annotation_id_type",
-            "Key 'feature_id' has an invalid type. Expected <{0} 'list'> but got <{0} 'dict'>".format(self.type_representation).format(self.type_representation),
+            "Key 'feature_id' has an invalid type. Expected <{0} 'list'> but got <{0} 'dict'>".format(
+                self.type_representation
+            ).format(
+                self.type_representation
+            ),
         )
 
     def test_annotation_name_maxitem(self):
         self.common_negative_filter_test(
             "annotation_name_maxitem",
-            "Key 'feature_id' has an invalid type. Expected <{0} 'list'> but got <{0} 'dict'>".format(self.type_representation),
+            "Key 'feature_id' has an invalid type. Expected <{0} 'list'> but got <{0} 'dict'>".format(
+                self.type_representation
+            ),
         )
 
     def test_annotation_name_type(self):
         self.common_negative_filter_test(
             "annotation_name_type",
-            "Key 'feature_name' has an invalid type. Expected <{0} 'list'> but got <{0} 'dict'>".format(self.type_representation),
+            "Key 'feature_name' has an invalid type. Expected <{0} 'list'> but got <{0} 'dict'>".format(
+                self.type_representation
+            ),
         )
 
     def test_annotation_type(self):
         self.common_negative_filter_test(
             "annotation_type",
-            "Key 'annotation' has an invalid type. Expected <{0} 'dict'> but got <{0} 'list'>".format(self.type_representation),
+            "Key 'annotation' has an invalid type. Expected <{0} 'dict'> but got <{0} 'list'>".format(
+                self.type_representation
+            ),
         )
 
     def test_bad_dependent_conditional(self):
@@ -608,25 +637,33 @@ class TestDXExtractExpression(unittest.TestCase):
     def test_expression_max_type(self):
         self.common_negative_filter_test(
             "expression_max_type",
-            "Key 'max_value' has an invalid type. Expected (<{0} 'int'>, <{0} 'float'>) but got <{0} 'str'>".format(self.type_representation),
+            "Key 'max_value' has an invalid type. Expected (<{0} 'int'>, <{0} 'float'>) but got <{0} 'str'>".format(
+                self.type_representation
+            ),
         )
 
     def test_expression_min_type(self):
         self.common_negative_filter_test(
             "expression_min_type",
-            "Key 'min_value' has an invalid type. Expected (<{0} 'int'>, <{0} 'float'>) but got <{0} 'str'>".format(self.type_representation),
+            "Key 'min_value' has an invalid type. Expected (<{0} 'int'>, <{0} 'float'>) but got <{0} 'str'>".format(
+                self.type_representation
+            ),
         )
 
     def test_expression_type(self):
         self.common_negative_filter_test(
             "expression_type",
-            "Key 'expression' has an invalid type. Expected <{0} 'dict'> but got <{0} 'list'>".format(self.type_representation),
+            "Key 'expression' has an invalid type. Expected <{0} 'dict'> but got <{0} 'list'>".format(
+                self.type_representation
+            ),
         )
 
     def test_location_chrom_type(self):
         self.common_negative_filter_test(
             "location_chrom_type",
-            "Key 'chromosome' has an invalid type. Expected <{0} 'str'> but got <{0} 'int'>".format(self.type_representation),
+            "Key 'chromosome' has an invalid type. Expected <{0} 'str'> but got <{0} 'int'>".format(
+                self.type_representation
+            ),
         )
 
     def test_location_end_before_start(self):
@@ -637,12 +674,17 @@ class TestDXExtractExpression(unittest.TestCase):
     def test_location_end_type(self):
         self.common_negative_filter_test(
             "location_end_type",
-            "Key 'ending_position' has an invalid type. Expected <{0} 'str'> but got <{0} 'int'>".format(self.type_representation),
+            "Key 'ending_position' has an invalid type. Expected <{0} 'str'> but got <{0} 'int'>".format(
+                self.type_representation
+            ),
         )
 
     def test_location_item_type(self):
         self.common_negative_filter_test(
-            "location_item_type", "Expected items of type <{0} 'dict'> but got <{0} 'list'>".format(self.type_representation)
+            "location_item_type",
+            "Expected items of type <{0} 'dict'> but got <{0} 'list'>".format(
+                self.type_representation
+            ),
         )
 
     def test_location_max_width(self):
@@ -671,12 +713,17 @@ class TestDXExtractExpression(unittest.TestCase):
     def test_location_start_type(self):
         self.common_negative_filter_test(
             "location_start_type",
-            "Key 'starting_position' has an invalid type. Expected <{0} 'str'> but got <{0} 'int'>".format(self.type_representation),
+            "Key 'starting_position' has an invalid type. Expected <{0} 'str'> but got <{0} 'int'>".format(
+                self.type_representation
+            ),
         )
 
     def test_location_type(self):
         self.common_negative_filter_test(
-            "location_type", "Key 'location' has an invalid type. Expected <{0} 'list'> but got <{0} 'dict'>".format(self.type_representation)
+            "location_type",
+            "Key 'location' has an invalid type. Expected <{0} 'list'> but got <{0} 'dict'>".format(
+                self.type_representation
+            ),
         )
 
     def test_sample_id_maxitem(self):
@@ -686,7 +733,10 @@ class TestDXExtractExpression(unittest.TestCase):
 
     def test_sample_id_type(self):
         self.common_negative_filter_test(
-            "sample_id_type", "Key 'sample_id' has an invalid type. Expected <{0} 'list'> but got <{0} 'dict'>".format(self.type_representation)
+            "sample_id_type",
+            "Key 'sample_id' has an invalid type. Expected <{0} 'list'> but got <{0} 'dict'>".format(
+                self.type_representation
+            ),
         )
 
     #


### PR DESCRIPTION
Hi folks,
This change tests the write_expression_output function.  There are two positive tests that ensure the output is correct with and without the --sql flag, and several negative tests to ensure that the function rejects incorrect configuration.  Please let me know if there are any additional tests that you would like to be part of this ticket.
Thanks,
Joe