### PR TITLE
COMPUTE-219 Remove dxpy dependencies requests and cryptography

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 
 ## Unreleased
 
+### Added
+
+* certifi dxpy dependency
+
+### Changed
+
+* urllib3 dxpy dependency to >=1.26.18,<2.2
+
+### Removed
+
+* requests, cryptography as dependencies of dxpy
+
 ## [365.0] - beta
 
 ### Changed

--- a/src/python/doc/dxpy.rst
+++ b/src/python/doc/dxpy.rst
@@ -16,14 +16,6 @@ This Python 2.7 package includes three key modules:
 
 It has the following external dependencies:
 
-* :mod:`requests`: To install on Linux, use ``sudo pip install
-  requests``. Other installation options can be found at
-  http://docs.python-requests.org/en/latest/user/install
-
-* :mod:`futures`: To install on Linux, use ``sudo pip install futures``.
-  Other installation options can be found at
-  http://code.google.com/p/pythonfutures/
-
 
 Package Configuration
 ---------------------

--- a/src/python/doc/dxpy.rst
+++ b/src/python/doc/dxpy.rst
@@ -14,8 +14,6 @@ This package includes three key modules:
 * :mod:`dxpy.exceptions`: Contains exceptions used in the other
   :mod:`dxpy` modules.
 
-It has the following external dependencies:
-
 
 Package Configuration
 ---------------------

--- a/src/python/doc/dxpy.rst
+++ b/src/python/doc/dxpy.rst
@@ -1,7 +1,7 @@
 :mod:`dxpy` Package
 ===================
 
-This Python 2.7 package includes three key modules:
+This package includes three key modules:
 
 * :mod:`dxpy.bindings`: Contains useful Pythonic bindings for
   interacting with remote objects via the DNAnexus API server. For

--- a/src/python/dxpy/__init__.py
+++ b/src/python/dxpy/__init__.py
@@ -134,7 +134,6 @@ import errno
 import math
 import socket
 import threading
-import requests
 import certifi
 from collections import namedtuple
 

--- a/src/python/dxpy/__init__.py
+++ b/src/python/dxpy/__init__.py
@@ -648,10 +648,6 @@ def DXHTTPRequest(resource, data, method='POST', headers=None, auth=True,
                         raise exceptions.BadJSONInReply("Invalid JSON received from server", response.status)
                     try:
                         error_class = getattr(exceptions, content["error"]["type"], exceptions.DXAPIError)
-                        print(content["error"]["type"])
-                        print(error_class)
-                        err_ex = error_class(content, response.status, time_started, req_id)
-                        print(err_ex)
                     except (KeyError, AttributeError, TypeError):
                         raise exceptions.HTTPErrorWithContent("Appropriate error class not found. [HTTPCode=%s]" % response.status, content)
                     raise error_class(content, response.status, time_started, req_id)

--- a/src/python/dxpy/__init__.py
+++ b/src/python/dxpy/__init__.py
@@ -20,8 +20,7 @@ the following sources in order of decreasing priority:
 
 1. Environment variables
 2. Values stored in ``~/.dnanexus_config/environment``
-3. Values stored in ``/opt/dnanexus/environment``
-4. Hardcoded defaults
+3. Hardcoded defaults
 
 The bindings are configured by the following environment variables:
 
@@ -272,7 +271,7 @@ def _get_pool_manager(verify, cert_file, key_file, ssl_context=None):
                          cert_file=cert_file,
                          key_file=key_file,
                          ssl_context=ssl_context,
-                         ca_certs=verify or os.environ.get('DX_CA_CERT') or requests.certs.where())
+                         ca_certs=verify or os.environ.get('DX_CA_CERT') or certifi.where())
         if verify is False or os.environ.get('DX_CA_CERT') == 'NOVERIFY':
             pool_args.update(cert_reqs=ssl.CERT_NONE, ca_certs=None)
             urllib3.disable_warnings()
