### PR TITLE
APPS-3152: Update test_dxclient

### DIFF
--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -6848,7 +6848,8 @@ class TestDXClientNewUser(DXTestCase):
             "cloudIntegrationManagement": False,
             "appAccess": True,
             "projectAccess": "CONTRIBUTE",
-            "id": user_id
+            "id": user_id,
+            "treManagement": False
         }
         res = dxpy.api.org_find_members(self.org_id, {"id": [user_id]})["results"][0]
         self.assertEqual(res, exp)
@@ -7016,7 +7017,8 @@ class TestDXClientMembership(DXTestCase):
                           "allowBillableActivities": True,
                           "cloudIntegrationManagement": False,
                           "appAccess": True,
-                          "projectAccess": "ADMINISTER"}
+                          "projectAccess": "ADMINISTER",
+                          "treManagement": False}
         membership = self._org_find_members(self.user_id)
         self.assertEqual(membership, exp_membership)
 
@@ -7028,7 +7030,8 @@ class TestDXClientMembership(DXTestCase):
                           "allowBillableActivities": False,
                           "cloudIntegrationManagement": False,
                           "appAccess": True,
-                          "projectAccess": "CONTRIBUTE"}
+                          "projectAccess": "CONTRIBUTE",
+                          "treManagement": False}
         membership = self._org_find_members(self.user_id)
         self.assertEqual(membership, exp_membership)
 
@@ -7089,7 +7092,8 @@ class TestDXClientMembership(DXTestCase):
                           "allowBillableActivities": True,
                           "cloudIntegrationManagement": False,
                           "appAccess": True,
-                          "projectAccess": "ADMINISTER"}
+                          "projectAccess": "ADMINISTER",
+                          "treManagement": False}
         membership = self._org_find_members(self.user_id)
         self.assertEqual(membership, exp_membership)
 
@@ -7216,7 +7220,8 @@ class TestDXClientMembership(DXTestCase):
                           "allowBillableActivities": True,
                           "cloudIntegrationManagement": False,
                           "appAccess": True,
-                          "projectAccess": "ADMINISTER"}
+                          "projectAccess": "ADMINISTER",
+                          "treManagement": False}
         membership = self._org_find_members(self.user_id)
         self.assertEqual(membership, exp_membership)
 
@@ -7227,7 +7232,8 @@ class TestDXClientMembership(DXTestCase):
                           "allowBillableActivities": False,
                           "cloudIntegrationManagement": False,
                           "projectAccess": "VIEW",
-                          "appAccess": True}
+                          "appAccess": True,
+                          "treManagement": False}
         membership = self._org_find_members(self.user_id)
         self.assertEqual(membership, exp_membership)
 
@@ -7238,7 +7244,8 @@ class TestDXClientMembership(DXTestCase):
                           "allowBillableActivities": True,
                           "cloudIntegrationManagement": False,
                           "projectAccess": "VIEW",
-                          "appAccess": False}
+                          "appAccess": False,
+                          "treManagement": False}
 
         membership = self._org_find_members(self.user_id)
         self.assertEqual(membership, exp_membership)

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -6868,7 +6868,8 @@ class TestDXClientNewUser(DXTestCase):
             "cloudIntegrationManagement": False,
             "appAccess": True,
             "projectAccess": "CONTRIBUTE",
-            "id": user_id
+            "id": user_id,
+            "treManagement": False
         }
         res = dxpy.api.org_find_members(self.org_id, {"id": [user_id]})["results"][0]
         self.assertEqual(res, exp)
@@ -6885,7 +6886,8 @@ class TestDXClientNewUser(DXTestCase):
             "cloudIntegrationManagement": False,
             "appAccess": False,
             "projectAccess": "VIEW",
-            "id": user_id
+            "id": user_id,
+            "treManagement": False
         }
         res = dxpy.api.org_find_members(self.org_id, {"id": [user_id]})["results"][0]
         self.assertEqual(res, exp)
@@ -6903,7 +6905,8 @@ class TestDXClientNewUser(DXTestCase):
             "cloudIntegrationManagement": False,
             "appAccess": True,
             "projectAccess": "ADMINISTER",
-            "id": user_id
+            "id": user_id,
+            "treManagement": False
         }
         res = dxpy.api.org_find_members(self.org_id, {"id": [user_id]})["results"][0]
         self.assertEqual(res, exp)


### PR DESCRIPTION
https://jira.internal.dnanexus.com/browse/APPS-3152

Several tests in `test_dxclient.py` started failing recently due to changes brought by [TIP-3998](https://jira.internal.dnanexus.com/browse/TIP-3998). To ensure the affected test can be executed daily, I am updating the expected values returned by `org_find_members` (the method started returning an additional key:value pair `'treManagement': False`).

* [Passing run](https://jenkins-vstg.internal.dnanexus.com/view/Traceability%20Platform%20Tests/job/RTM/job/dx-toolkit_traceability_tests_isolated_master/15/) of the affected suite ✅