### PR TITLE
TITAN-183: Update test dxclient

### DIFF
--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -6990,7 +6990,11 @@ class TestDXClientNewUser(DXTestCase):
             "appAccess": True,
             "projectAccess": "CONTRIBUTE",
             "id": user_id,
-            "treManagement": False
+            "treManagement": False,
+            "archivalManagement": False,
+            "dataDeletion": False,
+            "dataSearch": False,
+            "projectMemberDemotion": False
         }
         res = dxpy.api.org_find_members(self.org_id, {"id": [user_id]})["results"][0]
         self.assertEqual(res, exp)
@@ -7010,7 +7014,11 @@ class TestDXClientNewUser(DXTestCase):
             "appAccess": True,
             "projectAccess": "CONTRIBUTE",
             "id": user_id,
-            "treManagement": False
+            "treManagement": False,
+            "archivalManagement": False,
+            "dataDeletion": False,
+            "dataSearch": False,
+            "projectMemberDemotion": False
         }
         res = dxpy.api.org_find_members(self.org_id, {"id": [user_id]})["results"][0]
         self.assertEqual(res, exp)
@@ -7028,7 +7036,11 @@ class TestDXClientNewUser(DXTestCase):
             "appAccess": False,
             "projectAccess": "VIEW",
             "id": user_id,
-            "treManagement": False
+            "treManagement": False,
+            "archivalManagement": False,
+            "dataDeletion": False,
+            "dataSearch": False,
+            "projectMemberDemotion": False
         }
         res = dxpy.api.org_find_members(self.org_id, {"id": [user_id]})["results"][0]
         self.assertEqual(res, exp)
@@ -7047,7 +7059,11 @@ class TestDXClientNewUser(DXTestCase):
             "appAccess": True,
             "projectAccess": "ADMINISTER",
             "id": user_id,
-            "treManagement": False
+            "treManagement": False,
+            "archivalManagement": False,
+            "dataDeletion": False,
+            "dataSearch": False,
+            "projectMemberDemotion": False
         }
         res = dxpy.api.org_find_members(self.org_id, {"id": [user_id]})["results"][0]
         self.assertEqual(res, exp)
@@ -7162,7 +7178,11 @@ class TestDXClientMembership(DXTestCase):
                           "cloudIntegrationManagement": False,
                           "appAccess": True,
                           "projectAccess": "ADMINISTER",
-                          "treManagement": False}
+                          "treManagement": False,
+                          "archivalManagement": False,
+                          "dataDeletion": False,
+                          "dataSearch": False,
+                          "projectMemberDemotion": False}
         membership = self._org_find_members(self.user_id)
         self.assertEqual(membership, exp_membership)
 
@@ -7175,7 +7195,11 @@ class TestDXClientMembership(DXTestCase):
                           "cloudIntegrationManagement": False,
                           "appAccess": True,
                           "projectAccess": "CONTRIBUTE",
-                          "treManagement": False}
+                          "treManagement": False,
+                          "archivalManagement": False,
+                          "dataDeletion": False,
+                          "dataSearch": False,
+                          "projectMemberDemotion": False}
         membership = self._org_find_members(self.user_id)
         self.assertEqual(membership, exp_membership)
 
@@ -7237,7 +7261,11 @@ class TestDXClientMembership(DXTestCase):
                           "cloudIntegrationManagement": False,
                           "appAccess": True,
                           "projectAccess": "ADMINISTER",
-                          "treManagement": False}
+                          "treManagement": False,
+                          "archivalManagement": False,
+                          "dataDeletion": False,
+                          "dataSearch": False,
+                          "projectMemberDemotion": False}
         membership = self._org_find_members(self.user_id)
         self.assertEqual(membership, exp_membership)
 
@@ -7365,7 +7393,11 @@ class TestDXClientMembership(DXTestCase):
                           "cloudIntegrationManagement": False,
                           "appAccess": True,
                           "projectAccess": "ADMINISTER",
-                          "treManagement": False}
+                          "treManagement": False,
+                          "archivalManagement": False,
+                          "dataDeletion": False,
+                          "dataSearch": False,
+                          "projectMemberDemotion": False}
         membership = self._org_find_members(self.user_id)
         self.assertEqual(membership, exp_membership)
 