@@ -479,13 +478,11 @@ def DXHTTPRequest(resource, data, method='POST', headers=None, auth=True,
     :type auth: tuple, object, True (default), or None
     :param timeout: HTTP request timeout, in seconds
     :type timeout: float
-    :param config: *config* value to pass through to :meth:`requests.request`
-    :type config: dict
     :param use_compression: Deprecated
     :type use_compression: string or None
     :param jsonify_data: If True, *data* is converted from a Python list or dict to a JSON string
     :type jsonify_data: boolean
-    :param want_full_response: If True, the full :class:`requests.Response` object is returned (otherwise, only the content of the response body is returned)
+    :param want_full_response: If True, the full :class:`urllib3.response.HTTPResponse` object is returned (otherwise, only the content of the response body is returned)
     :type want_full_response: boolean
     :param decode_response_body: If True (and *want_full_response* is False), the response body is decoded and, if it is a JSON string, deserialized. Otherwise, the response body is uncompressed if transport compression is on, and returned raw.
     :type decode_response_body: boolean
@@ -506,9 +503,9 @@ def DXHTTPRequest(resource, data, method='POST', headers=None, auth=True,
 
     :type always_retry: boolean
     :returns: Response from API server in the format indicated by *want_full_response* and *decode_response_body*.
-    :raises: :exc:`exceptions.DXAPIError` or a subclass if the server returned a non-200 status code; :exc:`requests.exceptions.HTTPError` if an invalid response was received from the server; or :exc:`requests.exceptions.ConnectionError` if a connection cannot be established.
+    :raises: :exc:`exceptions.DXAPIError` or a subclass if the server returned a non-200 status code; :exc:`urllib3.exceptions.HTTPError` if an invalid response was received from the server; or :exc:`urllib3.exceptions.ConnectionError` if a connection cannot be established.
 
-    Wrapper around :meth:`requests.request()` that makes an HTTP
+    Wrapper around :meth:`urllib3.request()` that makes an HTTP
     request, inserting authentication headers and (by default)
     converting *data* to JSON.
 

--- a/src/python/dxpy/bindings/dxfile.py
+++ b/src/python/dxpy/bindings/dxfile.py
@@ -658,7 +658,7 @@ class DXFile(DXDataObject):
         :type display_progress: boolean
         :param report_progress_fn: Optional: a function to call that takes in two arguments (self, # bytes transmitted)
         :type report_progress_fn: function or None
-        :raises: :exc:`dxpy.exceptions.DXFileError` if *index* is given and is not in the correct range, :exc:`requests.exceptions.HTTPError` if upload fails
+        :raises: :exc:`dxpy.exceptions.DXFileError` if *index* is given and is not in the correct range, :exc:`urllib3.exceptions.HTTPError` if upload fails
 
         Uploads the data in *data* as part number *index* for the
         associated file. If no value for *index* is given, *index*

--- a/src/python/dxpy/cli/cp.py
+++ b/src/python/dxpy/cli/cp.py
@@ -24,9 +24,8 @@ command-line client.
 from __future__ import print_function, unicode_literals, division, absolute_import
 
 import dxpy
-import requests
 from ..utils.resolver import (resolve_existing_path, resolve_path, is_hashid, get_last_pos_of_char)
-from ..exceptions import (err_exit, DXCLIError)
+from ..exceptions import (err_exit, DXCLIError, ResourceNotFound)
 from . import try_call
 from dxpy.utils.printing import (fill)
 
@@ -47,8 +46,8 @@ def cp_to_noexistent_destination(args, dest_path, dx_dest, dest_proj):
     dest_name = dest_path[last_slash_pos + 1:].replace('\/', '/')
     try:
         dx_dest.list_folder(folder=dest_folder, only='folders')
-    except dxpy.DXAPIError as details:
-        if details.code == requests.codes['not_found']:
+    except dxpy.DXAPIError as e:
+        if isinstance(e, ResourceNotFound):
             raise DXCLIError('The destination folder does not exist')
         else:
             raise

--- a/src/python/dxpy/exceptions.py
+++ b/src/python/dxpy/exceptions.py
@@ -25,8 +25,7 @@ import json
 import traceback
 import errno
 import socket
-import requests
-from requests.exceptions import HTTPError
+from urllib3.exceptions import HTTPError
 
 import dxpy
 from .compat import USING_PYTHON2
@@ -238,12 +237,12 @@ def exit_with_exc_info(code=1, message='', print_tb=False, exception=None):
         sys.stderr.write('\n')
     sys.exit(code)
 
-network_exceptions = (requests.packages.urllib3.exceptions.ProtocolError,
-                      requests.packages.urllib3.exceptions.NewConnectionError,
-                      requests.packages.urllib3.exceptions.DecodeError,
-                      requests.packages.urllib3.exceptions.ConnectTimeoutError,
-                      requests.packages.urllib3.exceptions.ReadTimeoutError,
-                      requests.packages.urllib3.connectionpool.HTTPException,
+network_exceptions = (urllib3.exceptions.ProtocolError,
+                      urllib3.exceptions.NewConnectionError,
+                      urllib3.exceptions.DecodeError,
+                      urllib3.exceptions.ConnectTimeoutError,
+                      urllib3.exceptions.ReadTimeoutError,
+                      urllib3.connectionpool.HTTPException,
                       urllib3.exceptions.SSLError,
                       ssl.SSLError,
                       HTTPError,

--- a/src/python/dxpy/packages/__init__.py
+++ b/src/python/dxpy/packages/__init__.py
@@ -1,3 +1,0 @@
-import sys
-import requests
-sys.modules[__name__ + '.requests'] = sys.modules['requests']

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -21,7 +21,6 @@ from __future__ import print_function, unicode_literals, division, absolute_impo
 
 import os, sys, datetime, getpass, collections, re, json, argparse, copy, hashlib, io, time, subprocess, glob, logging, functools
 
-import requests
 import csv
 
 logging.basicConfig(level=logging.INFO)
@@ -1139,9 +1138,10 @@ def describe(args):
                 print(get_result_str())
                 print_desc(desc, args.verbose)
             found_match = True
-        except dxpy.DXAPIError as details:
-            if details.code != requests.codes.not_found:
-                raise
+        except dxpy.DXAPIError as e:
+            if not isinstance(e, ResourceNotFound):
+                raise e
+
         return found_match
 
     def find_global_executable(json_output, args):
@@ -1191,9 +1191,9 @@ def describe(args):
                     # access.
                     dxpy.api.project_list_folder(dxpy.WORKSPACE_ID)
                     json_input['project'] = dxpy.WORKSPACE_ID
-                except dxpy.DXAPIError as details:
-                    if details.code != requests.codes.not_found:
-                        raise
+                except dxpy.DXAPIError as e:
+                    if not isinstance(e, ResourceNotFound):
+                        raise e
 
         if is_job_id(args.path):
             if args.verbose:
@@ -1261,9 +1261,9 @@ def describe(args):
                     else:
                         print(get_result_str())
                         print_desc(desc, args.verbose)
-                except dxpy.DXAPIError as details:
-                    if details.code != requests.codes.not_found:
-                        raise
+                except dxpy.DXAPIError as e:
+                    if not isinstance(e, ResourceNotFound):
+                        raise e
             elif is_container_id(args.path):
                 try:
                     desc = dxpy.api.project_describe(args.path, json_input)
@@ -1275,9 +1275,9 @@ def describe(args):
                     else:
                         print(get_result_str())
                         print_desc(desc, args.verbose)
-                except dxpy.DXAPIError as details:
-                    if details.code != requests.codes.not_found:
-                        raise
+                except dxpy.DXAPIError as e:
+                    if not isinstance(e, ResourceNotFound):
+                        raise e
 
         # Found data object or is an id
         if entity_results is not None:
@@ -1317,9 +1317,9 @@ def describe(args):
                     else:
                         print(get_result_str())
                         print_desc(desc, args.verbose)
-                except dxpy.DXAPIError as details:
-                    if details.code != requests.codes.not_found:
-                        raise
+                except dxpy.DXAPIError as e:
+                    if not isinstance(e, ResourceNotFound):
+                        raise e
             elif args.path.startswith('org-') or args.path.startswith('team-'):
                 # Org or team
                 try:
@@ -1332,9 +1332,9 @@ def describe(args):
                     else:
                         print(get_result_str())
                         print_desc(desc, args.verbose)
-                except dxpy.DXAPIError as details:
-                    if details.code != requests.codes.not_found:
-                        raise
+                except dxpy.DXAPIError as e:
+                    if not isinstance(e, ResourceNotFound):
+                        raise e
 
         if args.json:
             if args.multi:

--- a/src/python/dxpy/scripts/dx_build_app.py
+++ b/src/python/dxpy/scripts/dx_build_app.py
@@ -21,7 +21,7 @@ from __future__ import print_function, unicode_literals, division, absolute_impo
 
 import logging
 logging.basicConfig(level=logging.WARNING)
-logging.getLogger('requests.packages.urllib3.connectionpool').setLevel(logging.ERROR)
+logging.getLogger('urllib3.connectionpool').setLevel(logging.ERROR)
 
 import os, sys, json, subprocess, argparse
 import platform

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -3,8 +3,8 @@ argcomplete>=1.9.4,<2.0.0; python_version < "3.10"
 websocket-client==0.54.0
 python-dateutil>=2.5
 psutil>=5.9.3
-requests>=2.8.0,<2.28; python_version < "3.7"
-requests>=2.8.0,<2.29; python_version >= "3.7"
+certifi
+urllib3>=1.26.18,<2.1.0
 cryptography>=3.4.2,<41; python_version > "3.5"
 pyreadline3==3.4.1; sys_platform == "win32" and python_version >= "3.5"
 colorama==0.4.4; sys_platform == "win32" and python_version >= "3.5" and python_version < "3.7"

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -4,7 +4,7 @@ websocket-client==0.54.0
 python-dateutil>=2.5
 psutil>=5.9.3
 certifi
-urllib3>=1.26.18,<2.1.0
+urllib3>=1.26.18,<2.2
 pyreadline3==3.4.1; sys_platform == "win32" and python_version >= "3.5"
 colorama==0.4.4; sys_platform == "win32" and python_version >= "3.5" and python_version < "3.7"
 colorama>=0.4.4,<=0.4.6; sys_platform == "win32" and python_version >= "3.7"

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -5,7 +5,6 @@ python-dateutil>=2.5
 psutil>=5.9.3
 certifi
 urllib3>=1.26.18,<2.1.0
-cryptography>=3.4.2,<41; python_version > "3.5"
 pyreadline3==3.4.1; sys_platform == "win32" and python_version >= "3.5"
 colorama==0.4.4; sys_platform == "win32" and python_version >= "3.5" and python_version < "3.7"
 colorama>=0.4.4,<=0.4.6; sys_platform == "win32" and python_version >= "3.7"

--- a/src/python/requirements_test.txt
+++ b/src/python/requirements_test.txt
@@ -6,3 +6,4 @@ pytest-timeout==2.1.0
 parameterized==0.8.1
 pandas==1.3.5; python_version>='3.7'
 pandas>=0.23.3,<=0.25.3; python_version>='3.5.3' and python_version<'3.7'
+requests

--- a/src/python/test/test_dx_completion.py
+++ b/src/python/test/test_dx_completion.py
@@ -151,7 +151,7 @@ class TestDXTabCompletion(unittest.TestCase):
     def test_project_completion(self):
         self.ids_to_destroy.append(dxpy.api.project_new({"name": "to select"})['id'])
         self.assert_completion("dx select to", "to select\\:")
-        self.assert_completion("dx select to\ sele", "to select\\:")
+        self.assert_completion(r"dx select to\ sele", "to select\\:")
 
     def test_completion_with_bad_current_project(self):
         os.environ['DX_PROJECT_CONTEXT_ID'] = ''

--- a/src/python/test/test_dxasset.py
+++ b/src/python/test/test_dxasset.py
@@ -102,7 +102,7 @@ class TestDXBuildAsset(DXTestCase):
 
     def test_build_asset_with_malformed_dxasset_json(self):
         asset_dir = self.write_asset_directory("asset_with_malform_json", "{")
-        with self.assertSubprocessFailure(stderr_regexp='Could not parse dxasset\.json', exit_code=1):
+        with self.assertSubprocessFailure(stderr_regexp=r'Could not parse dxasset\.json', exit_code=1):
             run("dx build_asset " + asset_dir)
 
     @unittest.skipUnless(testutil.TEST_RUN_JOBS, 'skipping test that would run jobs')

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -4838,7 +4838,7 @@ class TestDXClientGlobalWorkflow(DXTestCaseBuildWorkflows):
                                                      readme_content="Workflow Readme Please")
 
         error_msg = "The applet {} is not available".format(self.test_applet_id)
-        with self.assertRaisesRegexp(DXCalledProcessError, error_msg):
+        with self.assertRaisesRegex(DXCalledProcessError, error_msg):
             run("dx build --globalworkflow --region azure:westus --json " + workflow_dir)
 
     @unittest.skipUnless(testutil.TEST_ISOLATED_ENV,
@@ -7442,7 +7442,7 @@ class TestDXBuildWorkflow(DXTestCaseBuildWorkflows):
         # will be enabled in the region of the project context
         # (if regionalOptions or --region are not set)
         env = override_environment(DX_PROJECT_CONTEXT_ID='project-B00000000000000000000000')
-        with self.assertRaisesRegexp(subprocess.CalledProcessError, "ResourceNotFound"):
+        with self.assertRaisesRegex(subprocess.CalledProcessError, "ResourceNotFound"):
             run("dx build --create-globalworkflow --json " + workflow_dir, env=env)
 
     # this is NOT a global workflow

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -26,6 +26,7 @@ import subprocess
 import platform
 import pytest
 import re
+import certifi
 
 from urllib3.exceptions import SSLError
 
@@ -2507,7 +2508,7 @@ class TestHTTPResponses(testutil.DXTestCaseCompat):
     def test_bad_host(self):
         # Verify that the exception raised is one that dxpy would
         # consider to be retryable, but truncate the actual retry loop
-        with self.assertRaises(requests.packages.urllib3.exceptions.NewConnectionError) as exception_cm:
+        with self.assertRaises(urllib3.exceptions.NewConnectionError) as exception_cm:
             dxpy.DXHTTPRequest('http://doesnotresolve.dnanexus.com/', {}, prepend_srv=False, always_retry=False,
                                max_retries=1)
         self.assertTrue(dxpy._is_retryable_exception(exception_cm.exception))
@@ -2515,7 +2516,7 @@ class TestHTTPResponses(testutil.DXTestCaseCompat):
     def test_connection_refused(self):
         # Verify that the exception raised is one that dxpy would
         # consider to be retryable, but truncate the actual retry loop
-        with self.assertRaises(requests.packages.urllib3.exceptions.NewConnectionError) as exception_cm:
+        with self.assertRaises(.urllib3.exceptions.NewConnectionError) as exception_cm:
             # Connecting to a port on which there is no server running
             dxpy.DXHTTPRequest('http://localhost:20406', {}, prepend_srv=False, always_retry=False, max_retries=1)
         self.assertTrue(dxpy._is_retryable_exception(exception_cm.exception))
@@ -2530,8 +2531,8 @@ class TestHTTPResponses(testutil.DXTestCaseCompat):
     # pyopenssl to requirements_test.txt - see DEVEX-2263 for details.
     def test_ssl_options(self):
         dxpy.DXHTTPRequest("/system/whoami", {}, verify=False)
-        dxpy.DXHTTPRequest("/system/whoami", {}, verify=requests.certs.where())
-        dxpy.DXHTTPRequest("/system/whoami", {}, verify=requests.certs.where(), cert_file=None, key_file=None)
+        dxpy.DXHTTPRequest("/system/whoami", {}, verify=certifi.where())
+        dxpy.DXHTTPRequest("/system/whoami", {}, verify=certifi.where(), cert_file=None, key_file=None)
         with self.assertRaises(TypeError):
             dxpy.DXHTTPRequest("/system/whoami", {}, cert="nonexistent")
         if dxpy.APISERVER_PROTOCOL == "https":

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -28,7 +28,7 @@ import pytest
 import re
 import certifi
 
-from urllib3.exceptions import SSLError
+from urllib3.exceptions import SSLError, NewConnectionError
 
 import dxpy
 import dxpy_testutil as testutil
@@ -2508,7 +2508,7 @@ class TestHTTPResponses(testutil.DXTestCaseCompat):
     def test_bad_host(self):
         # Verify that the exception raised is one that dxpy would
         # consider to be retryable, but truncate the actual retry loop
-        with self.assertRaises(urllib3.exceptions.NewConnectionError) as exception_cm:
+        with self.assertRaises(NewConnectionError) as exception_cm:
             dxpy.DXHTTPRequest('http://doesnotresolve.dnanexus.com/', {}, prepend_srv=False, always_retry=False,
                                max_retries=1)
         self.assertTrue(dxpy._is_retryable_exception(exception_cm.exception))
@@ -2516,7 +2516,7 @@ class TestHTTPResponses(testutil.DXTestCaseCompat):
     def test_connection_refused(self):
         # Verify that the exception raised is one that dxpy would
         # consider to be retryable, but truncate the actual retry loop
-        with self.assertRaises(.urllib3.exceptions.NewConnectionError) as exception_cm:
+        with self.assertRaises(NewConnectionError) as exception_cm:
             # Connecting to a port on which there is no server running
             dxpy.DXHTTPRequest('http://localhost:20406', {}, prepend_srv=False, always_retry=False, max_retries=1)
         self.assertTrue(dxpy._is_retryable_exception(exception_cm.exception))

--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -27,8 +27,7 @@ import platform
 import pytest
 import re
 
-import requests
-from requests.packages.urllib3.exceptions import SSLError
+from urllib3.exceptions import SSLError
 
 import dxpy
 import dxpy_testutil as testutil

--- a/src/python/test/test_dxpy_utils.py
+++ b/src/python/test/test_dxpy_utils.py
@@ -121,6 +121,7 @@ class TestDXUtils(unittest.TestCase):
                          '{"a": [{"b": {"$dnanexus_link": "file-xxxxxxxxxxxxxxxxxxxxxxxx"}}, {"$dnanexus_link": "record-rrrrrrrrrrrrrrrrrrrrrrrr"}]}')
 
 class TestEDI(DXExecDependencyInstaller):
+    __test__ = False
     def __init__(self, *args, **kwargs):
         self.command_log, self.message_log = [], []
         DXExecDependencyInstaller.__init__(self, *args, **kwargs)
@@ -223,7 +224,7 @@ class TestDXExecDependsUtils(testutil.DXTestCaseCompat):
         self.assertNotRegex("\n".join(edi.command_log), "w00t")
         for name in "w00t", "f1":
             assert_log_contains(edi,
-                                "Skipping dependency {} because it is inactive in stage \(function\) main".format(name))
+                                r"Skipping dependency {} because it is inactive in stage \(function\) main".format(name))
 
         edi = self.get_edi({"execDepends": [{"name": "git", "stages": ["foo", "bar"]}]},
                            job_desc={"function": "foo"})


### PR DESCRIPTION
Remove both `requests` and `cryptography` from dxpy requirements. 
Fixed pytest warnings and removed some python2 specific code. 