### PR TITLE
APPS-4202: Fix duplicated record prefix in Nextaur 1.15.0 staging asset

### DIFF
--- a/src/python/dxpy/nextflow/nextaur_assets_25_10.staging.json
+++ b/src/python/dxpy/nextflow/nextaur_assets_25_10.staging.json
@@ -7,6 +7,6 @@
     "azure:uksouth-ofh": "record-J9GJJ392JZ8Gk3b6V1YVB3jX",
     "azure:westeurope": "record-J9GJJ7jBJ0vGy5f1yyvFpg5g",
     "azure:westus": "record-J9GJBBj9BYgqvq27KKjb205b",
-    "oci:us-ashburn-1": "record-record-J9GK2JV644FJXg3z28Vj9Q7F"
+    "oci:us-ashburn-1": "record-J9GK2JV644FJXg3z28Vj9Q7F"
 }
 


### PR DESCRIPTION
## Summary

Correct the Nextaur 1.15.0 staging asset mapping for `oci:us-ashburn-1`.

The current mapping contains a duplicated `record-` prefix:

```text
record-record-J9GK2JV644FJXg3z28Vj9Q7F
```

The corrected asset ID is:

```text
record-J9GK2JV644FJXg3z28Vj9Q7F
```

## Root cause

The malformed static value is defined in:

```text
src/python/dxpy/nextflow/nextaur_assets_25_10.staging.json
```

During:

```bash
dx build --nextflow ...
```

the value is added to `runSpec.assetDepends`.

`dxpy.app_builder.upload_applet()` then executes:

```python
dxpy.DXRecord(asset["id"]).describe(...)
```

and rejects the malformed value during local DXID validation:

```text
Invalid ID of class record:
'record-record-J9GK2JV644FJXg3z28Vj9Q7F'
```

## Change

```diff
- "oci:us-ashburn-1": "record-record-J9GK2JV644FJXg3z28Vj9Q7F"
+ "oci:us-ashburn-1": "record-J9GK2JV644FJXg3z28Vj9Q7F"
```

## Validation

The corrected asset was validated manually:

```bash
dx describe record-J9GK2JV644FJXg3z28Vj9Q7F --json
```

Confirmed:

* The record exists.
* The record is in the `closed` state.
* It is an `AssetBundle`.
* Its version is Nextaur `1.15.0`.
* It contains a valid `details.archiveFileId`.

The malformed value was also checked:

```bash
dx describe record-record-J9GK2JV644FJXg3z28Vj9Q7F --json
```

and does not resolve.

## Impact

Without this fix, staging Nextflow builds that resolve the Nextaur 1.15.0 asset for `oci:us-ashburn-1` fail before applet upload.

This currently blocks the Nextflow QE GitHub Actions regression test:

```text
TestNextflowRequirements.test_build_nextflow_locally_and_run
```