### PR TITLE
PTFM-38891 Fix test for allowedExecutables default value

### DIFF
--- a/src/python/test/test_dxpy.py
+++ b/src/python/test/test_dxpy.py
@@ -212,7 +212,7 @@ class TestDXProject(unittest.TestCase):
         desc = dxproject.describe()
         self.assertEqual(desc["restricted"], False)
         self.assertEqual(desc["downloadRestricted"], False)
-        self.assertTrue("allowedExecutables" not in desc)
+        self.assertEqual(desc["allowedExecutables"], None)
         self.assertEqual(desc["databaseResultsRestricted"], None)
 
     def test_new_list_remove_folders(self):


### PR DESCRIPTION
Fix allowedExecutables default value changed in apiserver


Successful test: https://jenkins-vstg.internal.dnanexus.com/view/dx-toolkit%20release%20board/job/dx-toolkit/job/dxpy-branch-integration-tests-on-staging-20.04-python3/843/console