### PR TITLE
build and publish wheel

### DIFF
--- a/build/upload_to_pypi.sh
+++ b/build/upload_to_pypi.sh
@@ -21,4 +21,4 @@ while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
 root="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 make -C $root/../src api_wrappers toolkit_version
-(cd $root/../src/python; /usr/bin/python setup.py sdist; twine upload dist/*)
+(cd $root/../src/python; /usr/bin/python -m build; twine upload dist/*)


### PR DESCRIPTION
Direct invocation of setup.py is [deprecated](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/).  Build and publish a wheel.

I did not see where you set up pre-requisites for build and publish.  You will need to `pip install build` before building (just as you `pip install twine` before publishing)