@@ -7377,7 +7409,11 @@ class TestDXClientMembership(DXTestCase):
                           "cloudIntegrationManagement": False,
                           "projectAccess": "VIEW",
                           "appAccess": True,
-                          "treManagement": False}
+                          "treManagement": False,
+                          "archivalManagement": False,
+                          "dataDeletion": False,
+                          "dataSearch": False,
+                          "projectMemberDemotion": False}
         membership = self._org_find_members(self.user_id)
         self.assertEqual(membership, exp_membership)
 
@@ -7389,7 +7425,11 @@ class TestDXClientMembership(DXTestCase):
                           "cloudIntegrationManagement": False,
                           "projectAccess": "VIEW",
                           "appAccess": False,
-                          "treManagement": False}
+                          "treManagement": False,
+                          "archivalManagement": False,
+                          "dataDeletion": False,
+                          "dataSearch": False,
+                          "projectMemberDemotion": False}
 
         membership = self._org_find_members(self.user_id)
         self.assertEqual(membership, exp_membership)

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -7060,10 +7060,10 @@ class TestDXClientNewUser(DXTestCase):
             "projectAccess": "ADMINISTER",
             "id": user_id,
             "treManagement": False,
-            "archivalManagement": False,
-            "dataDeletion": False,
-            "dataSearch": False,
-            "projectMemberDemotion": False
+            "archivalManagement": True,
+            "dataDeletion": True,
+            "dataSearch": True,
+            "projectMemberDemotion": True
         }
         res = dxpy.api.org_find_members(self.org_id, {"id": [user_id]})["results"][0]
         self.assertEqual(res, exp)
@@ -7179,10 +7179,10 @@ class TestDXClientMembership(DXTestCase):
                           "appAccess": True,
                           "projectAccess": "ADMINISTER",
                           "treManagement": False,
-                          "archivalManagement": False,
-                          "dataDeletion": False,
-                          "dataSearch": False,
-                          "projectMemberDemotion": False}
+                          "archivalManagement": True,
+                          "dataDeletion": True,
+                          "dataSearch": True,
+                          "projectMemberDemotion": True}
         membership = self._org_find_members(self.user_id)
         self.assertEqual(membership, exp_membership)
 
@@ -7262,10 +7262,10 @@ class TestDXClientMembership(DXTestCase):
                           "appAccess": True,
                           "projectAccess": "ADMINISTER",
                           "treManagement": False,
-                          "archivalManagement": False,
-                          "dataDeletion": False,
-                          "dataSearch": False,
-                          "projectMemberDemotion": False}
+                          "archivalManagement": True,
+                          "dataDeletion": True,
+                          "dataSearch": True,
+                          "projectMemberDemotion": True}
         membership = self._org_find_members(self.user_id)
         self.assertEqual(membership, exp_membership)
 
@@ -7394,10 +7394,10 @@ class TestDXClientMembership(DXTestCase):
                           "appAccess": True,
                           "projectAccess": "ADMINISTER",
                           "treManagement": False,
-                          "archivalManagement": False,
-                          "dataDeletion": False,
-                          "dataSearch": False,
-                          "projectMemberDemotion": False}
+                          "archivalManagement": True,
+                          "dataDeletion": True,
+                          "dataSearch": True,
+                          "projectMemberDemotion": True}
         membership = self._org_find_members(self.user_id)
         self.assertEqual(membership, exp_membership)
 


### PR DESCRIPTION
https://jira.internal.dnanexus.com/browse/TITAN-183

Several tests in test_dxclient.py started failing recently due to changes brought by

- [TITAN-70](https://jira.internal.dnanexus.com/browse/TITAN-70)

- [TITAN-56](https://jira.internal.dnanexus.com/browse/TITAN-56)

To ensure the affected test can be executed daily, I am updating the expected values returned by org_find_members (the method started returning an additional key:value pairs

```
"archivalManagement": False,
"dataDeletion": False,
"dataSearch": False,
"projectMemberDemotion": False
```

[Passing run](https://jenkins-vstg.internal.dnanexus.com/job/RTM/job/dx-toolkit_traceability_tests_isolated_master_Jenkinsfile/489/) of the affected suite ✅