### PR TITLE
DOCS-2793 Fix redundant `cpuUsageIdle` description in `dx watch --metrics-help`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 
 * Display a security warning when downloading or generating download URLs for files flagged as malicious
 
+### Fixed
+
+* Fix redundant `cpuUsageIdle` description in `dx watch --metrics-help` output
+
 ## [409.0] - beta
 
 * No significant changes

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -5714,7 +5714,7 @@ The "csv" mode outputs the following columns with headers in csv format to stdou
 - cpuUsageUser: The percentage of cpu time spent in user mode on the instance during the metric collection period.
 - cpuUsageSystem: The percentage of cpu time spent in system mode on the instance during the metric collection period.
 - cpuUsageIowait: The percentage of cpu time spent in waiting for I/O operations to complete on the instance during the metric collection period.
-- cpuUsageIdle: The percentage of cpu time spent in waiting for I/O operations to complete on the instance during the metric collection period.
+- cpuUsageIdle: The percentage of cpu time spent idle on the instance during the metric collection period.
 - memoryUsedBytes: Bytes of memory used (calculated as total - free - buffers - cache - slab_reclaimable + shared_memory).
 - memoryTotalBytes: Total memory available on the instance that ran the job.
 - diskUsedBytes: Bytes of storage allocated to the AEE that are used by the filesystem.


### PR DESCRIPTION
## Summary

Fix a copy-paste error in the `dx watch --metrics-help` output where `cpuUsageIdle` had an identical description to `cpuUsageIowait`.

**Before:**
```
- cpuUsageIowait: The percentage of cpu time spent in waiting for I/O operations to complete on the instance during the metric collection period.
- cpuUsageIdle: The percentage of cpu time spent in waiting for I/O operations to complete on the instance during the metric collection period.
```

**After:**
```
- cpuUsageIowait: The percentage of cpu time spent in waiting for I/O operations to complete on the instance during the metric collection period.
- cpuUsageIdle: The percentage of cpu time spent idle on the instance during the metric collection period.
```