### PR TITLE
COMPUTE-1113: Increase backoff timeout for throttled requests over attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 
 ## [394.0] - beta
 
-* 
 ### Fixed
 
 * Update parsing of nextflow_schema.json file to be compatible with new schema convention

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,23 +6,27 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 
 ## Unreleased
 
+### Changed
+
+* Increased timeout to retry throttled requests over attempts
+
 ## [394.0] - beta
 
+* 
 ### Fixed
 
 * Update parsing of nextflow_schema.json file to be compatible with new schema convention
 * `DXFile.read()` increase in API calls introduced in 392.0
+
+### Changed
+
+* Retry requests when received 429 response status code in Python, Java SDKs
 
 ## [393.0] - 2025.03.24
 
 ### Fixed
 
 * Preserve newlines in dxpy file iterator for large files
-
-### Changed
-
-* Retry requests when received 429 response status code in Python, Java SDKs
-* Increased timeout to retry throttled requests over attempts 
 
 ## [392.0] - 2025.03.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 ### Changed
 
 * Retry requests when received 429 response status code in Python, Java SDKs
+* Increased timeout to retry throttled requests over attempts 
 
 ## [392.0] - 2025.03.10
 

--- a/src/python/dxpy/__init__.py
+++ b/src/python/dxpy/__init__.py
@@ -353,7 +353,13 @@ def _calculate_retry_delay(response, num_attempts):
     '''
     if response is not None and response.status in (503, 429) and 'retry-after' in response.headers:
         try:
-            return int(response.headers['retry-after'])
+            suggested_delay = int(response.headers['retry-after']) # 20-30 seconds
+
+            # By default, apiserver doesn't track attempts and doesn't provide increased timeout over attempts.
+            # So, increasing backoff for throttled requests up to x5 times from the original one.
+            # After 20th attempt delay will be from 100 to 150 seconds.
+            return suggested_delay if suggested_delay >= 60 \
+                else suggested_delay + 0.25 * min(num_attempts - 1, 20) * suggested_delay
         except ValueError:
             # In RFC 2616, retry-after can be formatted as absolute time
             # instead of seconds to wait. We don't bother to parse that,
@@ -361,7 +367,7 @@ def _calculate_retry_delay(response, num_attempts):
             pass
     if num_attempts <= 1:
         return 1
-    num_attempts = min(num_attempts, 7)
+    num_attempts = min(num_attempts, 8) # after 8th attempt delay will be from 64 to 128 seconds
     return randint(2 ** (num_attempts - 2), 2 ** (num_attempts - 1))
 
 


### PR DESCRIPTION
https://jira.internal.dnanexus.com/browse/COMPUTE-1113

Reduce frequency of retrying throttled requests if apiserver continues to return 429/503 response code over multiple attempts.

[Java sdk](https://github.com/dnanexus/dx-toolkit/blob/master/src/java/src/main/java/com/dnanexus/DXHTTPRequest.java#L412) already has such increased backoff strategy