### PR TITLE
APPS-4127: review fixes for #1571

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 
 ### Added
 
-* Nextflow applets support offline mode: `nextflow_run_opts="-offline"` exports `NXF_OFFLINE`, and it is enabled automatically when the job has no outbound internet access (`jobOutboundInternet=false`). `-offline=false` forces a run back online.
+* Nextflow applets support offline mode: `nextflow_run_opts="-offline"` exports `NXF_OFFLINE`, and it is enabled
+  automatically when the job has no outbound internet access -- either because the project policy disallows it
+  (`jobOutboundInternet=false`) or because the applet was built with `access.network: []`. `-offline=false` forces a
+  run back online. Note: automatic activation from `jobOutboundInternet=false` has not been exercised on the
+  platform -- no project carrying that policy was available -- and is covered by unit tests only. Offline mode is
+  also absent from applets built with `--cache-docker`, which are rendered by the Nextflow Pipeline Importer app
+  using its own dxpy.
 
 ## [413.0] - beta
 

--- a/src/python/dxpy/templating/templates/nextflow/src/nextflow.sh
+++ b/src/python/dxpy/templating/templates/nextflow/src/nextflow.sh
@@ -454,52 +454,136 @@ get_job_outbound_internet() {
   echo "$result"
 }
 
+# Echoes "false" when this applet was built without outbound network access, "true" when it
+# has some, and nothing when it cannot be told. Effective egress on a worker is
+# `access.network` AND `jobOutboundInternet`; this is the half `jobOutboundInternet` does not
+# cover. An applet built with `access.network: []` has no internet even in a project whose
+# jobOutboundInternet is true, which is the ordinary way a Nextflow applet gets restricted.
+# Reads the describe cached by detect_nextaur_plugin_version, so it costs no extra API call.
+get_executable_network_access() {
+  local entries
+  entries=$(echo "$DX_EXECUTABLE_DESCRIBE" |
+    jq -r 'if has("access") then (.access.network // [] | length | tostring) else "" end' 2>/dev/null || true)
+  case $entries in
+  "") ;;
+  0) echo "false" ;;
+  *) echo "true" ;;
+  esac
+}
+
+# Splits $nextflow_run_opts into $RUN_OPTS_TOKENS. Deliberate word splitting rather than
+# `read -r -a`: `read` stops at the first line break, so options written on a second line
+# would be silently dropped from the command. Globbing cannot interfere -- `set -f` is in
+# force for the whole script.
+split_run_opts() {
+  # shellcheck disable=SC2206
+  RUN_OPTS_TOKENS=($nextflow_run_opts)
+}
+
+# Echoes $1 without one layer of surrounding quotes. `declare -a NEXTFLOW_CMD="(...)"` strips
+# those before Nextflow sees the token, so the matching here has to strip them too -- otherwise
+# a quoted "-offline=true" is not recognised and reaches the CLI, which rejects it.
+dequote_run_opt() {
+  local bare=$1
+  bare=${bare#[\"\']}
+  bare=${bare%[\"\']}
+  echo "$bare"
+}
+
+# Writes $2.. back into $nextflow_run_opts, but only when a token was actually removed ($1 is
+# the original token count). Rejoining is not loss-free -- runs of spaces inside a quoted value
+# collapse -- so the string is left byte-for-byte alone on every run that changes nothing,
+# which is every run that does not use -offline= or -latest.
+set_run_opts_if_changed() {
+  local original_count=$1
+  shift
+  [[ $# -eq $original_count ]] || nextflow_run_opts="$*"
+}
+
 # Reads the offline request out of $nextflow_run_opts into $NXF_OFFLINE_REQUEST ("on", "off"
 # or empty) and rewrites $nextflow_run_opts.
-# `-offline` is a real Nextflow option and is passed through untouched. `-offline=<value>` is
-# not: Nextflow rejects that form with "Unknown option", so it is treated as a DNAnexus-only
-# control and consumed here instead of reaching the command line.
+# `-offline` is a real Nextflow run option and is normally passed through untouched. It is
+# dropped when the final decision is "off": leaving it on the command line would turn
+# Nextflow's own offline flag on while the job log says the run is online, and would make
+# Nextflow abort if `-latest` is also present.
+# `-offline=<value>` is not a Nextflow option -- Nextflow rejects that form with "Unknown
+# option" -- so it is a DNAnexus-only control and is consumed here. Only `true` and `false`
+# are accepted: guessing at `-offline=0` would silently do the opposite of what was asked.
 parse_offline_run_opts() {
-  local opt
-  local -a offline_opts=() kept=()
+  local opt bare
+  local -a kept=()
   NXF_OFFLINE_REQUEST=""
-  IFS=" " read -r -a offline_opts <<<"$nextflow_run_opts"
-  for opt in "${offline_opts[@]}"; do
-    case $opt in
-    -offline)
+  split_run_opts
+
+  # first pass: decide, so the second pass knows whether a bare `-offline` may stay
+  for opt in "${RUN_OPTS_TOKENS[@]}"; do
+    bare=$(dequote_run_opt "$opt")
+    case $bare in
+    -offline | -offline=true)
       NXF_OFFLINE_REQUEST="on"
-      kept+=("$opt")
       ;;
     -offline=false)
       NXF_OFFLINE_REQUEST="off"
       ;;
     -offline=*)
-      NXF_OFFLINE_REQUEST="on"
+      dx-jobutil-report-error "Unsupported value in nextflow_run_opts: ${bare}. Use -offline or -offline=true to run Nextflow without internet access, or -offline=false to force the run back online."
       ;;
+    esac
+  done
+
+  # second pass: drop the tokens that must not reach the Nextflow command line
+  for opt in "${RUN_OPTS_TOKENS[@]}"; do
+    bare=$(dequote_run_opt "$opt")
+    case $bare in
+    -offline)
+      [[ $NXF_OFFLINE_REQUEST == off ]] || kept+=("$opt")
+      ;;
+    -offline=*) ;;
     *)
       kept+=("$opt")
       ;;
     esac
   done
