### PR TITLE
SCIPROD-1892 [GENOMOD] remove hom-alt genotype type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 * Python 3.12 support
 * `--nextflow-pipeline-params` for `dx build --nextflow --cache-docker`
 * `dx build --nextflow --cache-docker` supports the `--profile` parameter to cache images associated with specific profile 
+* additional regional resources can be specified in dxworkflow.json or using `--extra-args` when `dx build` global workflows 
 
 ### Fixed
 

--- a/src/python/dxpy/app_builder.py
+++ b/src/python/dxpy/app_builder.py
@@ -503,7 +503,8 @@ def upload_applet(src_dir, uploaded_resources, check_name_collisions=True, overw
 
     # -----
     # Override various fields from the pristine dxapp.json
-
+    # TODO: should merge extra args into app spec before processing
+    #       see line https://github.com/dnanexus/dx-toolkit/blob/f2ebe53a9e49b3213f8252e7ac1cd35d99913333/src/python/dxpy/app_builder.py#L616
     # Carry region-specific values from regionalOptions into the main
     # runSpec
     applet_spec["runSpec"].setdefault("bundledDepends", [])

--- a/src/python/dxpy/cli/dataset_utilities.py
+++ b/src/python/dxpy/cli/dataset_utilities.py
@@ -750,7 +750,14 @@ def extract_assay_germline(args):
                 comment_fill('Filters and respective definitions', comment_string='# ') + '\n#\n' +
                 comment_fill('allele_id: ID(s) of one or more alleles for which sample genotypes will be returned. If multiple values are provided, any samples having at least one allele that match any of the values specified will be listed. For example, ["1_1000_A_T", "1_1010_C_T"], will search for samples with at least one allele matching either "1_1000_A_T" or "1_1010_C_T". String match is case insensitive.') + '\n#\n' +
                 comment_fill('sample_id: Optional, one or more sample IDs for which sample genotypes will be returned. If the provided object is a cohort, this further intersects the sample ids. If a user has a list of samples more than 1,000, it is recommended to use a cohort id containing all the samples.') + '\n#\n' +
-                comment_fill('genotype_type: Optional, one or more genotype types for which sample genotype types will be returned. One of: ref (homozygous for the reference allele e.g. 0/0), het-ref (heterozygous for the ref allele and alt allele e.g. 0/1), hom (homozygous for the non-ref allele e.g. 1/1), het-alt (heterozygous with two distinct alt alleles e.g. 1/2), half (only one alt allele is known, second allele is unknown e.g. ./1), no-call (both alleles are unknown e.g. ./.).') + '\n#\n' +
+                comment_fill('genotype_type: Optional, one or more genotype types for which sample genotype types will be returned.') + '\n' +
+                comment_fill('One of:') + '\n' +
+                comment_fill('\tref\t(homozygous for the reference allele\t\t\te.g. 0/0)') + '\n' +
+                comment_fill('\thet-ref\t(heterozygous for the ref allele and alt allele\t\te.g. 0/1)') + '\n' +
+                comment_fill('\thom\t(homozygous for the non-ref allele\t\t\te.g. 1/1)') + '\n' +
+                comment_fill('\thet-alt\t(heterozygous with two distinct alt alleles\t\te.g. 1/2)') + '\n' +
+                comment_fill('\thalf\t(only one alt allele is known, second allele is unknown\te.g. ./1)') + '\n' +
+                comment_fill('\tno-call\t(both alleles are unknown\t\t\t\te.g. ./.)') + '\n#\n' +
                 comment_fill('JSON filter template for --retrieve-genotype', comment_string='# ') + '\n' +
                 '{\n  "sample_id": ["s1", "s2"],\n  "allele_id": ["1_1000_A_T","2_1000_G_C"],\n  "genotype_type": ["ref", "het-ref", "hom", "het-alt", "half", "no-call"]\n}'
             )

--- a/src/python/dxpy/cli/dataset_utilities.py
+++ b/src/python/dxpy/cli/dataset_utilities.py
@@ -750,9 +750,9 @@ def extract_assay_germline(args):
                 comment_fill('Filters and respective definitions', comment_string='# ') + '\n#\n' +
                 comment_fill('allele_id: ID(s) of one or more alleles for which sample genotypes will be returned. If multiple values are provided, any samples having at least one allele that match any of the values specified will be listed. For example, ["1_1000_A_T", "1_1010_C_T"], will search for samples with at least one allele matching either "1_1000_A_T" or "1_1010_C_T". String match is case insensitive.') + '\n#\n' +
                 comment_fill('sample_id: Optional, one or more sample IDs for which sample genotypes will be returned. If the provided object is a cohort, this further intersects the sample ids. If a user has a list of samples more than 1,000, it is recommended to use a cohort id containing all the samples.') + '\n#\n' +
