### PR TITLE
[PTFM-40226] Enable running `dxpy` tests within a container composition

### DIFF
--- a/src/python/dxpy/__init__.py
+++ b/src/python/dxpy/__init__.py
@@ -993,7 +993,7 @@ def get_auth_server_name(host_override=None, port_override=None, protocol='https
         return 'https://stagingauth.cn.dnanexus.com:7001'
     elif APISERVER_HOST == 'api.cn.dnanexus.com':
         return 'https://auth.cn.dnanexus.com:8001'
-    elif APISERVER_HOST == "localhost" or APISERVER_HOST == "127.0.0.1":
+    elif APISERVER_HOST == "localhost" or APISERVER_HOST == "127.0.0.1" or APISERVER_HOST == "apiserver":
         if "DX_AUTHSERVER_HOST" not in os.environ or "DX_AUTHSERVER_PORT" not in os.environ:
             err_msg = "Must set authserver env vars (DX_AUTHSERVER_HOST, DX_AUTHSERVER_PORT) if apiserver is {apiserver}."
             raise exceptions.DXError(err_msg.format(apiserver=APISERVER_HOST))


### PR DESCRIPTION
Add support for using `apiserver` as a hostname for apiserver instead of `localhost` and `127.0.0.1` only to support running tests within a container composition that uses `apiserver` as a hostname of apiserver.