### PR TITLE
APPS-4103: Nextaur 1.16.0 asset mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 
 ### Added
 
-* Released Nextaur 1.16.0 (APPS-4103): fix the cache eviction and lookup throttle that abort `publishDir` with `NoSuchFileException`. Reverts the 1.15.0 seed-on-close attempt, which did not fix the defect.
 * Released Nextaur 1.15.0: Fix upload/path-resolution race by seeding path cache after file close
 
 ## [411.0] - beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 
 ### Added
 
-* Released Nextaur 1.15.0: Fix upload/path-resolution race by seeding path cache after file close
+* Released Nextaur 1.16.0: fix the cache eviction and lookup throttle that abort `publishDir` with `NoSuchFileException`.
 
 ## [411.0] - beta
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 
 ### Added
 
+* Released Nextaur 1.16.0 (APPS-4103): fix the cache eviction and lookup throttle that abort `publishDir` with `NoSuchFileException`. Reverts the 1.15.0 seed-on-close attempt, which did not fix the defect.
 * Released Nextaur 1.15.0: Fix upload/path-resolution race by seeding path cache after file close
 
 ## [411.0] - beta

--- a/src/python/dxpy/nextflow/nextaur_assets_25_10.json
+++ b/src/python/dxpy/nextflow/nextaur_assets_25_10.json
@@ -1,11 +1,11 @@
 {
-    "aws:ap-southeast-2": "record-REPLACE_WITH_1.16.0_PROD_BUILD",
-    "aws:eu-central-1": "record-REPLACE_WITH_1.16.0_PROD_BUILD",
-    "aws:eu-west-2-g": "record-REPLACE_WITH_1.16.0_PROD_BUILD",
-    "aws:me-south-1": "record-REPLACE_WITH_1.16.0_PROD_BUILD",
-    "aws:us-east-1": "record-REPLACE_WITH_1.16.0_PROD_BUILD",
-    "azure:uksouth-ofh": "record-REPLACE_WITH_1.16.0_PROD_BUILD",
-    "azure:westeurope": "record-REPLACE_WITH_1.16.0_PROD_BUILD",
-    "azure:westus": "record-REPLACE_WITH_1.16.0_PROD_BUILD",
-    "oci:us-ashburn-1": "record-REPLACE_WITH_1.16.0_PROD_BUILD"
+    "aws:ap-southeast-2": "record-J9Ppzf85bYJ56ByFVX8G3351",
+    "aws:eu-central-1": "record-J9Ppzf84Qz0zG66y411y6y7x",
+    "aws:eu-west-2-g": "record-J9PpzjBKZ3zGjpVZ1fFGqQq6",
+    "aws:me-south-1": "record-J753PyV3pK4z0G95x298FVXz",
+    "aws:us-east-1": "record-J9Ppxbj0QYk2jPP1BgvXvp09",
+    "azure:uksouth-ofh": "record-J9Pq1k129fkZvX9BfYyz79XV",
+    "azure:westeurope": "record-J9Pq1K0BVJy7FzqxJFp0yx38",
+    "azure:westus": "record-J9Pq1vj9PJFy7yvP1ZvXB11z",
+    "oci:us-ashburn-1": "record-J9Pq0Pk6QyJpXXF8Y6Fq63vv"
 }

--- a/src/python/dxpy/nextflow/nextaur_assets_25_10.json
+++ b/src/python/dxpy/nextflow/nextaur_assets_25_10.json
@@ -1,13 +1,11 @@
 {
-    "aws:ap-southeast-2": "record-J9GJ9b8559xKxFJ0BPj3yjpX",
-    "aws:eu-central-1": "record-J9GJ9Y84qVYjPk253P1YJQ3K",
-    "aws:eu-west-2-g": "record-J9GJ9YXK4J92F2FpP4BB44fP",
-    "aws:me-south-1": "record-J753PyV3pK4z0G95x298FVXz",
-    "aws:us-east-1": "record-J9GJ6fQ0GFB1XpgQpqpf9j7j",
-    "azure:uksouth-ofh": "record-J9GJFp12y3yq8XJf7kzbfJPB",
-    "azure:westeurope": "record-J9GJFGjB0KXyp3X1G4V8y9zq",
-    "azure:westus": "record-J9GJG089Z7j3GJyJ6BbV48gP",
-    "oci:us-ashburn-1": "record-J9GJBGk60JZQ7fVfk8BJbB61"
+    "aws:ap-southeast-2": "record-REPLACE_WITH_1.16.0_PROD_BUILD",
+    "aws:eu-central-1": "record-REPLACE_WITH_1.16.0_PROD_BUILD",
+    "aws:eu-west-2-g": "record-REPLACE_WITH_1.16.0_PROD_BUILD",
+    "aws:me-south-1": "record-REPLACE_WITH_1.16.0_PROD_BUILD",
+    "aws:us-east-1": "record-REPLACE_WITH_1.16.0_PROD_BUILD",
+    "azure:uksouth-ofh": "record-REPLACE_WITH_1.16.0_PROD_BUILD",
+    "azure:westeurope": "record-REPLACE_WITH_1.16.0_PROD_BUILD",
+    "azure:westus": "record-REPLACE_WITH_1.16.0_PROD_BUILD",
+    "oci:us-ashburn-1": "record-REPLACE_WITH_1.16.0_PROD_BUILD"
 }