-  nextflow_run_opts="${kept[*]}"
+
+  set_run_opts_if_changed "${#RUN_OPTS_TOKENS[@]}" "${kept[@]}"
 }
 
 # `-latest` pulls updates for a pipeline hosted in a remote repository. On DNAnexus the
 # pipeline ships inside the applet, so the option has no effect at all -- but Nextflow refuses
 # to combine it with offline mode and aborts the run. Drop it instead, and say so.
 drop_latest_run_opt() {
-  local opt
-  local -a latest_opts=() kept=()
-  IFS=" " read -r -a latest_opts <<<"$nextflow_run_opts"
-  for opt in "${latest_opts[@]}"; do
-    if [[ $opt == -latest ]]; then
+  local opt bare
+  local -a kept=()
+  split_run_opts
+  for opt in "${RUN_OPTS_TOKENS[@]}"; do
+    bare=$(dequote_run_opt "$opt")
+    if [[ $bare == -latest ]]; then
       echo "Ignoring the -latest run option: it has no effect on a pipeline bundled in an applet"
       echo "and Nextflow does not allow it together with offline mode."
       continue
     fi
     kept+=("$opt")
   done
-  nextflow_run_opts="${kept[*]}"
+  set_run_opts_if_changed "${#RUN_OPTS_TOKENS[@]}" "${kept[@]}"
+}
+
+# `-offline` is a `nextflow run` option, not a top-level one: `nextflow -offline run ...`
+# fails with "Unknown option". nf-core's documentation talks about it without that
+# distinction, so catch the mistake here with an actionable message instead of letting
+# Nextflow abort on an opaque one.
+reject_offline_in_top_level_opts() {
+  local opt bare
+  local -a tokens=()
+  # shellcheck disable=SC2206
+  tokens=($nextflow_top_level_opts)
+  for opt in "${tokens[@]}"; do
+    bare=$(dequote_run_opt "$opt")
+    case $bare in
+    -offline | -offline=*)
+      dx-jobutil-report-error "Please pass ${bare} in nextflow_run_opts, not in nextflow_top_level_opts. Nextflow only accepts -offline as a run option; given as a top-level option it fails with \"Unknown option\"."
+      ;;
+    esac
+  done
 }
 
 # Turns on Nextflow offline mode: no version check, no plugin registry access, no