-                comment_fill('genotype_type: Optional, one or more genotype types for which sample genotype types will be returned. One of: hom-alt (homozygous for the non-ref allele), het-ref (heterozygous with a ref allele and alt allele), het-alt (heterozygous with two distinct alt alleles), half (only one alt allele is known, second allele is unknown).') + '\n#\n' +
+                comment_fill('genotype_type: Optional, one or more genotype types for which sample genotype types will be returned. One of: ref (homozygous for the reference allele e.g. 0/0), het-ref (heterozygous for the ref allele and alt allele e.g. 0/1), hom (homozygous for the non-ref allele e.g. 1/1), het-alt (heterozygous with two distinct alt alleles e.g. 1/2), half (only one alt allele is known, second allele is unknown e.g. ./1), no-call (both alleles are unknown e.g. ./.).') + '\n#\n' +
                 comment_fill('JSON filter template for --retrieve-genotype', comment_string='# ') + '\n' +
-                '{\n  "sample_id": ["s1", "s2"],\n  "allele_id": ["1_1000_A_T","2_1000_G_C"],\n  "genotype_type": ["het-ref", "hom-alt"]\n}'
+                '{\n  "sample_id": ["s1", "s2"],\n  "allele_id": ["1_1000_A_T","2_1000_G_C"],\n  "genotype_type": ["ref", "het-ref", "hom", "het-alt", "half", "no-call"]\n}'
             )
             sys.exit(0)
 

--- a/src/python/dxpy/cli/dataset_utilities.py
+++ b/src/python/dxpy/cli/dataset_utilities.py
@@ -849,10 +849,6 @@ def extract_assay_germline(args):
                 except Exception:
                         err_exit("Failed to find the table, {}, in the generated SQL".format(additional_descriptor_info["genotype_type_table"]), 
                                  expected_exceptions=(AttributeError,))
-                substr = "`" + geno_table + "`.`type`"
-                sql_results = sql_results.replace(
-                    substr, "REPLACE(`" + geno_table + "`.`type`, 'hom', 'hom-alt')", 1
-                )
 
             if print_to_stdout:
                 print(sql_results)

--- a/src/python/dxpy/cli/dataset_utilities.py
+++ b/src/python/dxpy/cli/dataset_utilities.py
@@ -857,10 +857,6 @@ def extract_assay_germline(args):
                     print(sql_results, file=sql_file)
         else:
             resp_raw = raw_api_call(resp, payload)
-            if args.retrieve_genotype:
-                for r in resp_raw["results"]:
-                    if r["genotype_type"] == "hom":
-                        r["genotype_type"] = "hom-alt"
 
             def sort_variant(d):
                 chrom, pos = d["allele_id"].split("_")[:2]

--- a/src/python/dxpy/dx_extract_utils/filter_to_payload.py
+++ b/src/python/dxpy/dx_extract_utils/filter_to_payload.py
@@ -1,10 +1,9 @@
 import json
 
-from ..exceptions import err_exit, ResourceNotFound
+from ..exceptions import err_exit
 from .input_validation import validate_filter
 import os
 import dxpy
