### PR TITLE
SCIPROD-2016: [GENOMOD] `dx extract_assay germline --retrieve-genotype` inference use alleles to determine loci

### DIFF
--- a/src/python/dxpy/cli/dataset_utilities.py
+++ b/src/python/dxpy/cli/dataset_utilities.py
@@ -54,6 +54,7 @@ from ..dx_extract_utils.germline_utils import (
     harmonize_germline_sql,
     harmonize_germline_results,
     get_germline_ref_payload,
+    get_germline_loci_payload,
     update_genotype_only_ref,
     get_genotype_types,
     infer_genotype_type,
@@ -1096,8 +1097,10 @@ def extract_assay_germline(args):
 
             if args.infer_ref or args.infer_nocall:
                 samples = retrieve_samples(resp, selected_assay_name, selected_assay_id)
+                loci_payload = get_germline_loci_payload(filter_dict["location"], genotype_payload)
+                loci = [locus for locus in raw_api_call(resp, loci_payload)["results"]]
                 type_to_infer = "ref" if args.infer_ref else "no-call"
-                ordered_results = infer_genotype_type(samples, ordered_results, type_to_infer)
+                ordered_results = infer_genotype_type(samples, loci, ordered_results, type_to_infer)
                 # Filter out not requested genotypes
                 if len(types_to_filter_out) > 0:
                     ordered_results = filter_results(ordered_results, "genotype_type", types_to_filter_out)

--- a/src/python/dxpy/dx_extract_utils/germline_utils.py
+++ b/src/python/dxpy/dx_extract_utils/germline_utils.py
@@ -177,6 +177,7 @@ def get_germline_ref_payload(results, genotype_payload):
             {"locus_id": "allele$locus_id"},
             {"ref": "allele$ref"},
         ],
