### PR TITLE
SCIPROD-1731 function created for widening output data table

### DIFF
--- a/src/python/dxpy/bindings/apollo/expression_matrix_transformation.py
+++ b/src/python/dxpy/bindings/apollo/expression_matrix_transformation.py
@@ -19,4 +19,13 @@ def expression_transform(results_list):
         for (feature_id,expression) in transformed_dict[sample].items():
             samp_row[feature_id] = expression
         dict_list.append(samp_row)
-    return dict_list
+    
+    # Get the column names that the output writer will use to generate the table
+    colnames = set()
+    for row in results_list:
+        colnames.add(row["feature_id"])
+    colnames = list(colnames)
+    # add sample_id to front
+    colnames.insert(0,"sample_id")
+
+    return (dict_list,colnames)

--- a/src/python/dxpy/bindings/apollo/expression_matrix_transformation.py
+++ b/src/python/dxpy/bindings/apollo/expression_matrix_transformation.py
@@ -21,10 +21,12 @@ def expression_transform(results_list):
         dict_list.append(samp_row)
     
     # Get the column names that the output writer will use to generate the table
-    colnames = set()
+    # Can't use set here because we want the order of the columns to be deterministic
+    colnames = []
     for row in results_list:
-        colnames.add(row["feature_id"])
-    colnames = list(colnames)
+        row_colname = row["feature_id"] 
+        if not row_colname in colnames:
+            colnames.append(row_colname)
     # add sample_id to front
     colnames.insert(0,"sample_id")
 

--- a/src/python/dxpy/bindings/apollo/expression_matrix_transformation.py
+++ b/src/python/dxpy/bindings/apollo/expression_matrix_transformation.py
@@ -52,6 +52,6 @@ def expression_transform(results_list):
     for dict_row in dict_list:
         for colname in colnames:
             if colname not in dict_row:
-                dict_row[colname] = "None"
+                dict_row[colname] = None
 
     return (dict_list,colnames)

--- a/src/python/dxpy/bindings/apollo/expression_matrix_transformation.py
+++ b/src/python/dxpy/bindings/apollo/expression_matrix_transformation.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 
 def expression_transform(results_list):
     """
@@ -30,34 +29,25 @@ def expression_transform(results_list):
     # create a dict of the form
     # {
     #   <sample_id>:{
+    #       "sample_id":<sample_id>,
     #       <feature_id_1>:<expression_1>,
     #       <feature_id_2>:<expression_2>,
     #        etc.
     #   }
     # 
     # }
+    colnames = set()
     for entry in results_list:
+        # Keep track of all seen feature_ids, they will become the columns of our final table
+        colnames.add(entry["feature_id"])
         if entry["sample_id"] not in transformed_dict:
-            transformed_dict[entry["sample_id"]] = {entry["feature_id"]:entry["expression"]}
+            transformed_dict[entry["sample_id"]] = {"sample_id":entry["sample_id"],entry["feature_id"]:entry["expression"]}
         else:
             transformed_dict[entry["sample_id"]][entry["feature_id"]] = entry["expression"]
-
-    # Modify the above dictionary into a list of dictionaries, essentially moving the key of each
-    # dict into the dict itself
-    dict_list = []
-    for sample in transformed_dict:
-        samp_row = deepcopy(transformed_dict[sample])
-        samp_row["sample_id"] = sample
-        dict_list.append(samp_row)
-    
-    # Get the column names that the output writer will use to generate the table
-    # Can't use set here because we want the order of the columns to be deterministic
-    colnames = []
-    for row in results_list:
-        row_colname = row["feature_id"] 
-        if not row_colname in colnames:
-            colnames.append(row_colname)
-    # add sample_id to front
+    colnames = sorted(list(colnames))
     colnames.insert(0,"sample_id")
+
+    # We want the output to be a list of dictionaries, rather than a single dicitonary keyed on sample_id
+    dict_list = list(transformed_dict.values())
 
     return (dict_list,colnames)

--- a/src/python/dxpy/bindings/apollo/expression_matrix_transformation.py
+++ b/src/python/dxpy/bindings/apollo/expression_matrix_transformation.py
@@ -1,0 +1,22 @@
+from collections import OrderedDict
+
+def expression_transform(results_list):
+    # First, create a dictionary where each key is a sample id, and the values are the feature_id:expression pairs
+    # Then, convert it to a list of dictionaries (the format that output handling is expecting)
+    # Each item in the list is a dictionary containing one "sample_id":sample_id pair, and
+    # multiple feature_id:expression pairs
+
+    transformed_dict = {}
+    for entry in results_list:
+        if entry["sample_id"] not in transformed_dict:
+            transformed_dict[entry["sample_id"]] = {entry["feature_id"]:entry["expression"]}
+        else:
+            transformed_dict[entry["sample_id"]][entry["feature_id"]] = entry["expression"]
+
+    dict_list = []
+    for sample in transformed_dict:
+        samp_row = OrderedDict([("sample_id",sample)])
+        for (feature_id,expression) in transformed_dict[sample].items():
+            samp_row[feature_id] = expression
+        dict_list.append(samp_row)
+    return dict_list

--- a/src/python/dxpy/bindings/apollo/expression_matrix_transformation.py
+++ b/src/python/dxpy/bindings/apollo/expression_matrix_transformation.py
@@ -1,23 +1,53 @@
-from collections import OrderedDict
+from copy import deepcopy
 
 def expression_transform(results_list):
-    # First, create a dictionary where each key is a sample id, and the values are the feature_id:expression pairs
-    # Then, convert it to a list of dictionaries (the format that output handling is expecting)
-    # Each item in the list is a dictionary containing one "sample_id":sample_id pair, and
-    # multiple feature_id:expression pairs
+    """
+    results_list: list of dictionaries, each of the form
+    {
+        "feature_id":<feature_id>,
+        "sample_id":<sample_id>,
+        "expression":<expression>
+    }
+    Additional key:value pairs are possible, but are not included in the transformed output
 