-
-

--- a/src/python/dxpy/nextflow/nextaur_assets_25_10.staging.json
+++ b/src/python/dxpy/nextflow/nextaur_assets_25_10.staging.json
@@ -1,11 +1,11 @@
 {
-    "aws:ap-southeast-2": "record-REPLACE_WITH_1.16.0_STAGING_BUILD",
-    "aws:eu-central-1": "record-REPLACE_WITH_1.16.0_STAGING_BUILD",
-    "aws:eu-west-2-g": "record-REPLACE_WITH_1.16.0_STAGING_BUILD",
-    "aws:me-south-1": "record-REPLACE_WITH_1.16.0_STAGING_BUILD",
-    "aws:us-east-1": "record-REPLACE_WITH_1.16.0_STAGING_BUILD",
-    "azure:uksouth-ofh": "record-REPLACE_WITH_1.16.0_STAGING_BUILD",
-    "azure:westeurope": "record-REPLACE_WITH_1.16.0_STAGING_BUILD",
-    "azure:westus": "record-REPLACE_WITH_1.16.0_STAGING_BUILD",
-    "oci:us-ashburn-1": "record-REPLACE_WITH_1.16.0_STAGING_BUILD"
+    "aws:ap-southeast-2": "record-J9PkzvQ5PPBZ4Yf0gXvJbf77",
+    "aws:eu-central-1": "record-J9Pkzkj42pVGfb6XYxf34k8j",
+    "aws:eu-west-2-g": "record-J9PkzxBKfQ54jygxyJGKb1G4",
+    "aws:me-south-1": "record-J753XZ932gZKkjZFbGVpjXJ9",
+    "aws:us-east-1": "record-J9Pkqk00ZzQ4jygxyJGKb1Fg",
+    "azure:uksouth-ofh": "record-J9Pp21V2G94pYzX00Y9bzbpB",
+    "azure:westeurope": "record-J9Pp208B5Yb8pbzPQ2Zz5xjq",
+    "azure:westus": "record-J9Pp2G09v15FfGfz9g69QZjz",
+    "oci:us-ashburn-1": "record-J9Pp0ZV6gk64q0P5pJYVyxJJ"
 }

--- a/src/python/dxpy/nextflow/nextaur_assets_25_10.staging.json
+++ b/src/python/dxpy/nextflow/nextaur_assets_25_10.staging.json
@@ -1,12 +1,11 @@
 {
-    "aws:ap-southeast-2": "record-J9GJFJ85qg92PK11QK2v8kY1",
-    "aws:eu-central-1": "record-J9GJFv04bFx2p5zqP7vg6Qx7",
-    "aws:eu-west-2-g": "record-J9GJFGpKpJzvk3b6V1YVB3jJ",
-    "aws:me-south-1": "record-J753XZ932gZKkjZFbGVpjXJ9",
-    "aws:us-east-1": "record-J9GJ8Zj042FXPK11QK2v8kXq",
-    "azure:uksouth-ofh": "record-J9GJJ392JZ8Gk3b6V1YVB3jX",
-    "azure:westeurope": "record-J9GJJ7jBJ0vGy5f1yyvFpg5g",
-    "azure:westus": "record-J9GJBBj9BYgqvq27KKjb205b",
-    "oci:us-ashburn-1": "record-J9GK2JV644FJXg3z28Vj9Q7F"
+    "aws:ap-southeast-2": "record-REPLACE_WITH_1.16.0_STAGING_BUILD",
+    "aws:eu-central-1": "record-REPLACE_WITH_1.16.0_STAGING_BUILD",
+    "aws:eu-west-2-g": "record-REPLACE_WITH_1.16.0_STAGING_BUILD",
+    "aws:me-south-1": "record-REPLACE_WITH_1.16.0_STAGING_BUILD",
+    "aws:us-east-1": "record-REPLACE_WITH_1.16.0_STAGING_BUILD",
+    "azure:uksouth-ofh": "record-REPLACE_WITH_1.16.0_STAGING_BUILD",
+    "azure:westeurope": "record-REPLACE_WITH_1.16.0_STAGING_BUILD",
+    "azure:westus": "record-REPLACE_WITH_1.16.0_STAGING_BUILD",
+    "oci:us-ashburn-1": "record-REPLACE_WITH_1.16.0_STAGING_BUILD"
 }
-


### PR DESCRIPTION
Companion to nextaur release 1.16.0.

Maps the Nextaur 1.16.0 asset records into
nextaur_assets_25_10.json (prod) and .staging.json (staging) for all active
regions.

aws:me-south-1 is left on its pre-1.16.0 record (nextaur-1.12.1): that region
currently has no worker capacity for asset-build jobs (they queue
indefinitely), so no 1.16.0 asset could be built there.

**Test**
- [ ] Run Nextflow QE requirements tests on this branch before merging.

**Merge order**: per doc/Releasing.md, merge this PR before the nextaur-app
release PR.