### PR TITLE
COMPUTE-1237: Fix java sdk to handle network errors when there is no response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 
 * Retry requests when received 429 response status code in R SDK
 * Increased timeout to retry throttled requests over attempts
+* Fix Java SDK exception `java.lang.NullPointerException` when could not receive response in `com.dnanexus.DXHTTPRequest`
 
 ### Added
 

--- a/src/java/src/main/java/com/dnanexus/DXHTTPRequest.java
+++ b/src/java/src/main/java/com/dnanexus/DXHTTPRequest.java
@@ -450,7 +450,7 @@ public class DXHTTPRequest {
             attemptsWithThrottled++;
             // Retries due to 429 or 503 Service Unavailable and Retry-After do NOT count against the
             // allowed number of retries.
-            if (statusCode != 503 && statusCode != 429) {
+            if (statusCode == null || (statusCode != 503 && statusCode != 429)) {
                 attempts++;
             }
 


### PR DESCRIPTION
`NullPointerException` happened when I tried to [use dxApi in dxCompiler](https://github.com/dnanexus/dxCompiler/actions/runs/14089210499/job/39590964151).
Seems that in case when there is some network error response is not initialized and statusCode is still null and can't be used with integer comparison.

with that fix compiler was built and tested w/o errors https://github.com/dnanexus/dxCompiler/actions/runs/14132661095