+        "is_cohort": False,
         "raw_filters": {
             "assay_filters": {
                 "id": genotype_payload["raw_filters"]["assay_filters"]["id"],
@@ -200,38 +201,82 @@ def update_genotype_only_ref(results, locus_id_refs):
         result["ref"] = locus_id_ref_map[result["locus_id"]]
 
 
-def _produce_loci_dict(reults_entries: list[dict]) -> dict:
+def get_germline_loci_payload(locations, genotype_payload):
+    """
+    Create a payload to query locus ids from the allele table with a location filter
+    """
+    return {
+        "project_context": genotype_payload["project_context"],
+        "adjust_geno_bins": False,
+        "distinct": True,
+        "logic": "and",
+        "fields": [
+            {"locus_id": "allele$locus_id"},
+            {"chromosome": "allele$chr"},
+            {"starting_position": "allele$pos"},
+            {"ref": "allele$ref"},
+        ],
+        "is_cohort": False,
+        "raw_filters": {
+            "assay_filters": {
+                "id": genotype_payload["raw_filters"]["assay_filters"]["id"],
+                "name": genotype_payload["raw_filters"]["assay_filters"]["name"],
+                "filters": {
+                    "allele$a_id": [{
+                        "condition": "in",
+                        "values": [],
+                        "geno_bins": [
+                            {
+                                "chr": location["chromosome"],
+                                "start": location["starting_position"],
+                                "end": location["starting_position"]
+                            } for location in locations
+                        ],
+                    }],
+                },
+            },
+        },
+    }
+
+
+def _produce_loci_dict(loci: list[dict], results_entries: list[dict]) -> dict:
     """
     Produces a dictionary with locus_id as key and a set of samples and entry as value.
     """
     loci_dict = {}
-    for entry in reults_entries:
-        locus_id = entry["locus_id"]
-        sample_id = entry["sample_id"]
-        if locus_id not in loci_dict:
-            loci_dict[locus_id] = {
-                "samples": {sample_id},
-                "entry": {
-                    "allele_id": None,
-                    "locus_id": locus_id,
-                    "chromosome": entry["chromosome"],
-                    "starting_position": entry["starting_position"],
-                    "ref": entry["ref"],
-                    "alt": None,
-                },
-            }
-        else:
-            loci_dict[locus_id]["samples"].add(sample_id)
+    for locus in loci:
+        loci_dict[locus["locus_id"]] = {
+            "samples": set(),
+            "entry": {
+                "allele_id": None,
+                "locus_id": locus["locus_id"],
+                "chromosome": locus["chromosome"],
+                "starting_position": locus["starting_position"],
+                "ref": locus["ref"],
+                "alt": None,
+            },
+        }
+
+    for entry in results_entries:
+        loci_dict[entry["locus_id"]]["samples"].add(entry["sample_id"])
+
     return loci_dict
 
 
 def infer_genotype_type(
-    samples: list, result_entries: list[dict], type_to_infer: str
+    samples: list, loci: list[dict], result_entries: list[dict], type_to_infer: str
 ) -> list[dict]:
     """
     If the result_entries does not contain entry with sample_id of specifific starting_position the the genotype type is either no-call or ref.
     Args:
         samples: list of all samples
+        loci: list of information on each loci within the filter  e.g.
+            {
+            "locus_id": "1_1076145_A_T",
+            "chromosome": "1",
+            "starting_position": 1076145,
+            "ref": "A",
+            }
         result_entries: list of results from extract_assay query. e.g.
             {
             "sample_id": "SAMPLE_2",
@@ -246,7 +291,7 @@ def infer_genotype_type(
         type_to_infer: type to infer either  "ref" or "no-call"
     Returns: list of infered entries with added inferred genotype type and other entries retrieved from result for loci of interest.
     """
-    loci_dict = _produce_loci_dict(result_entries)
+    loci_dict = _produce_loci_dict(loci, result_entries)
     inferred_entries = []
     for locus in loci_dict:
         for sample in samples:

--- a/src/python/dxpy/dx_extract_utils/input_validation.py
+++ b/src/python/dxpy/dx_extract_utils/input_validation.py
@@ -194,6 +194,8 @@ def validate_filter(filter, filter_type):
                 # Ensure all keys are there
                 if not ("chromosome" in indiv_loc_keys and "starting_position" in indiv_loc_keys):
                     err_exit(malformed_filter.format("location"))
+                if "ending_position" in indiv_loc_keys:
+                    err_exit(malformed_filter.format("location"))
                 # Check that each key is a string
                 if not is_list_of_strings(list(indiv_location.values())):
                     err_exit(malformed_filter.format("location"))

--- a/src/python/test/test_extract_assay.py
+++ b/src/python/test/test_extract_assay.py
@@ -481,6 +481,26 @@ class TestDXExtractAssay(unittest.TestCase):
 
     def test_produce_loci_dict(self):
         # Define the input data
+        loci = [
+            {
+                "locus_id": "18_47361_A_T",
+                "chromosome": "18",
+                "starting_position": 47361,
+                "ref": "A",
+            },
+            {
+                "locus_id": "X_1000_C_A",
+                "chromosome": "X",
+                "starting_position": 1000,
+                "ref": "C",
+            },
+            {
+                "locus_id": "1_123_A_.",
+                "chromosome": "1",
+                "starting_position": 123,
+                "ref": "A",
+            },
+        ]
         results_entries = [
             {
                 "locus_id": "18_47361_A_T",
@@ -535,16 +555,41 @@ class TestDXExtractAssay(unittest.TestCase):
                     "alt": None,
                 },
             },
+            "1_123_A_.": {
+                "samples": set(),
+                "entry": {
+                    "allele_id": None,
+                    "locus_id": "1_123_A_.",
+                    "chromosome": "1",
+                    "starting_position": 123,
+                    "ref": "A",
+                    "alt": None,
+                },
+            },
         }
 
         # Call the function
-        result = _produce_loci_dict(results_entries)
+        result = _produce_loci_dict(loci, results_entries)
 
         # Assert the result
         self.assertEqual(result, expected_output)
 
     def test_infer_genotype_type(self):
         samples = ["SAMPLE_1", "SAMPLE_2", "SAMPLE_3"]
+        loci = [
+            {
+                "locus_id": "1_1076145_A_T",
+                "chromosome": "1",
+                "starting_position": 1076145,
+                "ref": "A",
+            },
+            {
+                "locus_id": "2_1042_G_CC",
+                "chromosome": "2",
+                "starting_position": 1042,
+                "ref": "G",
+            },
+        ]
         result_entries = [
             {
                 "sample_id": "SAMPLE_2",
@@ -580,9 +625,39 @@ class TestDXExtractAssay(unittest.TestCase):
                 "alt": None,
                 "genotype_type": "no-call",
             },
+            {
+                "sample_id": "SAMPLE_1",
+                "allele_id": None,
+                "locus_id": "2_1042_G_CC",
+                "chromosome": "2",
+                "starting_position": 1042,
+                "ref": "G",
+                "alt": None,
+                "genotype_type": "no-call",
+            },
+            {
+                "sample_id": "SAMPLE_2",
+                "allele_id": None,
+                "locus_id": "2_1042_G_CC",
+                "chromosome": "2",
+                "starting_position": 1042,
+                "ref": "G",
+                "alt": None,
+                "genotype_type": "no-call",
+            },
+            {
+                "sample_id": "SAMPLE_3",
+                "allele_id": None,
+                "locus_id": "2_1042_G_CC",
+                "chromosome": "2",
+                "starting_position": 1042,
+                "ref": "G",
+                "alt": None,
+                "genotype_type": "no-call",
+            },
         ]
 
-        output = infer_genotype_type(samples, result_entries, type_to_infer)
+        output = infer_genotype_type(samples, loci, result_entries, type_to_infer)
         self.assertEqual(output, result_entries + expected_output)
     ##########
     # Normal Command Lines


### PR DESCRIPTION
Updated genotype inference in `dx extract_assay germline --retrieve-genotype` to use loci from the allele table to determine missing samples to infer excluded genotype types.