+    How it works:
+    First, create a dictionary where each key is a sample id, and the values are the feature_id:expression pairs
+    Then, convert it to a list of dictionaries (the format that output handling is expecting)
+    Each item in the list is a dictionary containing one "sample_id":sample_id pair, and
+    multiple feature_id:expression pairs
+
+    Returns:
+    A list of dictionaries, each of the form:
+    {
+        "sample_id":<sample_id>,
+        <feature_id_1>:<expression_1>
+        <feature_id_2>:<expression_2>
+        ...
+        <feature_id_n>:<expression_n>
+    }
+    """
     transformed_dict = {}
+    # create a dict of the form
+    # {
+    #   <sample_id>:{
+    #       <feature_id_1>:<expression_1>,
+    #       <feature_id_2>:<expression_2>,
+    #        etc.
+    #   }
+    # 
+    # }
     for entry in results_list:
         if entry["sample_id"] not in transformed_dict:
             transformed_dict[entry["sample_id"]] = {entry["feature_id"]:entry["expression"]}
         else:
             transformed_dict[entry["sample_id"]][entry["feature_id"]] = entry["expression"]
 
+    # Modify the above dictionary into a list of dictionaries, essentially moving the key of each
+    # dict into the dict itself
     dict_list = []
     for sample in transformed_dict:
-        samp_row = OrderedDict([("sample_id",sample)])
-        for (feature_id,expression) in transformed_dict[sample].items():
-            samp_row[feature_id] = expression
+        samp_row = deepcopy(transformed_dict[sample])
+        samp_row["sample_id"] = sample
         dict_list.append(samp_row)
     
     # Get the column names that the output writer will use to generate the table

--- a/src/python/dxpy/bindings/apollo/expression_matrix_transformation.py
+++ b/src/python/dxpy/bindings/apollo/expression_matrix_transformation.py
@@ -49,5 +49,9 @@ def expression_transform(results_list):
 
     # We want the output to be a list of dictionaries, rather than a single dicitonary keyed on sample_id
     dict_list = list(transformed_dict.values())
+    for dict_row in dict_list:
+        for colname in colnames:
+            if colname not in dict_row:
+                dict_row[colname] = "None"
 
     return (dict_list,colnames)

--- a/src/python/dxpy/cli/dataset_utilities.py
+++ b/src/python/dxpy/cli/dataset_utilities.py
@@ -59,6 +59,7 @@ from ..bindings.apollo.assay_filtering_conditions import EXTRACT_ASSAY_EXPRESSIO
 from ..bindings.apollo.vizserver_filters_from_json_parser import JSONFiltersValidator
 from ..bindings.apollo.vizserver_payload_builder import VizPayloadBuilder
 from ..bindings.apollo.vizclient import VizClient
+from ..bindings.apollo.expression_matrix_transformation import expression_transform
 from .output_handling import write_expression_output
 
 from .help_messages import EXTRACT_ASSAY_EXPRESSION_JSON_HELP
@@ -1125,10 +1126,6 @@ def extract_assay_expression(args):
             COHORT_FILTERS = None
             IS_COHORT = False
 
-        
-
-    
-
     if args.list_assays:
         print(*dataset.assay_names_list("molecular_expression"), sep="\n")
         sys.exit(0)
@@ -1225,10 +1222,18 @@ def extract_assay_expression(args):
     else:
         vizserver_response = client.get_data(vizserver_payload, record_id)
 
+
+
+    output_data = vizserver_response['results']
+    if args.expression_matrix:
+        transformed_response = expression_transform(vizserver_response["results"])
+        output_data = transformed_response
+    
+
     write_expression_output(args.output, 
                             args.delim, 
                             args.sql, 
-                            vizserver_response['results'], 
+                            output_data, 
                             save_uncommon_delim_to_txt=True, 
                             output_file_name=dataset.detail_describe["name"])
 

--- a/src/python/dxpy/cli/dataset_utilities.py
+++ b/src/python/dxpy/cli/dataset_utilities.py
@@ -1225,8 +1225,9 @@ def extract_assay_expression(args):
 
 
     output_data = vizserver_response['results']
+    colnames = None
     if args.expression_matrix:
-        transformed_response = expression_transform(vizserver_response["results"])
+        transformed_response,colnames = expression_transform(vizserver_response["results"])
         output_data = transformed_response
     
 
@@ -1235,7 +1236,9 @@ def extract_assay_expression(args):
                             args.sql, 
                             output_data, 
                             save_uncommon_delim_to_txt=True, 
-                            output_file_name=dataset.detail_describe["name"])
+                            output_file_name=dataset.detail_describe["name"],
+                            colnames=colnames
+    )
 
 
 

--- a/src/python/dxpy/cli/dataset_utilities.py
+++ b/src/python/dxpy/cli/dataset_utilities.py
@@ -1240,13 +1240,16 @@ def extract_assay_expression(args):
     else:
         vizserver_response = client.get_data(vizserver_payload, record_id)
 
-
-
-    output_data = vizserver_response['results']
     colnames = None
-    if args.expression_matrix:
-        transformed_response,colnames = expression_transform(vizserver_response["results"])
-        output_data = transformed_response
+    # Output is on the "sql" key rather than the "results" key when sql is requested
+    if args.sql:
+        output_data = vizserver_response["sql"]
+    else:
+        output_data = vizserver_response['results']
+
+        if args.expression_matrix:
+            transformed_response,colnames = expression_transform(vizserver_response["results"])
+            output_data = transformed_response
     
 
     write_expression_output(args.output, 

--- a/src/python/dxpy/cli/output_handling.py
+++ b/src/python/dxpy/cli/output_handling.py
@@ -11,7 +11,8 @@ def write_expression_output(
     output_listdict_or_string,
     save_uncommon_delim_to_txt=True,
     output_file_name=None,
-    error_handler=err_exit
+    error_handler=err_exit,
+    colnames = None
 ):
     """
     arg_output: str