@@ -519,6 +603,7 @@ enable_offline_mode() {
 # Every branch records $NXF_OFFLINE_REASON, so log_context_info can state why the run is
 # offline *or* why it is not -- support has to be able to answer that from the job log alone.
 setup_offline_mode() {
+  reject_offline_in_top_level_opts
   parse_offline_run_opts
 
   # explicit opt-out wins over everything: a restricted environment, and a variable that
@@ -540,18 +625,26 @@ setup_offline_mode() {
     return
   fi
 
-  case $(get_job_outbound_internet) in
-  false)
+  # a worker reaches the internet only when the project policy allows it *and* the applet was
+  # built with network access, so either one saying no is enough to decide
+  local outbound network
+  outbound=$(get_job_outbound_internet)
+  network=$(get_executable_network_access)
+
+  if [[ $outbound == false ]]; then
     enable_offline_mode "this job has no outbound internet access (jobOutboundInternet=false)"
-    ;;
-  true)
+    return
+  fi
+  if [[ $network == false ]]; then
+    enable_offline_mode "this applet was built without network access (access.network is empty)"
+    return
+  fi
+  if [[ $outbound == true ]]; then
     NXF_OFFLINE_REASON="this job has outbound internet access (jobOutboundInternet=true)"
-    ;;
-  *)
-    NXF_OFFLINE_REASON="could not determine whether this job has outbound internet access"
-    echo "Could not determine whether this job has outbound internet access; assuming it has."
-    ;;
-  esac
+    return
+  fi
+  NXF_OFFLINE_REASON="could not determine whether this job has outbound internet access"
+  echo "Could not determine whether this job has outbound internet access; assuming it has."
 }
 
 # =========================================================
