### PR TITLE
SCIPROD-2031 [GENOMOD] pretty print example filer JSON

### DIFF
--- a/src/python/dxpy/cli/dataset_utilities.py
+++ b/src/python/dxpy/cli/dataset_utilities.py
@@ -80,7 +80,7 @@ from ..bindings.apollo.vizserver_payload_builder import VizPayloadBuilder
 from ..bindings.apollo.vizclient import VizClient
 
 from ..bindings.apollo.data_transformations import transform_to_expression_matrix
-from .output_handling import write_expression_output
+from .output_handling import write_expression_output, pretty_print_json
 
 from .help_messages import EXTRACT_ASSAY_EXPRESSION_JSON_HELP, EXTRACT_ASSAY_EXPRESSION_ADDITIONAL_FIELDS_HELP
 
@@ -799,23 +799,23 @@ def extract_assay_germline(args):
                 comment_fill('\tno-call\t(both alleles are unknown\t\t\t\te.g. ./.)') + '\n#\n' +
                 comment_fill('JSON filter templates for --retrieve-genotype', comment_string='# ') + '\n#\n' +
                 comment_fill('Example using location:', comment_string='# ') + '\n' +
-                comment_fill('{', comment_string='# ') + '\n' +
-                comment_fill('  "sample_id": ["s1", "s2"],', comment_string='# ') + '\n' +
-                comment_fill('  "location": [', comment_string='# ') + '\n' +
-                comment_fill('    {', comment_string='# ') + '\n' +
-                comment_fill('      "chromosome": "1",', comment_string='# ') + '\n' +
-                comment_fill('      "starting_position": "10000"', comment_string='# ') + '\n' +
-                comment_fill('    },', comment_string='# ') + '\n' +
-                comment_fill('    {', comment_string='# ') + '\n' +
-                comment_fill('      "chromosome": "X",', comment_string='# ') + '\n' +
-                comment_fill('      "starting_position": "500"', comment_string='# ') + '\n' +
-                comment_fill('    }', comment_string='# ') + '\n' +
-                comment_fill('  ],', comment_string='# ') + '\n' +
-                comment_fill('  "genotype_type": ["ref", "het-ref", "hom", "het-alt", "half", "no-call"]', comment_string='# ') + '\n' +
-                comment_fill('}', comment_string='# ') + '\n#\n' +
-
+                pretty_print_json(
+                    {
+                        "sample_id": ["s1", "s2"],
+                        "location": [
+                            {"chromosome": "1", "starting_position": "10000"},
+                            {"chromosome": "X", "starting_position": "500"},
+                        ],
+                        "genotype_type": ["ref", "het-ref", "hom", "het-alt", "half", "no-call"],
+                    }
+                ) + '\n' +
                 comment_fill('Example using allele_id:', comment_string='# ') + '\n' +
-                '{\n  "sample_id": ["s1", "s2"],\n  "allele_id": ["1_1000_A_T","2_1000_G_C"],\n  "genotype_type": ["het-ref", "hom", "het-alt", "half"]\n}'
+                pretty_print_json({
+                    "sample_id": ["s1", "s2"],
+                    "allele_id": ["1_1000_A_T", "2_1000_G_C"],
+                    "genotype_type": ["het-ref", "hom", "het-alt", "half"],
+                }
+                )
             )
             sys.exit(0)
 

--- a/src/python/dxpy/cli/output_handling.py
+++ b/src/python/dxpy/cli/output_handling.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
 import sys
 import csv
 import os
+import json
 from ..exceptions import err_exit
 
 
@@ -160,3 +162,21 @@ def write_expression_output(
 
         else:
             error_handler("Unexpected error occurred while writing output")
+
+
+
+def pretty_print_json(json_dict: dict) -> str:
+    """Pretty-prints the provided JSON object.
+
+    Args:
+        json_dict: A string containing valid JSON data.
+
+    Returns:
+        Returns a string with formatted JSON or None if there's an error.
+    """
+    if isinstance(json_dict, dict):
+        formatted_json = json.dumps(json_dict, sort_keys=True, indent=4)
+        return formatted_json
+    else:
+        print("WARNING: Invalid JSON provided.")
+        return None

--- a/src/python/dxpy/cli/output_handling.py
+++ b/src/python/dxpy/cli/output_handling.py
@@ -178,5 +178,5 @@ def pretty_print_json(json_dict: dict) -> str:
         formatted_json = json.dumps(json_dict, sort_keys=True, indent=4)
         return formatted_json
     else:
-        print("WARNING: Invalid JSON provided.")
+        print("WARNING: Invalid JSON provided.", file=sys.stderr)
         return None


### PR DESCRIPTION
removing `#` from `--json-help` text:
```
# Example using location:
# {
#   "sample_id": ["s1", "s2"],
#   "location": [
#     {
#       "chromosome": "1",
#       "starting_position": "10000"
#     },
#     {
#       "chromosome": "X",
#       "starting_position": "500"
#     }
#   ],
#   "genotype_type": ["ref", "het-ref", "hom", "het-alt", "half", "no-call"]
# }
#
# Example using allele_id:
{
  "sample_id": ["s1", "s2"],
  "allele_id": ["1_1000_A_T","2_1000_G_C"],
  "genotype_type": ["het-ref", "hom", "het-alt", "half"]
}
```