### PR TITLE
DEVEX-2412 Cache DXFile._proj if found in DXFile.read()

### DIFF
--- a/src/python/dxpy/bindings/dxfile.py
+++ b/src/python/dxpy/bindings/dxfile.py
@@ -254,7 +254,7 @@ class DXFile(DXDataObject):
         self._cur_part = 1
         self._num_uploaded_parts = 0
         # Cache for object existence in project
-        self._exists_in_project = None  
+        self._exists_in_proj = None  
 
     def _new(self, dx_hash, media_type=None, **kwargs):
         """
@@ -938,10 +938,10 @@ class DXFile(DXDataObject):
 
     def read(self, length=None, use_compression=None, project=None, **kwargs):
         # Check if the file is present in dxfile project attribute if the project arg not specified 
-        if project is None and not self._exists_in_project and self.get_proj_id() is not None:
-            self._exists_in_project = object_exists_in_project(self.get_id(), self.get_proj_id())
+        if project is None and not self._exists_in_proj and self.get_proj_id() is not None:
+            self._exists_in_proj = object_exists_in_project(self.get_id(), self.get_proj_id())
         # Use the dxfile attribute if the project arg is not specified
-        if project is None and self._exists_in_project:
+        if project is None and self._exists_in_proj:
             project = self.get_proj_id()
         data = self._read2(length=length, use_compression=use_compression, project=project, **kwargs)
         if USING_PYTHON2:

--- a/src/python/dxpy/bindings/dxfile.py
+++ b/src/python/dxpy/bindings/dxfile.py
@@ -253,6 +253,8 @@ class DXFile(DXDataObject):
         self._file_length = None
         self._cur_part = 1
         self._num_uploaded_parts = 0
+        # Cache for object existence in project
+        self._exists_in_project = None  
 
     def _new(self, dx_hash, media_type=None, **kwargs):
         """
@@ -934,14 +936,12 @@ class DXFile(DXDataObject):
             buf.seek(orig_buf_pos)
             return buf.read()
 
-        # Debug fallback
-        # import urllib2
-        # req = urllib2.Request(url, headers=headers)
-        # response = urllib2.urlopen(req)
-        # return response.read()
-
     def read(self, length=None, use_compression=None, project=None, **kwargs):
-        if project is None and object_exists_in_project(self.get_id(), self.get_proj_id()):
+        # Check if the file is present in dxfile project attribute if the project arg not specified 
+        if project is None and not self._exists_in_project and self.get_proj_id() is not None:
+            self._exists_in_project = object_exists_in_project(self.get_id(), self.get_proj_id())
+        # Use the dxfile attribute if the project arg is not specified
+        if project is None and self._exists_in_project:
             project = self.get_proj_id()
         data = self._read2(length=length, use_compression=use_compression, project=project, **kwargs)
         if USING_PYTHON2:

--- a/src/python/dxpy/bindings/dxfile.py
+++ b/src/python/dxpy/bindings/dxfile.py
@@ -940,12 +940,10 @@ class DXFile(DXDataObject):
         # Check if the file is present in dxfile project attribute if the project arg not specified 
         if project is None and not self._exists_in_proj and self.get_proj_id() is not None:
             self._exists_in_proj = object_exists_in_project(self.get_id(), self.get_proj_id())
-        # Use the dxfile attribute if the project arg is not specified
+        # Use the DXFile attribute if the project arg is not provided
         if project is None and self._exists_in_proj:
             project = self.get_proj_id()
         data = self._read2(length=length, use_compression=use_compression, project=project, **kwargs)
-        if USING_PYTHON2:
-            return data
         # In python3, the underlying system methods use the 'bytes' type, not 'string'
         if self._binary_mode is True:
             return data

--- a/src/python/dxpy/bindings/dxfile.py
+++ b/src/python/dxpy/bindings/dxfile.py
@@ -938,7 +938,7 @@ class DXFile(DXDataObject):
 
     def read(self, length=None, use_compression=None, project=None, **kwargs):
         # Check if the file is present in dxfile project attribute if the project arg not specified 
-        if project is None and not self._exists_in_proj and self.get_proj_id() is not None:
+        if project is None and self._exists_in_proj is None and self.get_proj_id() is not None:
             self._exists_in_proj = object_exists_in_project(self.get_id(), self.get_proj_id())
         # Use the DXFile attribute if the project arg is not provided
         if project is None and self._exists_in_proj:


### PR DESCRIPTION
Cache the return of `object_exists_in_project()` in `DXFile.read()` at `DXFile._exists_in_proj` if the file exists in the `DXFile._proj` attribute. Avoids excessive `/file-xxxx/describe` calls for many `read()` calls. 

Fix behavior where `object_exists_in_project()` could have been called even if `self.get_proj_id() ` is `None`. 