### PR TITLE
TIP-3908 Handle DataTooLarge error from vizserver

### DIFF
--- a/src/python/dxpy/bindings/apollo/vizclient.py
+++ b/src/python/dxpy/bindings/apollo/vizclient.py
@@ -20,6 +20,8 @@ class VizClient(object):
                     )
                 elif response["error"]["type"] == "QueryTimeOut":
                     err_message = "Please consider using --sql option to generate the SQL query and execute query via a private compute cluster."
+                elif response["error"]["type"] == "DataTooLarge":
+                    err_message = "Please consider using --sql option to generate the SQL query and execute query via a private compute cluster."
                 else:
                     err_message = response["error"]
                 self.error_handler(str(err_message))


### PR DESCRIPTION
New DataTooLarge error is thrown from apiproxy if we encounter vizserver response larger than 512MB. Currently it returns as InternalError.