@@ -580,7 +673,10 @@ validate_run_opts() {
 
 detect_nextaur_plugin_version() {
   executable=$(cat dnanexus-executable.json | jq -r .id )
-  bundled_dependency=$(dx describe ${executable} --json | jq -r '.runSpec.bundledDepends[] | select(.name=="nextaur.tar.gz") | .id."$dnanexus_link"')
+  # kept in a variable so get_executable_network_access can reuse it: the offline decision
+  # needs .access.network from the same document, and this describe already happens
+  DX_EXECUTABLE_DESCRIBE=$(dx describe ${executable} --json)
+  bundled_dependency=$(echo "$DX_EXECUTABLE_DESCRIBE" | jq -r '.runSpec.bundledDepends[] | select(.name=="nextaur.tar.gz") | .id."$dnanexus_link"')
   asset_dependency=$(dx describe ${bundled_dependency} --json | jq -r .properties.AssetBundle)
   export NXF_PLUGINS_VERSION=$(dx describe ${asset_dependency} --json | jq -r .properties.version)
 }

--- a/src/python/dxpy/templating/templates/nextflow/src/nextflow.sh
+++ b/src/python/dxpy/templating/templates/nextflow/src/nextflow.sh
@@ -454,12 +454,10 @@ get_job_outbound_internet() {
   echo "$result"
 }
 
-# Echoes "false" when this applet was built without outbound network access, "true" when it
-# has some, and nothing when it cannot be told. Effective egress on a worker is
-# `access.network` AND `jobOutboundInternet`; this is the half `jobOutboundInternet` does not
-# cover. An applet built with `access.network: []` has no internet even in a project whose
-# jobOutboundInternet is true, which is the ordinary way a Nextflow applet gets restricted.
-# Reads the describe cached by detect_nextaur_plugin_version, so it costs no extra API call.
+# Effective egress on a worker is `access.network` AND `jobOutboundInternet`; this is the half
+# `jobOutboundInternet` does not cover. An applet built with `access.network: []` has no
+# internet even in a project whose jobOutboundInternet is true, which is the ordinary way a
+# Nextflow applet gets restricted.
 get_executable_network_access() {
   local entries
   entries=$(echo "$DX_EXECUTABLE_DESCRIBE" |
@@ -471,18 +469,17 @@ get_executable_network_access() {
   esac
 }
 
-# Splits $nextflow_run_opts into $RUN_OPTS_TOKENS. Deliberate word splitting rather than
-# `read -r -a`: `read` stops at the first line break, so options written on a second line
-# would be silently dropped from the command. Globbing cannot interfere -- `set -f` is in
-# force for the whole script.
+# Word splitting rather than `read -r -a`: `read` stops at the first line break, so options
+# written on a second line would be silently dropped. `set -f` is in force for the whole
+# script, so globbing cannot interfere.
 split_run_opts() {
   # shellcheck disable=SC2206
   RUN_OPTS_TOKENS=($nextflow_run_opts)
 }
 
-# Echoes $1 without one layer of surrounding quotes. `declare -a NEXTFLOW_CMD="(...)"` strips
-# those before Nextflow sees the token, so the matching here has to strip them too -- otherwise
-# a quoted "-offline=true" is not recognised and reaches the CLI, which rejects it.
+# `declare -a NEXTFLOW_CMD="(...)"` strips one layer of quotes before Nextflow sees the token,
+# so the matching has to strip it too -- otherwise a quoted "-offline=true" is not recognised
+# and reaches the CLI, which rejects it.
 dequote_run_opt() {
   local bare=$1
   bare=${bare#[\"\']}
@@ -490,18 +487,14 @@ dequote_run_opt() {
   echo "$bare"
 }
 
-# Writes $2.. back into $nextflow_run_opts, but only when a token was actually removed ($1 is
-# the original token count). Rejoining is not loss-free -- runs of spaces inside a quoted value
-# collapse -- so the string is left byte-for-byte alone on every run that changes nothing,
-# which is every run that does not use -offline= or -latest.
+# $1 is the original token count. Rejoining is not loss-free -- runs of spaces inside a quoted
+# value collapse -- so the string is left alone unless a token was actually removed.
 set_run_opts_if_changed() {
   local original_count=$1
   shift
   [[ $# -eq $original_count ]] || nextflow_run_opts="$*"
 }
 
-# Reads the offline request out of $nextflow_run_opts into $NXF_OFFLINE_REQUEST ("on", "off"
-# or empty) and rewrites $nextflow_run_opts.
 # `-offline` is a real Nextflow run option and is normally passed through untouched. It is
 # dropped when the final decision is "off": leaving it on the command line would turn
 # Nextflow's own offline flag on while the job log says the run is online, and would make
@@ -515,7 +508,7 @@ parse_offline_run_opts() {
   NXF_OFFLINE_REQUEST=""
   split_run_opts
 
-  # first pass: decide, so the second pass knows whether a bare `-offline` may stay
+  # decide first, so the filtering pass below knows whether a bare `-offline` may stay
   for opt in "${RUN_OPTS_TOKENS[@]}"; do
     bare=$(dequote_run_opt "$opt")
     case $bare in
@@ -531,7 +524,6 @@ parse_offline_run_opts() {
     esac
   done
 
-  # second pass: drop the tokens that must not reach the Nextflow command line
   for opt in "${RUN_OPTS_TOKENS[@]}"; do
     bare=$(dequote_run_opt "$opt")
     case $bare in
@@ -567,10 +559,9 @@ drop_latest_run_opt() {
   set_run_opts_if_changed "${#RUN_OPTS_TOKENS[@]}" "${kept[@]}"
 }
 
-# `-offline` is a `nextflow run` option, not a top-level one: `nextflow -offline run ...`
-# fails with "Unknown option". nf-core's documentation talks about it without that
-# distinction, so catch the mistake here with an actionable message instead of letting
-# Nextflow abort on an opaque one.
+# `-offline` is a `nextflow run` option, not a top-level one: `nextflow -offline run ...` fails
+# with "Unknown option". nf-core's documentation does not make that distinction, so catch the
+# mistake with an actionable message.
 reject_offline_in_top_level_opts() {
   local opt bare
   local -a tokens=()
@@ -625,8 +616,6 @@ setup_offline_mode() {
     return
   fi
 
-  # a worker reaches the internet only when the project policy allows it *and* the applet was
-  # built with network access, so either one saying no is enough to decide
   local outbound network
   outbound=$(get_job_outbound_internet)
   network=$(get_executable_network_access)
@@ -673,8 +662,7 @@ validate_run_opts() {
 
 detect_nextaur_plugin_version() {
   executable=$(cat dnanexus-executable.json | jq -r .id )
-  # kept in a variable so get_executable_network_access can reuse it: the offline decision
-  # needs .access.network from the same document, and this describe already happens
+  # cached so get_executable_network_access can read .access.network without a second describe
   DX_EXECUTABLE_DESCRIBE=$(dx describe ${executable} --json)
   bundled_dependency=$(echo "$DX_EXECUTABLE_DESCRIBE" | jq -r '.runSpec.bundledDepends[] | select(.name=="nextaur.tar.gz") | .id."$dnanexus_link"')
   asset_dependency=$(dx describe ${bundled_dependency} --json | jq -r .properties.AssetBundle)

--- a/src/python/test/test_nextflow.py
+++ b/src/python/test/test_nextflow.py
@@ -21,6 +21,7 @@ from parameterized import parameterized
 
 import tempfile
 import textwrap
+import subprocess
 import shutil
 import os
 import sys
@@ -600,16 +601,21 @@ class TestNextflowOfflineMode(unittest.TestCase):
                 esac
                 """))
         os.chmod(dx_stub, 0o755)
+        # `dx-jobutil-report-error` aborts the job on the platform; here it prints the message
+        # and exits non-zero, so a test can assert both the failure and what the user is told
+        err_stub = os.path.join(cls.stub_dir, "dx-jobutil-report-error")
+        with open(err_stub, "w") as f:
+            f.write('#!/usr/bin/env bash\necho "$1"\nexit 1\n')
+        os.chmod(err_stub, 0o755)
 
     @classmethod
     def tearDownClass(cls):
         shutil.rmtree(cls.tempdir, ignore_errors=True)
 
     def _run_bash(self, snippet, describe_json="", api_fails=False, run_opts="", nxf_offline=None,
-                  job_json=None, project_json=None):
+                  job_json=None, project_json=None, top_level_opts="", executable_json="",
+                  expect_failure=False):
         """Runs `snippet` against the sourced applet script; returns (stdout, described ids)."""
-        import subprocess
-
         calls_file = os.path.join(self.tempdir, "dx_calls.log")
         if os.path.exists(calls_file):
             os.remove(calls_file)
@@ -625,6 +631,9 @@ class TestNextflowOfflineMode(unittest.TestCase):
         if project_json is not None:
             env["DX_STUB_PROJECT_JSON"] = project_json
         env["nextflow_run_opts"] = run_opts
+        env["nextflow_top_level_opts"] = top_level_opts
+        # normally set by detect_nextaur_plugin_version from the executable describe
+        env["DX_EXECUTABLE_DESCRIBE"] = executable_json
         if nxf_offline is not None:
             env["NXF_OFFLINE"] = nxf_offline
         else:
@@ -634,7 +643,10 @@ class TestNextflowOfflineMode(unittest.TestCase):
         result = subprocess.run(
             ["bash", "-c", "set -e; source '{}'; {}".format(self.src_file, snippet)],
             env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
-        self.assertEqual(result.returncode, 0, result.stderr)
+        if expect_failure:
+            self.assertNotEqual(result.returncode, 0, "expected the helper to abort the job")
+        else:
+            self.assertEqual(result.returncode, 0, result.stderr)
         described = []
         if os.path.exists(calls_file):
             with open(calls_file) as f:
@@ -817,6 +829,118 @@ class TestNextflowOfflineMode(unittest.TestCase):
             'setup_offline_mode >/dev/null; echo "${NXF_DISABLE_CHECK_LATEST:-unset}"',
             describe_json='{"jobOutboundInternet":false}')
         self.assertEqual(flag, "true")
+
+    @parameterized.expand([
+        # `read -r -a` stops at the first line break, so rebuilding the string from it drops
+        # every option written on a later line -- silently, on a run that then succeeds with
+        # the wrong options. This bites every run, not only the offline ones.
+        # nothing is removed here, so the string is left byte-for-byte alone -- newline included
+        ("newline_offline_requested", "-offline\n-profile docker --outdir results",
+         '{"jobOutboundInternet":true}', "-offline\n-profile docker --outdir results"),
+        ("newline_nothing_to_rewrite", "-resume\n-profile docker",
+         '{"jobOutboundInternet":true}', "-resume\n-profile docker"),
+        ("newline_with_latest_dropped", "-offline\n-latest -resume",
+         '{"jobOutboundInternet":true}', "-offline -resume"),
+    ])
+    def test_run_opts_survive_line_breaks(self, _name, run_opts, describe_json, expected):
+        opts, _calls = self._run_bash('setup_offline_mode >/dev/null; echo "$nextflow_run_opts"',
+                                      describe_json=describe_json, run_opts=run_opts)
+        self.assertEqual(opts, expected)
+
+    def test_run_opts_left_untouched_when_nothing_is_removed(self):
+        # rejoining tokens collapses runs of spaces inside a quoted value, so the string must
+        # not be rewritten on a run that removes nothing
+        opts, _calls = self._run_bash('setup_offline_mode >/dev/null; echo "$nextflow_run_opts"',
+                                      describe_json='{"jobOutboundInternet":true}',
+                                      run_opts='-offline --with-report "a  b.html"')
+        self.assertEqual(opts, '-offline --with-report "a  b.html"')
+
+    @parameterized.expand([
+        # A bare `-offline` must not survive an opt-out: it would set CmdRun.offline while the
+        # log says the run is online, and it makes Nextflow abort when `-latest` is present too
+        ("bare_offline_dropped", "-offline -offline=false", "unset", ""),
+        ("bare_offline_dropped_keeps_rest", "-resume -offline -offline=false", "unset", "-resume"),
+        ("latest_may_stay_when_online", "-offline -offline=false -latest", "unset", "-latest"),
+    ])
+    def test_opt_out_also_strips_bare_offline(self, _name, run_opts, expected_flag, expected_opts):
+        flag, _calls = self._offline_flag(describe_json='{"jobOutboundInternet":true}',
+                                          run_opts=run_opts)
+        self.assertEqual(flag, expected_flag)
+        opts, _calls = self._run_bash('setup_offline_mode >/dev/null; echo "$nextflow_run_opts"',
+                                      describe_json='{"jobOutboundInternet":true}', run_opts=run_opts)
+        self.assertEqual(opts, expected_opts)
+
+    @parameterized.expand([
+        # `declare -a NEXTFLOW_CMD="(...)"` strips one layer of quotes before Nextflow sees the
+        # token, so the matching has to strip it too -- otherwise the token reaches the CLI,
+        # which rejects `-offline=<value>` with "Unknown option"
+        ('double_quoted', '"-offline=true"'),
+        ('single_quoted', "'-offline=true'"),
+    ])
+    def test_quoted_offline_tokens_are_recognised(self, _name, run_opts):
+        flag, _calls = self._offline_flag(describe_json='{"jobOutboundInternet":true}',
+                                          run_opts=run_opts)
+        self.assertEqual(flag, "true")
+        opts, _calls = self._run_bash('setup_offline_mode >/dev/null; echo "$nextflow_run_opts"',
+                                      describe_json='{"jobOutboundInternet":true}', run_opts=run_opts)
+        self.assertEqual(opts, "")
+
+    @parameterized.expand([
+        # Guessing at an unrecognised value risks doing the opposite of what was asked
+        ("zero", "-offline=0"),
+        ("no", "-offline=no"),
+        ("yes", "-offline=yes"),
+    ])
+    def test_unrecognised_offline_value_aborts(self, _name, run_opts):
+        out, _calls = self._run_bash('setup_offline_mode', run_opts=run_opts,
+                                     describe_json='{"jobOutboundInternet":true}',
+                                     expect_failure=True)
+        self.assertIn("Unsupported value in nextflow_run_opts", out)
+
+    @parameterized.expand([
+        # `-offline` is a `nextflow run` option; as a top-level option Nextflow rejects it
+        ("bare", "-offline"),
+        ("with_value", "-offline=true"),
+        ("among_others", "-quiet -offline"),
+    ])
+    def test_offline_in_top_level_opts_aborts_with_a_hint(self, _name, top_level_opts):
+        out, _calls = self._run_bash('setup_offline_mode', top_level_opts=top_level_opts,
+                                     describe_json='{"jobOutboundInternet":true}',
+                                     expect_failure=True)
+        self.assertIn("nextflow_run_opts, not in nextflow_top_level_opts", out)
+
+    @parameterized.expand([
+        # Effective egress is `access.network` AND `jobOutboundInternet`. An applet built with
+        # an empty network list has no internet even where jobOutboundInternet is true, which
+        # is how a Nextflow applet is normally restricted.
+        ("empty_network_goes_offline", '{"access":{"network":[]}}', '{"jobOutboundInternet":true}', "true"),
+        ("open_network_stays_online", '{"access":{"network":["*"]}}', '{"jobOutboundInternet":true}', "unset"),
+        ("restricted_host_list_stays_online", '{"access":{"network":["dnanexus.com"]}}',
+         '{"jobOutboundInternet":true}', "unset"),
+        # `access` absent means the describe could not be used; fail open, as everywhere else
+        ("no_access_field_stays_online", "{}", '{"jobOutboundInternet":true}', "unset"),
+        ("unavailable_describe_stays_online", "", '{"jobOutboundInternet":true}', "unset"),
+        # the project policy still decides on its own
+        ("policy_false_still_wins", '{"access":{"network":["*"]}}', '{"jobOutboundInternet":false}', "true"),
+    ])
+    def test_executable_network_access_feeds_auto_detection(self, _name, executable_json,
+                                                            describe_json, expected):
+        flag, _calls = self._offline_flag(describe_json=describe_json,
+                                          executable_json=executable_json)
+        self.assertEqual(flag, expected)
+
+    def test_network_access_reason_names_the_source(self):
+        reason, _calls = self._run_bash('setup_offline_mode >/dev/null; echo "$NXF_OFFLINE_REASON"',
+                                        describe_json='{"jobOutboundInternet":true}',
+                                        executable_json='{"access":{"network":[]}}')
+        self.assertIn("access.network is empty", reason)
+
+    def test_explicit_request_still_beats_network_detection(self):
+        # the opt-out must work in a restricted applet too, or there is no way back online
+        flag, _calls = self._offline_flag(describe_json='{"jobOutboundInternet":true}',
+                                          executable_json='{"access":{"network":[]}}',
+                                          run_opts="-offline=false")
+        self.assertEqual(flag, "unset")
 
     def test_src_reports_offline_mode_in_context_info(self):
         # Asserts the observability contract, not how it is written: the exact echo text and the


### PR DESCRIPTION
Addresses the review comments on #1571. Targets `APPS-4127`, so merging it folds the changes into that PR.

**Run option parsing** (`nextflow.sh`)
- `read -r -a` stops at the first line break, so options written on a later line were silently dropped from the Nextflow command — on every run, not only the offline ones. Word splitting instead.
- The string is now only rewritten when a token was actually removed, so a run that changes nothing keeps it byte-for-byte.
- One layer of quotes is stripped before matching, so a quoted `"-offline=true"` is recognised instead of reaching the CLI that rejects it.
- Parsing is two passes, so a bare `-offline` is dropped when `-offline=false` wins. Previously it stayed on the command line, turning Nextflow's own offline flag on while the log said the run was online — and aborting the run outright when `-latest` was also present.
- `-offline=<anything but true/false>` aborts instead of being guessed at.
- `-offline` in `nextflow_top_level_opts` aborts with a hint, rather than Nextflow's `Unknown option`.

**Automatic detection**
- A worker reaches the internet only when `jobOutboundInternet` **and** the applet's `access.network` allow it. An applet built with `access.network: []` has no egress even where `jobOutboundInternet` is true — the ordinary way a Nextflow applet gets restricted — so both are considered now.
- `access.network` is read from the executable describe `detect_nextaur_plugin_version` already performs, so it costs no extra API call.

**CHANGELOG** — states that automatic activation from `jobOutboundInternet=false` has never been exercised on the platform, and that `--cache-docker` applets do not carry the feature.

**Tests** — 23 new cases (68 pass in total; the existing 45 are unchanged). `shellcheck` is clean apart from the pre-existing SC2154 class.

Known limitation: rejoining tokens still collapses repeated spaces inside a quoted value on runs that genuinely remove a token. Avoiding that entirely means not round-tripping the string at all.