### PR TITLE
TIP-3590: Remove snowflake interceptor prefix

### DIFF
--- a/src/python/dxpy/utils/sfconnector.py
+++ b/src/python/dxpy/utils/sfconnector.py
@@ -18,7 +18,7 @@ class DXSFConnector(ABC):
         'warehouse': "dummy_warehouse",
         'role': "default",
         'host': "{}".format(dxpy.APISERVER_HOST),
-        'port': "{}/DB/SF-ROUTE".format(dxpy.APISERVER_PORT),
+        'port': "{}".format(dxpy.APISERVER_PORT),
         'protocol': dxpy.APISERVER_PROTOCOL
     }
 

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -110,9 +110,9 @@ setup(
                    "pandas>=0.23.3,<=0.25.3; python_version>='3.5.3' and python_version<'3.7'",
                    "pandas>=0.23.3,< 0.25.0; python_version<'3.5.3'"],
         'xattr': ["xattr==0.10.1; sys_platform == 'linux2' or sys_platform == 'linux'"],
-        'snowflake': ["cryptography==39.0.0; python_version>='3.7'",
-                      "pyOpenSSL==22.0.0; python_version>='3.7'", # officially 22.0.0
-                      "snowflake-connector-python==3.0.0; python_version>='3.7'"
+        'snowflake': ["cryptography==40.0.2; python_version>='3.7'",
+                      "pyOpenSSL==23.3.0; python_version>='3.7'", # officially 22.0.0
+                      "snowflake-connector-python==3.5.0; python_version>='3.7'"
                       ]
     },
     tests_require = test_dependencies,


### PR DESCRIPTION
This PR removes the snowflake interceptor prefix in the snowflake connector's connection config. Additionally, I've fixed the dependency versions due to some conflicts with those.