@@ -115,12 +116,15 @@ def write_expression_output(
             error_handler("Unexpected error occurred while writing SQL query output")
 
     else:
-        COLUMN_NAMES = output_listdict_or_string[0].keys()
+        if colnames:
+            COLUMN_NAMES = colnames
+        else:
+            COLUMN_NAMES = output_listdict_or_string[0].keys()
 
-        if not all(
-            set(i.keys()) == set(COLUMN_NAMES) for i in output_listdict_or_string
-        ):
-            error_handler("All rows must have the same column names")
+            if not all(
+                set(i.keys()) == set(COLUMN_NAMES) for i in output_listdict_or_string
+            ):
+                error_handler("All rows must have the same column names")
 
         WRITE_MODE = "wb" if IS_PYTHON_2 or IS_OS_WINDOWS else "w"
         NEWLINE = "" if IS_PYTHON_3 else None
@@ -140,7 +144,8 @@ def write_expression_output(
             "delimiter": DELIMITER,
             "lineterminator": OS_SPECIFIC_LINE_SEPARATOR,
             "quoting": QUOTING,
-            "quotechar": QUOTE_CHAR,
+            "quotechar": QUOTE_CHAR,\
+            "restval":0
         }
 
         if WRITE_METHOD == "FILE":

--- a/src/python/dxpy/cli/output_handling.py
+++ b/src/python/dxpy/cli/output_handling.py
@@ -12,7 +12,7 @@ def write_expression_output(
     save_uncommon_delim_to_txt=True,
     output_file_name=None,
     error_handler=err_exit,
-    colnames = None
+    colnames=None,
 ):
     """
     arg_output: str
@@ -121,10 +121,10 @@ def write_expression_output(
         else:
             COLUMN_NAMES = output_listdict_or_string[0].keys()
 
-            if not all(
-                set(i.keys()) == set(COLUMN_NAMES) for i in output_listdict_or_string
-            ):
-                error_handler("All rows must have the same column names")
+        if not all(
+            set(i.keys()) == set(COLUMN_NAMES) for i in output_listdict_or_string
+        ):
+            error_handler("All rows must have the same column names")
 
         WRITE_MODE = "wb" if IS_PYTHON_2 or IS_OS_WINDOWS else "w"
         NEWLINE = "" if IS_PYTHON_3 else None
@@ -144,8 +144,7 @@ def write_expression_output(
             "delimiter": DELIMITER,
             "lineterminator": OS_SPECIFIC_LINE_SEPARATOR,
             "quoting": QUOTING,
-            "quotechar": QUOTE_CHAR,\
-            "restval":"None"
+            "quotechar": QUOTE_CHAR,
         }
 
         if WRITE_METHOD == "FILE":

--- a/src/python/dxpy/cli/output_handling.py
+++ b/src/python/dxpy/cli/output_handling.py
@@ -145,7 +145,7 @@ def write_expression_output(
             "lineterminator": OS_SPECIFIC_LINE_SEPARATOR,
             "quoting": QUOTING,
             "quotechar": QUOTE_CHAR,\
-            "restval":0
+            "restval":"None"
         }
 
         if WRITE_METHOD == "FILE":

--- a/src/python/test/test_extract_expression.py
+++ b/src/python/test/test_extract_expression.py
@@ -337,13 +337,13 @@ class TestDXExtractExpression(unittest.TestCase):
                 "sample_id": "sample_2",
                 "ENST00000450305": 50,
                 "ENST00000488147": 20,
-                "ENST00000456328": "None",
+                "ENST00000456328": None,
             },
             {
                 "sample_id": "sample_1",
                 "ENST00000456328": 90,
-                "ENST00000450305": "None",
-                "ENST00000488147": "None",
+                "ENST00000450305": None,
+                "ENST00000488147": None,
             },
         ]
 
@@ -378,13 +378,13 @@ class TestDXExtractExpression(unittest.TestCase):
                 "sample_id": "sample_2",
                 "ENST00000450305": 50,
                 "ENST00000488147": 20,
-                "ENST00000456328": "None",
+                "ENST00000456328": None,
             },
             {
                 "sample_id": "sample_1",
                 "ENST00000450305": 77,
                 "ENST00000456328": 90,
-                "ENST00000488147": "None",
+                "ENST00000488147": None,
             },
         ]
 
@@ -418,8 +418,8 @@ class TestDXExtractExpression(unittest.TestCase):
         # The replace statement removes tabs(actually blocks of 4 spaces) that have been inserted
         # for readability in this python file
         expected_result = """sample_id,ENST00000450305,ENST00000456328,ENST00000488147
-                             sample_2,50,None,20
-                             sample_1,77,90,None""".replace(
+                             sample_2,50,,20
+                             sample_1,77,90,""".replace(
             " ", ""
         )
 

--- a/src/python/test/test_extract_expression.py
+++ b/src/python/test/test_extract_expression.py
@@ -379,6 +379,55 @@ class TestDXExtractExpression(unittest.TestCase):
 
         self.assertEqual(expected_output, transformed_results)
 
+    def test_exp_transform_output_compatibility(self):
+        vizserver_results = [
+            {
+                "feature_id": "ENST00000450305",
+                "sample_id": "sample_2",
+                "expression": 50,
+            },
+            {
+                "feature_id": "ENST00000450305",
+                "sample_id": "sample_1",
+                "expression": 77,
+            },
+            {
+                "feature_id": "ENST00000456328",
+                "sample_id": "sample_1",
+                "expression": 90,
+            },
+            {
+                "feature_id": "ENST00000488147",
+                "sample_id": "sample_2",
+                "expression": 90,
+            },
+        ]
+
+        # The replace statement removes tabs(actually blocks of 4 spaces) that have been inserted
+        # for readability in this python file
+        expected_result = """sample_id,ENST00000450305,ENST00000456328,ENST00000488147
+                             sample_2,50,0,90
+                             sample_1,77,90,0""".replace(
+            " ", ""
+        )
+
+        transformed_results, colnames = expression_transform(vizserver_results)
+        output_path = os.path.join(
+            self.general_output_dir, "exp_transform_compat.csv"
+        )
+        # Generate the formatted output file
+        write_expression_output(
+            output_path,
+            ",",
+            False,
+            transformed_results,
+            colnames=colnames
+        )
+
+        with open(output_path, "r") as infile:
+            data = infile.read()
+        self.assertEqual(expected_result.strip(), data.strip())
+
     #
     # Positive output tests
     #

--- a/src/python/test/test_extract_expression.py
+++ b/src/python/test/test_extract_expression.py
@@ -415,8 +415,8 @@ class TestDXExtractExpression(unittest.TestCase):
         # The replace statement removes tabs(actually blocks of 4 spaces) that have been inserted
         # for readability in this python file
         expected_result = """sample_id,ENST00000450305,ENST00000456328,ENST00000488147
-                             sample_2,50,0,20
-                             sample_1,77,90,0""".replace(
+                             sample_2,50,None,20
+                             sample_1,77,90,None""".replace(
             " ", ""
         )
 

--- a/src/python/test/test_extract_expression.py
+++ b/src/python/test/test_extract_expression.py
@@ -29,6 +29,7 @@ import copy
 import json
 import tempfile
 import csv
+from collections import OrderedDict
 
 import shutil
 from dxpy_testutil import cd, chdir
@@ -45,6 +46,7 @@ from dxpy.bindings.apollo.input_arguments_validation_schemas import (
 )
 from dxpy.bindings.apollo.expression_test_input_dict import CLIEXPRESS_TEST_INPUT
 from dxpy.bindings.apollo.vizserver_client import VizClient
+from dxpy.bindings.apollo.expression_matrix_transformation import expression_transform
 from dxpy.cli.output_handling import write_expression_output
 from dxpy.cli.help_messages import EXTRACT_ASSAY_EXPRESSION_JSON_TEMPLATE
 
@@ -107,8 +109,6 @@ class TestDXExtractExpression(unittest.TestCase):
             "output": None,
         }
 
-        
-
         cls.default_entity_describe = {
             "id": cls.test_record,
             "project": cls.proj_id,
@@ -167,28 +167,30 @@ class TestDXExtractExpression(unittest.TestCase):
         }
 
         cls.vizserver_data_mock_response = {
-                "results": [
-                    {
-                        "feature_id": "ENST00000450305",
-                        "sample_id": "sample_2",
-                        "expression": 50,
-                        "strand": "+",
-                    },
-                    {
-                        "feature_id": "ENST00000456328",
-                        "sample_id": "sample_2",
-                        "expression": 90,
-                        "strand": "+",
-                    },
-                    {
-                        "feature_id": "ENST00000488147",
-                        "sample_id": "sample_2",
-                        "expression": 90,
-                        "strand": "-",
-                    },
-                ]
-            }
-        cls.argparse_expression_help_message = os.path.join(dirname, "help_messages/extract_expression_help_message.txt")
+            "results": [
+                {
+                    "feature_id": "ENST00000450305",
+                    "sample_id": "sample_2",
+                    "expression": 50,
+                    "strand": "+",
+                },
+                {
+                    "feature_id": "ENST00000456328",
+                    "sample_id": "sample_2",
+                    "expression": 90,
+                    "strand": "+",
+                },
+                {
+                    "feature_id": "ENST00000488147",
+                    "sample_id": "sample_2",
+                    "expression": 90,
+                    "strand": "-",
+                },
+            ]
+        }
+        cls.argparse_expression_help_message = os.path.join(
+            dirname, "help_messages/extract_expression_help_message.txt"
+        )
 
     @classmethod
     def path_validation_error_handler(cls, message):
@@ -270,6 +272,114 @@ class TestDXExtractExpression(unittest.TestCase):
         self.assertEqual(expected_error_message, str(cm.exception).strip())
 
     #
+    # Expression matrix tests
+    #
+
+    def test_basic_exp_matrix_transform(self):
+        vizserver_results = [
+            {
+                "feature_id": "ENST00000450305",
+                "sample_id": "sample_2",
+                "expression": 50,
+            },
+            {
+                "feature_id": "ENST00000456328",
+                "sample_id": "sample_2",
+                "expression": 90,
+            },
+            {
+                "feature_id": "ENST00000488147",
+                "sample_id": "sample_2",
+                "expression": 90,
+            },
+        ]
+        expected_output = [
+            OrderedDict(
+                [
+                    ("sample_id", "sample_2"),
+                    ("ENST00000450305", 50),
+                    ("ENST00000456328", 90),
+                    ("ENST00000488147", 90),
+                ]
+            )
+        ]
+
+        transformed_results, colnames = expression_transform(vizserver_results)
+        self.assertEqual(expected_output, transformed_results)
+
+    def test_two_sample_exp_transform(self):
+        vizserver_results = [
+            {
+                "feature_id": "ENST00000450305",
+                "sample_id": "sample_2",
+                "expression": 50,
+            },
+            {
+                "feature_id": "ENST00000456328",
+                "sample_id": "sample_1",
+                "expression": 90,
+            },
+            {
+                "feature_id": "ENST00000488147",
+                "sample_id": "sample_2",
+                "expression": 90,
+            },
+        ]
+
+        expected_output = [
+            OrderedDict(
+                [
+                    ("sample_id", "sample_2"),
+                    ("ENST00000450305", 50),
+                    ("ENST00000488147", 90),
+                ]
+            ),
+            OrderedDict([("sample_id", "sample_1"), ("ENST00000456328", 90)]),
+        ]
+
+        transformed_results, colnames = expression_transform(vizserver_results)
+
+        self.assertEqual(expected_output, transformed_results)
+
+    def test_two_sample_feat_id_overlap_exp_trans(self):
+        vizserver_results = [
+            {
+                "feature_id": "ENST00000450305",
+                "sample_id": "sample_2",
+                "expression": 50,
+            },
+            {
+                "feature_id": "ENST00000450305",
+                "sample_id": "sample_1",
+                "expression": 77,
+            },
+            {
+                "feature_id": "ENST00000456328",
+                "sample_id": "sample_1",
+                "expression": 90,
+            },
+            {
+                "feature_id": "ENST00000488147",
+                "sample_id": "sample_2",
+                "expression": 90,
+            },
+        ]
+        expected_output = [
+            OrderedDict(
+                [
+                    ("sample_id", "sample_2"),
+                    ("ENST00000450305", 50),
+                    ("ENST00000488147", 90),
+                ]
+            ),
+            OrderedDict([("sample_id", "sample_1"), ("ENST00000450305", 77),("ENST00000456328", 90)]),
+        ]
+
+        transformed_results, colnames = expression_transform(vizserver_results)
+
+        self.assertEqual(expected_output, transformed_results)
+
+    #
     # Positive output tests
     #
 
@@ -277,7 +387,9 @@ class TestDXExtractExpression(unittest.TestCase):
         expected_result = """feature_id,sample_id,expression,strand
             ENST00000450305,sample_2,50,+
             ENST00000456328,sample_2,90,+
-            ENST00000488147,sample_2,90,-""".replace(" ","")
+            ENST00000488147,sample_2,90,-""".replace(
+            " ", ""
+        )
         output_path = os.path.join(
             self.general_output_dir, "extract_assay_expression_data.csv"
         )
@@ -293,8 +405,7 @@ class TestDXExtractExpression(unittest.TestCase):
         # can do a simple string comparison
         with open(output_path, "r") as infile:
             data = infile.read()
-        self.assertEqual(expected_result.strip(),data.strip())
-
+        self.assertEqual(expected_result.strip(), data.strip())
 
     def test_output_sql_format(self):
         sql_mock_response = {
@@ -316,7 +427,7 @@ class TestDXExtractExpression(unittest.TestCase):
         # can do a simple string comparison
         with open(output_path, "r") as infile:
             data = infile.read()
-        self.assertEqual(expected_result.strip(),data.strip())
+        self.assertEqual(expected_result.strip(), data.strip())
 
     #
     # Negative output tests
@@ -330,63 +441,65 @@ class TestDXExtractExpression(unittest.TestCase):
                 arg_delim=",",
                 arg_sql=True,
                 output_listdict_or_string=["not a string-formatted SQL query"],
-                error_handler=self.common_value_error_handler
+                error_handler=self.common_value_error_handler,
             )
         err_msg = str(cm.exception).strip()
         self.assertEqual(expected_error_message, err_msg)
 
     def test_output_bad_delimiter(self):
         bad_delim = "|"
-        expected_error_message =  "Unsupported delimiter: {}".format(bad_delim)
+        expected_error_message = "Unsupported delimiter: {}".format(bad_delim)
         with self.assertRaises(ValueError) as cm:
             write_expression_output(
-                arg_output= "-",
+                arg_output="-",
                 arg_delim=bad_delim,
                 arg_sql=False,
                 output_listdict_or_string=self.vizserver_data_mock_response["results"],
-                save_uncommon_delim_to_txt = False,
-                error_handler=self.common_value_error_handler
+                save_uncommon_delim_to_txt=False,
+                error_handler=self.common_value_error_handler,
             )
         err_msg = str(cm.exception).strip()
         self.assertEqual(expected_error_message, err_msg)
-    
+
     # EM-14
     def test_output_already_exist(self):
         output_path = os.path.join(
             self.general_output_dir, "already_existing_output.csv"
         )
-        expected_error_message = "{} already exists. Please specify a new file path".format(output_path)
+        expected_error_message = (
+            "{} already exists. Please specify a new file path".format(output_path)
+        )
 
-        with open(output_path,"w") as outfile:
+        with open(output_path, "w") as outfile:
             outfile.write("this output file already created")
 
         with self.assertRaises(ValueError) as cm:
             write_expression_output(
-                arg_output= output_path,
+                arg_output=output_path,
                 arg_delim=",",
                 arg_sql=False,
                 output_listdict_or_string=self.vizserver_data_mock_response["results"],
-                save_uncommon_delim_to_txt = False,
-                error_handler=self.common_value_error_handler
+                save_uncommon_delim_to_txt=False,
+                error_handler=self.common_value_error_handler,
             )
 
         err_msg = str(cm.exception).strip()
         self.assertEqual(expected_error_message, err_msg)
 
     def test_output_is_directory(self):
-        output_path = os.path.join(
-            self.general_output_dir, "directory"
+        output_path = os.path.join(self.general_output_dir, "directory")
+        expected_error_message = (
+            "{} is a directory. Please specify a new file path".format(output_path)
         )
-        expected_error_message = "{} is a directory. Please specify a new file path".format(output_path)
         os.mkdir(output_path)
         with self.assertRaises(ValueError) as cm:
             write_expression_output(
-                arg_output= output_path,
+                arg_output=output_path,
                 arg_delim=",",
                 arg_sql=False,
                 output_listdict_or_string=self.vizserver_data_mock_response["results"],
-                save_uncommon_delim_to_txt = False,
-                error_handler=self.common_value_error_handler
+                save_uncommon_delim_to_txt=False,
+                error_handler=self.common_value_error_handler,
             )
 
         err_msg = str(cm.exception).strip()
@@ -395,17 +508,15 @@ class TestDXExtractExpression(unittest.TestCase):
     @unittest.skip
     def test_incorrect_file_extension(self):
         expected_error_message = 'File extension ".tsv" does not match delimiter ","'
-        output_path = os.path.join(
-            self.general_output_dir, "wrong_extension.tsv"
-        )
+        output_path = os.path.join(self.general_output_dir, "wrong_extension.tsv")
         with self.assertRaises(ValueError) as cm:
             write_expression_output(
-                arg_output= output_path,
+                arg_output=output_path,
                 arg_delim=",",
                 arg_sql=False,
                 output_listdict_or_string=self.vizserver_data_mock_response["results"],
-                save_uncommon_delim_to_txt = False,
-                error_handler=self.common_value_error_handler
+                save_uncommon_delim_to_txt=False,
+                error_handler=self.common_value_error_handler,
             )
         err_msg = str(cm.exception).strip()
         self.assertEqual(expected_error_message, err_msg)
@@ -1067,7 +1178,7 @@ class TestDXExtractExpression(unittest.TestCase):
     def test_argparse_help_txt(self):
         expected_result = self.argparse_expression_help_message
         with open(expected_result) as f:
-            #lines = f.readlines()
+            # lines = f.readlines()
             file = f.read()
         process = subprocess.check_output("dx extract_assay expression -h", shell=True)
         help_output = process.decode()
@@ -1075,16 +1186,21 @@ class TestDXExtractExpression(unittest.TestCase):
         # In Python 3 self.assertEqual(file,help_output) passes,
         # However in Python 2 it fails due to some differences in where linebreaks appear in the text
         self.assertEqual(
-            file.replace(" ", "").replace("\n", ""), 
-            help_output.replace(" ", "").replace("\n", "")
+            file.replace(" ", "").replace("\n", ""),
+            help_output.replace(" ", "").replace("\n", ""),
         )
 
     #### Test --json-help
     def test_json_help_template(self):
-        process = subprocess.check_output("dx extract_assay expression --retrieve-expression fakepath --json-help", shell=True)
+        process = subprocess.check_output(
+            "dx extract_assay expression --retrieve-expression fakepath --json-help",
+            shell=True,
+        )
         self.assertIn(EXTRACT_ASSAY_EXPRESSION_JSON_TEMPLATE, process.decode())
-        self.assertIn("Additional descriptions of filtering keys and permissible values", process.decode())
-
+        self.assertIn(
+            "Additional descriptions of filtering keys and permissible values",
+            process.decode(),
+        )
 
 
 # Start the test

--- a/src/python/test/test_extract_expression.py
+++ b/src/python/test/test_extract_expression.py
@@ -290,18 +290,16 @@ class TestDXExtractExpression(unittest.TestCase):
             {
                 "feature_id": "ENST00000488147",
                 "sample_id": "sample_2",
-                "expression": 90,
+                "expression": 20,
             },
         ]
         expected_output = [
-            OrderedDict(
-                [
-                    ("sample_id", "sample_2"),
-                    ("ENST00000450305", 50),
-                    ("ENST00000456328", 90),
-                    ("ENST00000488147", 90),
-                ]
-            )
+            {
+                "ENST00000450305": 50,
+                "ENST00000456328": 90,
+                "ENST00000488147": 20,
+                "sample_id": "sample_2",
+            }
         ]
 
         transformed_results, colnames = expression_transform(vizserver_results)
@@ -322,19 +320,20 @@ class TestDXExtractExpression(unittest.TestCase):
             {
                 "feature_id": "ENST00000488147",
                 "sample_id": "sample_2",
-                "expression": 90,
+                "expression": 20,
             },
         ]
 
         expected_output = [
-            OrderedDict(
-                [
-                    ("sample_id", "sample_2"),
-                    ("ENST00000450305", 50),
-                    ("ENST00000488147", 90),
-                ]
-            ),
-            OrderedDict([("sample_id", "sample_1"), ("ENST00000456328", 90)]),
+            {
+                "ENST00000450305": 50,
+                "ENST00000488147": 20,
+                "sample_id": "sample_2",
+            },
+            {
+                "ENST00000456328": 90,
+                "sample_id": "sample_1",
+            },
         ]
 
         transformed_results, colnames = expression_transform(vizserver_results)
@@ -361,18 +360,20 @@ class TestDXExtractExpression(unittest.TestCase):
             {
                 "feature_id": "ENST00000488147",
                 "sample_id": "sample_2",
-                "expression": 90,
+                "expression": 20,
             },
         ]
         expected_output = [
-            OrderedDict(
-                [
-                    ("sample_id", "sample_2"),
-                    ("ENST00000450305", 50),
-                    ("ENST00000488147", 90),
-                ]
-            ),
-            OrderedDict([("sample_id", "sample_1"), ("ENST00000450305", 77),("ENST00000456328", 90)]),
+            {
+                "ENST00000450305": 50,
+                "ENST00000488147": 20,
+                "sample_id": "sample_2",
+            },
+            {
+                "ENST00000456328": 90,
+                "ENST00000450305": 77,
+                "sample_id": "sample_1",
+            },
         ]
 
         transformed_results, colnames = expression_transform(vizserver_results)