-import subprocess
 from .retrieve_bins import retrieve_bins
 
 extract_utils_basepath = os.path.join(
@@ -73,13 +72,10 @@ def basic_filter(
         values = int(values)
 
     # Check for special cases where the user-input values need to be changed before creating payload
-    # Case 1: genotype filter, genotype_type field, hom changes to hom-alt
-    if table == "genotype" and friendly_name == "genotype_type":
-        values = [x if x != "hom-alt" else "hom" for x in values]
-    # Case 2: Some fields need to be changed to upper case
+    # Case 1: Some fields need to be changed to upper case
     if friendly_name in ["gene_id", "feature_id", "putative_impact"]:
         values = [x.upper() for x in values]
-    # Case 3: remove duplicate rsid values
+    # Case 2: remove duplicate rsid values
     if table == "allele" and friendly_name == "rsid":
         values = list(set(values))
 

--- a/src/python/dxpy/dx_extract_utils/input_validation.py
+++ b/src/python/dxpy/dx_extract_utils/input_validation.py
@@ -191,5 +191,5 @@ def validate_filter(filter, filter_type):
                     err_exit(malformed_filter.format("genotype_type") +"\nvalue {} is not a valid genotype_type".format(item))
 
             # Check for too many values given
-            if len(filter["genotype_type"]) > 4:
+            if len(filter["genotype_type"]) > 6:
                 err_exit(maxitem_message.format("genotype_type", 4))

--- a/src/python/dxpy/dx_extract_utils/input_validation.py
+++ b/src/python/dxpy/dx_extract_utils/input_validation.py
@@ -1,4 +1,3 @@
-import json
 import sys
 from ..exceptions import err_exit
 
@@ -188,7 +187,7 @@ def validate_filter(filter, filter_type):
 
             # Check against allowed values
             for item in filter["genotype_type"]:
-                if item not in ["hom-alt", "het-ref", "het-alt", "half"]:
+                if item not in ["ref", "het-ref", "hom", "het-alt", "half", "no-call"]:
                     err_exit(malformed_filter.format("genotype_type") +"\nvalue {} is not a valid genotype_type".format(item))
 
             # Check for too many values given

--- a/src/python/dxpy/executable_builder.py
+++ b/src/python/dxpy/executable_builder.py
@@ -188,7 +188,7 @@ def assert_consistent_regions(from_spec, from_command_line, executable_builder_e
     if from_spec is None or from_command_line is None:
         return
     if set(from_spec) != set(from_command_line):
-        raise executable_builder_exception("--region and the 'regionalOptions' key in the JSON file do not agree")
+        raise executable_builder_exception("--region and the 'regionalOptions' key in the JSON file or --extra-args do not agree")
 
 
 def assert_consistent_reg_options(exec_type, json_spec, executable_builder_exception):
@@ -197,7 +197,7 @@ def assert_consistent_reg_options(exec_type, json_spec, executable_builder_excep
     in "regionalOptions" have the same options.
     """
     reg_options_spec = json_spec.get('regionalOptions')
-    json_fn = 'dxapp.json' if exec_type == 'app' else 'dxworkflow.json'
+    json_fn = 'dxapp.json or --extra-args' if exec_type == 'app' else 'dxworkflow.json or --extra-args'
 
     if not isinstance(reg_options_spec, dict):
         raise executable_builder_exception("The field 'regionalOptions' in  must be a mapping")

--- a/src/python/dxpy/scripts/dx_build_app.py
+++ b/src/python/dxpy/scripts/dx_build_app.py
@@ -47,6 +47,7 @@ from ..app_categories import APP_CATEGORIES
 from ..exceptions import err_exit
 from ..utils.printing import BOLD
 from ..compat import open, USING_PYTHON2, decode_command_line_args, basestring
+from ..cli.parsers import process_extra_args
 
 decode_command_line_args()
 
@@ -1221,7 +1222,7 @@ def _build_app(args, extra_args):
 
 def build(args):
     try:
-        executable_id = _build_app(args, json.loads(args.extra_args) if args.extra_args else {})
+        executable_id = _build_app(args, process_extra_args(args) if args.extra_args else {})
     except dxpy.app_builder.AppBuilderException as e:
         # AppBuilderException represents errors during app building
         # that could reasonably have been anticipated by the user.

--- a/src/python/dxpy/workflow_builder.py
+++ b/src/python/dxpy/workflow_builder.py
@@ -30,6 +30,7 @@ import copy
 
 import dxpy
 from .cli import INTERACTIVE_CLI
+from .cli.parsers import process_extra_args
 from .utils.printing import fill
 from .compat import input
 from .utils import json_load_raise_on_duplicates
@@ -390,10 +391,8 @@ def _assert_executable_regions_match(workflow_enabled_regions, workflow_spec):
         if exect.startswith("applet-"):
             applet_project = dxpy.DXApplet(exect).project
             applet_region = dxpy.DXProject(applet_project).region
-            if applet_region in workflow_enabled_regions:                
-                workflow_enabled_regions = {applet_region} # only one region is allowed when using applet
-            else:
-                raise WorkflowBuilderException("The applet {} is not available in requested region(s) {}"
+            if {applet_region} != workflow_enabled_regions:                
+                raise WorkflowBuilderException("The applet {} is not available in all requested region(s) {}"
                                                .format(exect, ','.join(workflow_enabled_regions)))
 
         elif exect.startswith("app-"):
@@ -537,12 +536,25 @@ def _build_global_workflow(json_spec, enabled_regions, args):
     workflows_by_region, projects_by_region = {}, {}  # IDs by region
     try:
         # prepare "regionalOptions" field for the globalworkflow/new input
+        existing_regional_options = json_spec.get('regionalOptions', {})
+
+        if existing_regional_options:
+            if set(existing_regional_options.keys()) != set(enabled_regions):
+                raise WorkflowBuilderException("These enabled regions do have regional options specified \
+                                           in the JSON spec or from --extra-args: {}",
+                                           ",".join(set(enabled_regions).difference(set(existing_regional_options.keys()))))
+                
+            updated_regional_options= copy.deepcopy(existing_regional_options)
+        else:
+            updated_regional_options = dict.fromkeys(enabled_regions, {})
+        
         workflows_by_region, projects_by_region = \
             _build_underlying_workflows(enabled_regions, json_spec, args)
-        regional_options = {}
         for region, workflow_id in workflows_by_region.items():
-            regional_options[region] = {'workflow': workflow_id}
-        json_spec.update({'regionalOptions': regional_options})
+            updated_regional_options[region]["workflow"] = workflow_id
+
+        # update existing regionalOptions with underlying workflow ids and ignore regions that are not enabled
+        json_spec.update({'regionalOptions': updated_regional_options})
 
         # leave only fields that are actually used to build the workflow
         gwf_provided_keys = GLOBALWF_SUPPORTED_KEYS.intersection(set(json_spec.keys()))
@@ -633,6 +645,7 @@ def _build_or_update_workflow(args, parser):
     try:
         if args.mode == 'workflow':
             json_spec = _fetch_spec_from_dxworkflowjson(args.src_dir, "dxworkflow.json", parser)
+            json_spec.update(args.extra_args or {})
             json_spec = _get_validated_json(json_spec, args)
             workflow_id = _build_regular_workflow(json_spec, args.keep_open)
         elif args.mode == 'globalworkflow':
@@ -646,6 +659,8 @@ def _build_or_update_workflow(args, parser):
             # so `dx build` requires --version to be specified when using the --from
             if args.version_override:
                 json_spec["version"] = args.version_override
+
+            json_spec.update(args.extra_args or {})
             json_spec = _get_validated_json(json_spec, args)
             
             # Check if the local or source workflow is compiled by dxCompiler that supported dependency annotation
@@ -697,8 +712,9 @@ def build(args, parser):
         raise Exception("Arguments not provided")
 
     try:
+        process_extra_args(args)
         workflow_id = _build_or_update_workflow(args, parser)
         _print_output(workflow_id, args)
     except WorkflowBuilderException as e:
-        print("Error: {}".format(e.args,), file=sys.stderr)
+        print("Error: {}".format(e), file=sys.stderr)
         sys.exit(3)

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -4824,11 +4824,77 @@ class TestDXClientGlobalWorkflow(DXTestCaseBuildWorkflows):
         workflow_dir = self.write_workflow_directory(gwf_name,
                                                      json.dumps(dxworkflow_json),
                                                      readme_content="Workflow Readme Please")
-       
+
         gwf_desc = json.loads(run('dx build --globalworkflow ' + workflow_dir + ' --json'))
         gwf_regional_options = gwf_desc["regionalOptions"]
         self.assertIn("aws:us-east-1", gwf_regional_options)
         self.assertNotIn("azure:westus",gwf_regional_options)
+
+    @unittest.skipUnless(testutil.TEST_ISOLATED_ENV, "skipping test that would create global workflows")
+    def test_build_workflow_with_regional_resources(self):
+        with temporary_project(region="aws:us-east-1") as aws_proj:
+            aws_file_id = create_file_in_project("aws_file", aws_proj.get_id())
+
+            gwf_name = "gwf_{t}_with_regional_resources".format(t=int(time.time()))
+            dxworkflow_json = dict(
+                self.dxworkflow_spec,
+                name=gwf_name,
+                regionalOptions={
+                    "aws:us-east-1": dict(resources=[aws_file_id]),
+                },
+            )
+            workflow_dir = self.write_workflow_directory(
+                gwf_name,
+                json.dumps(dxworkflow_json),
+                readme_content="Workflow Readme Please",
+            )
+
+            gwf_desc = json.loads(run("dx build --globalworkflow " + workflow_dir + " --json"))
+
+            self.assertIn("regionalOptions", gwf_desc)
+            gwf_regional_options = gwf_desc["regionalOptions"]
+            self.assertIn("aws:us-east-1", gwf_regional_options)
+
+            # Make sure additional resources were cloned to the workflow containers
+            # in the specified regions
+            aws_container = gwf_regional_options["aws:us-east-1"]["resources"]
+            aws_obj_id_list = dxpy.api.container_list_folder(aws_container, {"folder": "/"})
+            self.assertIn(aws_file_id, [item["id"] for item in aws_obj_id_list["objects"]])
+
+            error_msg = "--region and the 'regionalOptions' key in the JSON file or --extra-args do not agree"
+            with self.assertRaisesRegex(DXCalledProcessError, error_msg):
+                run("dx build --globalworkflow --region azure:westus --json " + workflow_dir)
+
+    @unittest.skipUnless(testutil.TEST_ISOLATED_ENV, "skipping test that would create global workflows")
+    def test_build_workflow_with_regional_resources_from_extra_args(self):
+        with temporary_project(region="aws:us-east-1") as aws_proj:
+            aws_file_id = create_file_in_project("aws_file", aws_proj.get_id())
+
+            gwf_name = "gwf_{t}_with_regional_resources_from_extra_args".format(t=int(time.time()))
+            dxworkflow_json = dict(self.dxworkflow_spec,name=gwf_name)
+            workflow_dir = self.write_workflow_directory(
+                gwf_name,
+                json.dumps(dxworkflow_json),
+                readme_content="Workflow Readme Please",
+            )
+
+            extra_args = json.dumps({"regionalOptions":{"aws:us-east-1": {"resources":aws_proj.get_id()}}})
+            
+            error_msg = "--region and the 'regionalOptions' key in the JSON file or --extra-args do not agree"
+            with self.assertRaisesRegex(DXCalledProcessError, error_msg):
+                run("dx build --globalworkflow --region azure:westus --extra-args \'{}\' --json {}".format(extra_args, workflow_dir))
+            
+            gwf_desc = json.loads(run("dx build --globalworkflow --json {} --extra-args \'{}\'".format(workflow_dir, extra_args)))
+
+            self.assertIn("regionalOptions", gwf_desc)
+            gwf_regional_options = gwf_desc["regionalOptions"]
+            self.assertIn("aws:us-east-1", gwf_regional_options)
+
+            # Make sure additional resources were cloned to the workflow containers
+            # in the specified regions
+            aws_container = gwf_regional_options["aws:us-east-1"]["resources"]
+            aws_obj_id_list = dxpy.api.container_list_folder(aws_container, {"folder": "/"})
+            self.assertIn(aws_file_id, [item["id"] for item in aws_obj_id_list["objects"]])
 
     def test_build_workflow_in_invalid_multi_regions(self):
         gwf_name = "gwf_{t}_multi_region".format(t=int(time.time()))
@@ -11420,7 +11486,7 @@ class TestDXArchive(DXTestCase):
         time.sleep(15)
         self.assertIn("Tagged 1 file(s) for unarchival", output)
         self.assertEqual(dxpy.describe(fid2)["archivalState"],"unarchiving")
-        
+
 if __name__ == '__main__':
     if 'DXTEST_FULL' not in os.environ:
         sys.stderr.write('WARNING: env var DXTEST_FULL is not set; tests that create apps or run jobs will not be run\n')

--- a/src/python/test/test_extract_assay.py
+++ b/src/python/test/test_extract_assay.py
@@ -414,6 +414,18 @@ class TestDXExtractAssay(unittest.TestCase):
         process2 = subprocess.Popen(command2, stdout=subprocess.PIPE, universal_newlines=True)
         self.assertEqual(process1.communicate(), process2.communicate())
 
+
+    def test_retrieve_genotype(self):
+        """Testing --retrieve-genotype functionality"""
+        allele_genotype_type_filter = json.dumps({
+            "allele_id": ["18_47408_G_A"], 
+            "genotype_type": ["ref", "het-ref", "hom", "het-alt", "half", "no-call"]
+            })
+        expected_result = "sample_1_3\t18_47408_G_A\t18_47408_G_A\t18\t47408\tG\tA\thet-ref"
+        command = ["dx", "extract_assay", "germline", self.test_record, "--retrieve-genotype", allele_genotype_type_filter, "-o", "-"]
+        process = subprocess.Popen(command, stdout=subprocess.PIPE, universal_newlines=True)
+        self.assertIn(expected_result, process.communicate()[0])
+
     ###########
     # Malformed command lines
     ###########


### PR DESCRIPTION
Removed references of `hom-alt` type, updated json.help string and added test covering `--retrieve-genotype` flag (runs locally). 