### PR TITLE
SCIPROD-1870 cliexpress insufficient permissions traceback suppression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 
 ## Unreleased
 
+* Suppressing traceback when extract_assay expression attempts to access a dataset it does not have access to 
+
 ### Fixed
 
 * Improved error messaging for `dx extract_assay expression`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 ### Fixed
 
 * Improved error messaging for `dx extract_assay expression`
-* Suppressing traceback when extract_assay expression attempts to access a dataset it does not have access to 
+* Suppressing traceback when `dx extract_assay expression` attempts to access a dataset it does not have access to 
 
 ## [366.0] - beta
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,10 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 
 ## Unreleased
 
-* Suppressing traceback when extract_assay expression attempts to access a dataset it does not have access to 
-
 ### Fixed
 
 * Improved error messaging for `dx extract_assay expression`
+* Suppressing traceback when extract_assay expression attempts to access a dataset it does not have access to 
 
 ## [366.0] - beta
 

--- a/src/python/dxpy/bindings/apollo/vizclient.py
+++ b/src/python/dxpy/bindings/apollo/vizclient.py
@@ -23,9 +23,9 @@ class VizClient(object):
                 else:
                     err_message = response["error"]
                 self.error_handler(str(err_message))
+            return response
         except Exception as details:
             self.error_handler(str(details))
-        return response
 
     def get_data(self, payload, record_id):
         resource_url = "{}/data/3.0/{}/raw".format(self.url, record_id)


### PR DESCRIPTION
Hi folks,
Super simple change that prevents the "variable referenced before assignment" traceback that was being shown to the user when there is insufficient permissions for the dataset.  Moving the return inside the try block means that it will only run if hte response variable has actually been set.
Thanks,
Joe