@@ -399,29 +400,23 @@ class TestDXExtractExpression(unittest.TestCase):
             {
                 "feature_id": "ENST00000488147",
                 "sample_id": "sample_2",
-                "expression": 90,
+                "expression": 20,
             },
         ]
 
         # The replace statement removes tabs(actually blocks of 4 spaces) that have been inserted
         # for readability in this python file
         expected_result = """sample_id,ENST00000450305,ENST00000456328,ENST00000488147
-                             sample_2,50,0,90
+                             sample_2,50,0,20
                              sample_1,77,90,0""".replace(
             " ", ""
         )
 
         transformed_results, colnames = expression_transform(vizserver_results)
-        output_path = os.path.join(
-            self.general_output_dir, "exp_transform_compat.csv"
-        )
+        output_path = os.path.join(self.general_output_dir, "exp_transform_compat.csv")
         # Generate the formatted output file
         write_expression_output(
-            output_path,
-            ",",
-            False,
-            transformed_results,
-            colnames=colnames
+            output_path, ",", False, transformed_results, colnames=colnames
         )
 
         with open(output_path, "r") as infile:

--- a/src/python/test/test_extract_expression.py
+++ b/src/python/test/test_extract_expression.py
@@ -334,18 +334,20 @@ class TestDXExtractExpression(unittest.TestCase):
 
         expected_output = [
             {
+                "sample_id": "sample_2",
                 "ENST00000450305": 50,
                 "ENST00000488147": 20,
-                "sample_id": "sample_2",
+                "ENST00000456328": "None",
             },
             {
-                "ENST00000456328": 90,
                 "sample_id": "sample_1",
+                "ENST00000456328": 90,
+                "ENST00000450305": "None",
+                "ENST00000488147": "None",
             },
         ]
 
         transformed_results, colnames = expression_transform(vizserver_results)
-
         self.assertEqual(expected_output, transformed_results)
 
     def test_two_sample_feat_id_overlap_exp_trans(self):
@@ -373,19 +375,20 @@ class TestDXExtractExpression(unittest.TestCase):
         ]
         expected_output = [
             {
+                "sample_id": "sample_2",
                 "ENST00000450305": 50,
                 "ENST00000488147": 20,
-                "sample_id": "sample_2",
+                "ENST00000456328": "None",
             },
             {
-                "ENST00000456328": 90,
-                "ENST00000450305": 77,
                 "sample_id": "sample_1",
+                "ENST00000450305": 77,
+                "ENST00000456328": 90,
+                "ENST00000488147": "None",
             },
         ]
 
         transformed_results, colnames = expression_transform(vizserver_results)
-
         self.assertEqual(expected_output, transformed_results)
 
     def test_exp_transform_output_compatibility(self):


### PR DESCRIPTION
Hi folks,
This PR adds a function which converts the regular vizserver output into a "wider" format, with one column for sample ID, and a column for each feature_id, with the contents of those columns being the expression value.  I'm going to make a few quick unit tests for this, just so I can be sure it works on input with multiple samples, especially if the samples have overlapping feature ids.
Thanks,
Joe