### PR TITLE
[APPS-4297] decrease default expiration from `30d` to `18h`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 
 ## Unreleased
 
+### Changed
+
+* Decreased default `dx login` session expiration from 30 days to 18 hours to be aligned with [current platform behaviour](https://documentation.dnanexus.com/user/login-and-logout#session-expiration)
+
 ## [413.0] - beta
 
 * No significant changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 
 ### Changed
 
-* Decreased default `dx login` session expiration from 30 days to 18 hours to be aligned with [current platform behaviour](https://documentation.dnanexus.com/user/login-and-logout#session-expiration)
+* Decreased default `dx login` session expiration from 30 days to 18 hours to align with [current platform behaviour](https://documentation.dnanexus.com/user/login-and-logout#session-expiration)
 
 ## [413.0] - beta
 

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -4635,7 +4635,7 @@ parser_login.add_argument('--noprojects', dest='projects', help='Do not print av
 parser_login.add_argument('--save', help='Save token and other environment variables for future sessions',
                           action='store_true')
 parser_login.add_argument('--timeout', default='18h',
-                          help='Timeout for this login token (in seconds, or use suffix s, m, h, d, w, M, y)')
+                          help='Timeout for this login token (in seconds, or use suffix s, m, h)')
 parser_login.add_argument('--staging', nargs=0, help=argparse.SUPPRESS, action=SetStagingEnv)
 parser_login.set_defaults(staging=False, func=login)
 register_parser(parser_login, categories='session')

--- a/src/python/dxpy/scripts/dx.py
+++ b/src/python/dxpy/scripts/dx.py
@@ -4634,7 +4634,7 @@ host_action.help = port_action.help = protocol_action.help = argparse.SUPPRESS
 parser_login.add_argument('--noprojects', dest='projects', help='Do not print available projects', action='store_false')
 parser_login.add_argument('--save', help='Save token and other environment variables for future sessions',
                           action='store_true')
-parser_login.add_argument('--timeout', default='30d',
+parser_login.add_argument('--timeout', default='18h',
                           help='Timeout for this login token (in seconds, or use suffix s, m, h, d, w, M, y)')
 parser_login.add_argument('--staging', nargs=0, help=argparse.SUPPRESS, action=SetStagingEnv)
 parser_login.set_defaults(staging=False, func=login)


### PR DESCRIPTION
Decrease defaultly requested login session expiration from `30d` to `18h`. As back-end caps the final value anyway, there is no need for such large default value.