### PR TITLE
COMPUTE-1235: Handle 429 response code in R sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 
 ### Changed
 
+* Retry requests when received 429 response status code in R SDK
 * Increased timeout to retry throttled requests over attempts
 
 ### Added

--- a/Readme.md
+++ b/Readme.md
@@ -42,9 +42,10 @@ Supported languages
 
 The Platform SDK contains API language bindings for the following platforms:
 
-* [Python](src/python/Readme.md) (requires Python 3.8 or higher)
-* C++
-* [Java](src/java/Readme.md) (requires Java 7 or higher)
+* [Python](src/python) (requires Python 3.8 or higher)
+* [C++](src/cpp)
+* [Java](src/java) (requires Java 7 or higher)
+* [R](src/R)
 
 Build dependencies for C++ and Java
 ------------------

--- a/src/python/dxpy/__init__.py
+++ b/src/python/dxpy/__init__.py
@@ -360,7 +360,7 @@ def _calculate_retry_delay(response, num_attempts):
             # The current implementation of apiserver returns a retry-after header ranging from 20 to 30 seconds.
             # Thus, after the 20th attempt the delay will always be between 100 and 150 seconds.
             return suggested_delay if suggested_delay >= 60 \
-                else suggested_delay + 0.25 * min(num_attempts - 1, 20) * suggested_delay
+                else suggested_delay + int(0.25 * min(num_attempts - 1, 20) * suggested_delay)
         except ValueError:
             # In RFC 2616, retry-after can be formatted as absolute time
             # instead of seconds to wait. We don't bother to parse that,


### PR DESCRIPTION
[COMPUTE-1235](https://jira.internal.dnanexus.com/browse/COMPUTE-1235)

- Handle 429 response code in R sdk.
- Add support to existing `alwaysRetry` option that previously was assigned but never used.
- Fix calculating increased backoff in dx.py to have int value of seconds instead of float in some cases.