### PR TITLE
TITAN-244: Prioritize md5 over per-part checksum on download

### DIFF
--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -432,7 +432,7 @@ def _download_dxfile(dxid, filename, part_retry_counter,
                 if chunk_part != cur_part:
                     verify_part(cur_part, got_bytes, hasher, e_tag)
                     cur_part, got_bytes, hasher = chunk_part, 0, md5_hasher()
-                    if dxfile_desc.get('drive') is not None:
+                    if dxfile_desc.get('drive') is not None and "md5" not in parts[cur_part]:
                         _verify_checksum(parts, cur_part, chunk_data, checksum_type, dxfile.get_id())
                 got_bytes += len(chunk_data)
                 hasher.update(chunk_data)

--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -400,7 +400,7 @@ def _download_dxfile(dxid, filename, part_retry_counter,
                         bytes_to_read -= max_verify_chunk_size
                     if hasher.hexdigest() != part_info["md5"]:
                         raise DXFileError("Checksum mismatch when verifying downloaded part {}".format(part_id))
-                    if dxfile_desc.get('drive') is not None:
+                    if dxfile_desc.get('drive') is not None and "md5" not in part_info:
                         _verify_checksum(parts, part_id, chunk, checksum_type, dxfile.get_id())
                     else:
                         last_verified_part = part_id

--- a/src/python/test/test_dxfile_download.py
+++ b/src/python/test/test_dxfile_download.py
@@ -17,9 +17,14 @@
 #   License for the specific language governing permissions and limitations
 #   under the License.
 
+import hashlib
+import os
+import tempfile
 import unittest
+from collections import defaultdict
 from mock import patch
 from dxpy.bindings.dxfile import DXFile
+from dxpy.bindings import dxfile_functions
 
 class TestGetDownloadUrlSecurityWarning(unittest.TestCase):
     FILE_ID = 'file-xxxx'
@@ -79,6 +84,61 @@ class TestGetDownloadUrlSecurityWarning(unittest.TestCase):
             # file_download API called once; warn called once
             mock_dl.assert_called_once()
             mock_warn.assert_called_once()
+
+
+class TestDownloadPerPartChecksumGating(unittest.TestCase):
+    """TITAN-244: on a symlink/drive file, per-part checksum verification is
+    skipped when the part carries an md5 (md5 is the single integrity check),
+    and still runs as a fallback when the part has no md5."""
+
+    FILE_ID = 'file-xxxx'
+    DRIVE = 'drive-xxxx'
+    CHUNK = b'hello world'
+
+    def _make_dxfile(self):
+        dxfile = DXFile()
+        dxfile._dxid = self.FILE_ID
+        return dxfile
+
+    def _run_download(self, part):
+        dxfile = self._make_dxfile()
+        describe_output = {
+            'parts': {'1': part},
+            'size': len(self.CHUNK),
+            'drive': self.DRIVE,
+            'checksumType': 'CRC64NVME',
+        }
+        fd, filename = tempfile.mkstemp()
+        os.close(fd)
+        os.remove(filename)  # ensure "rb+" open fails -> "wb" -> main download loop
+        try:
+            with patch.object(dxfile_functions, 'response_iterator',
+                              return_value=[('1', self.CHUNK)]), \
+                    patch.object(dxfile_functions, '_verify_checksum') as mock_verify:
+                dxfile_functions._download_dxfile(
+                    dxfile, filename, defaultdict(lambda: 3),
+                    describe_output=describe_output)
+            return mock_verify
+        finally:
+            if os.path.exists(filename):
+                os.remove(filename)
+
+    def test_checksum_skipped_when_md5_present(self):
+        part = {
+            'size': len(self.CHUNK),
+            'md5': hashlib.md5(self.CHUNK).hexdigest(),
+            'checksum': '688cIX1wosY=',
+        }
+        mock_verify = self._run_download(part)
+        mock_verify.assert_not_called()
+
+    def test_checksum_verified_when_md5_absent(self):
+        part = {
+            'size': len(self.CHUNK),
+            'checksum': '688cIX1wosY=',
+        }
+        mock_verify = self._run_download(part)
+        mock_verify.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/src/python/test/test_dxfile_download.py
+++ b/src/python/test/test_dxfile_download.py
@@ -123,6 +123,30 @@ class TestDownloadPerPartChecksumGating(unittest.TestCase):
             if os.path.exists(filename):
                 os.remove(filename)
 
+    def _run_resume_preflight(self, part):
+        dxfile = self._make_dxfile()
+        describe_output = {
+            'parts': {'1': part},
+            'size': len(self.CHUNK),
+            'drive': self.DRIVE,
+            'checksumType': 'CRC64NVME',
+        }
+        fd, filename = tempfile.mkstemp()
+        os.close(fd)
+        try:
+            with open(filename, 'wb') as fh:
+                fh.write(self.CHUNK)
+            with patch.object(dxfile_functions, 'response_iterator',
+                              return_value=[]), \
+                    patch.object(dxfile_functions, '_verify_checksum') as mock_verify:
+                dxfile_functions._download_dxfile(
+                    dxfile, filename, defaultdict(lambda: 3),
+                    describe_output=describe_output)
+            return mock_verify
+        finally:
+            if os.path.exists(filename):
+                os.remove(filename)
+
     def test_checksum_skipped_when_md5_present(self):
         part = {
             'size': len(self.CHUNK),
@@ -130,6 +154,15 @@ class TestDownloadPerPartChecksumGating(unittest.TestCase):
             'checksum': '688cIX1wosY=',
         }
         mock_verify = self._run_download(part)
+        mock_verify.assert_not_called()
+
+    def test_resume_preflight_checksum_skipped_when_md5_present(self):
+        part = {
+            'size': len(self.CHUNK),
+            'md5': hashlib.md5(self.CHUNK).hexdigest(),
+            'checksum': '688cIX1wosY=',
+        }
+        mock_verify = self._run_resume_preflight(part)
         mock_verify.assert_not_called()
 
     def test_checksum_verified_when_md5_absent(self):

--- a/src/python/test/test_dxfile_download.py
+++ b/src/python/test/test_dxfile_download.py
@@ -25,6 +25,7 @@ from collections import defaultdict
 from mock import patch
 from dxpy.bindings.dxfile import DXFile
 from dxpy.bindings import dxfile_functions
+from dxpy.exceptions import DXChecksumMismatchError
 
 class TestGetDownloadUrlSecurityWarning(unittest.TestCase):
     FILE_ID = 'file-xxxx'
@@ -155,6 +156,35 @@ class TestDownloadPerPartChecksumGating(unittest.TestCase):
         }
         mock_verify = self._run_download(part)
         mock_verify.assert_not_called()
+
+    def test_md5_verified_when_checksum_skipped(self):
+        dxfile = self._make_dxfile()
+        part = {
+            'size': len(self.CHUNK),
+            'md5': hashlib.md5(b'different data').hexdigest(),
+            'checksum': '688cIX1wosY=',
+        }
+        describe_output = {
+            'parts': {'1': part},
+            'size': len(self.CHUNK),
+            'drive': self.DRIVE,
+            'checksumType': 'CRC64NVME',
+        }
+        fd, filename = tempfile.mkstemp()
+        os.close(fd)
+        os.remove(filename)  # ensure "rb+" open fails -> "wb" -> main download loop
+        try:
+            with patch.object(dxfile_functions, 'response_iterator',
+                              return_value=[('1', self.CHUNK)]), \
+                    patch.object(dxfile_functions, '_verify_checksum') as mock_verify:
+                with self.assertRaises(DXChecksumMismatchError):
+                    dxfile_functions._download_dxfile(
+                        dxfile, filename, defaultdict(lambda: 1),
+                        describe_output=describe_output)
+            mock_verify.assert_not_called()
+        finally:
+            if os.path.exists(filename):
+                os.remove(filename)
 
     def test_resume_preflight_checksum_skipped_when_md5_present(self):
         part = {


### PR DESCRIPTION
## [TITAN-244] Prioritize md5 over per-part checksum on download

### Summary
On download, dxpy verified **both** the per-part `md5` and the per-part `checksum` whenever a symlink/drive file's part carried both. Per team decision with @XingGemini and @ksoni , md5 should be the single integrity check when present. This PR skips per-part `checksum` verification when a part has an `md5`; the checksum verification remains as a fallback for parts without an `md5`.

### Why
`migrateToSymlink`-created files (e.g. UKB migration) carry both `md5` and per-part `checksum`. On dxpy ≥ v0.402.0 (which added CRC64NVME verification), enforcing both causes redundant hashing and download failures (`CRC64NVME checksum not found` / checksum mismatch). This change is being done to unblock testing for the UKB symlink migration. 

### Change
- `src/python/dxpy/bindings/dxfile_functions.py` — gate the per-part `_verify_checksum` call in the main download loop on md5 absence:
  ```python
  if dxfile_desc.get('drive') is not None and "md5" not in parts[cur_part]:
  ```