### PR TITLE
SCIPROD-1984: [GENOMOD] update `dxpy` `extract_assay` SQL query harmonization

### DIFF
--- a/src/python/dxpy/cli/dataset_utilities.py
+++ b/src/python/dxpy/cli/dataset_utilities.py
@@ -756,6 +756,10 @@ def validate_filter_applicable_genotype_types(
                 print(
                     "WARNING: No genotype type requested in the filter. All genotype types will be returned.  'half-ref' genotype entries (0/.) were not ingested in the provided dataset!"
                 )
+        if (exclude_refdata is None and "ref" in filter_dict["genotype_type"] or exclude_nocall is None and "no-call" in filter_dict["genotype_type"]):
+            err_exit(
+                "\"ref\" and \"no-call\" genotype types can only be filtered when the undelying assay is of version generalized_assay_model_version 1.0.1/1.1.1 or higher."
+            )
 
 
 def extract_assay_germline(args):

--- a/src/python/dxpy/cli/dataset_utilities.py
+++ b/src/python/dxpy/cli/dataset_utilities.py
@@ -47,8 +47,9 @@ from ..exceptions import (
 )
 
 from ..dx_extract_utils.filter_to_payload import validate_JSON, final_payload
-from ..dx_extract_utils.germline_utils import get_genotype_only_types, add_germline_base_sql, sort_germline_variant, \
-    harmonize_germline_sql, harmonize_germline_results, get_germline_ref_payload, update_genotype_only_ref
+from ..dx_extract_utils.germline_utils import get_genotype_types, get_genotype_only_types, add_germline_base_sql, \
+    sort_germline_variant, harmonize_germline_sql, harmonize_germline_results, get_germline_ref_payload, \
+    update_genotype_only_ref
 from ..dx_extract_utils.input_validation_somatic import validate_somatic_filter
 from ..dx_extract_utils.somatic_filter_payload import somatic_final_payload
 from ..dx_extract_utils.cohort_filter_payload import cohort_filter_payload, cohort_final_payload
@@ -1002,16 +1003,21 @@ def extract_assay_germline(args):
 
                 genotype_only_payloads.append(genotype_only_payload)
 
+        # get the list of requested genotype types for the genotype/allele table query
+        genotype_types = get_genotype_types(filter_dict)
+
         if args.sql:
-            # get the genotype/allele table query
-            genotype_sql_query = raw_query_api_call(resp, genotype_payload)[:-1]
-            try:
-                geno_table_regex = r"\b" + additional_descriptor_info["genotype_type_table"] + r"\w+"
-                re.search(geno_table_regex, genotype_sql_query).group()
-            except Exception:
-                err_exit("Failed to find the table, {}, in the generated SQL".format(
-                    additional_descriptor_info["genotype_type_table"]), expected_exceptions=(AttributeError,))
-            sql_queries = [genotype_sql_query]
+            sql_queries = []
+            if genotype_types:
+                # get the genotype/allele table query
+                genotype_sql_query = raw_query_api_call(resp, genotype_payload)[:-1]
+                try:
+                    geno_table_regex = r"\b" + additional_descriptor_info["genotype_type_table"] + r"\w+"
+                    re.search(geno_table_regex, genotype_sql_query).group()
+                except Exception:
+                    err_exit("Failed to find the table, {}, in the generated SQL".format(
+                        additional_descriptor_info["genotype_type_table"]), expected_exceptions=(AttributeError,))
+                sql_queries.append(genotype_sql_query)
 
             # get the genotype table only query
             # assay_filter does not support "or" so there is a separate query for each partition
@@ -1033,8 +1039,9 @@ def extract_assay_germline(args):
         else:
             # get the list of dictionary results for the genotype/allele table query
             ordered_results = []
-            genotype_resp_raw = raw_api_call(resp, genotype_payload)
-            ordered_results.extend(genotype_resp_raw["results"])
+            if genotype_types:
+                genotype_resp_raw = raw_api_call(resp, genotype_payload)
+                ordered_results.extend(genotype_resp_raw["results"])
 
             # get the list of dictionary results for each genotype table only query
             for genotype_only_payload in genotype_only_payloads:

--- a/src/python/dxpy/dx_extract_utils/input_validation.py
+++ b/src/python/dxpy/dx_extract_utils/input_validation.py
@@ -8,6 +8,16 @@ maxitem_message = "Too many items given in field {}, maximum is {}"
 python_version = sys.version_info.major
 
 
+GENOTYPE_TYPES = (
+    "ref",
+    "het-ref",
+    "hom",
+    "het-alt",
+    "half",
+    "no-call",
+)
+
+
 def is_list_of_strings(object):
     if not isinstance(object, list):
         return False
@@ -204,7 +214,7 @@ def validate_filter(filter, filter_type):
 
             # Check against allowed values
             for item in filter["genotype_type"]:
-                if item not in ["ref", "het-ref", "hom", "het-alt", "half", "no-call"]:
+                if item not in GENOTYPE_TYPES:
                     err_exit(malformed_filter.format("genotype_type") +"\nvalue {} is not a valid genotype_type".format(item))
 
             # Check for too many values given


### PR DESCRIPTION
Updates to support `dx extract_assay germline --retrieve-genotype` 

- Exclude genotype and allele table query query when alternate genotypes types are not requested
- Include `DISTINCT` option if originally included after harmonization