### PR TITLE
COMPUTE-1671, APPS-3228: Add nextflow login sanity check to verify aws token role, audience

### DIFF
--- a/src/python/dxpy/templating/templates/nextflow/src/nextflow.sh
+++ b/src/python/dxpy/templating/templates/nextflow/src/nextflow.sh
@@ -350,6 +350,12 @@ aws_login() {
     # Clean up any old AWS config files to avoid conflicts. The SDK will now ignore ~/.aws/config and ~/.aws/credentials because the environment variables take precedence.
     rm -rf /home/dnanexus/.aws/
 
+    # This explicit check is added to ensure that existing pytest tests for invalid credentials still fail correctly.
+    # In the new model, the AWS SDK would normally handle this lazily, but the tests expect an immediate failure.
+    aws sts assume-role-with-web-identity --role-arn "$iamRoleArnToAssume" \
+      --role-session-name "dnanexus_${DX_JOB_ID}" \
+      --web-identity-token "$(cat "${web_identity_token_file}")" > /dev/null
+
     echo "Successfully configured AWS with Web Identity Token File."
     # Optional sanity check; SDK/CLI will now do STS AssumeRoleWithWebIdentity on demand
     aws sts get-caller-identity >/dev/null 2>&1 || echo "Note: initial STS call deferred to Nextflow/AWS SDK."


### PR DESCRIPTION
Return additional check for QE regression tests:

- `claims_do_not_match_profile` - https://staging.dnanexus.com/panx/projects/GyyvX2Q0Yvkq6JgYgk349Kvg/monitor/job/J2vq90j0YvkYj1225JPV71vG
- `invalid_role_profile` - https://staging.dnanexus.com/panx/projects/GyyvX2Q0Yvkq6JgYgk349Kvg/monitor/job/J2vq8v00Yvkf9z5062FxVp55
- `invalid_audience_profile` - https://staging.dnanexus.com/panx/projects/GyyvX2Q0Yvkq6JgYgk349Kvg/monitor/job/J2vq8y80Yvkp2vFyYbP9Z9zB