### PR TITLE
APPS-4308: Preserve request-scoped auth across DXFile operations

### DIFF
--- a/src/python/dxpy/bindings/dxfile.py
+++ b/src/python/dxpy/bindings/dxfile.py
@@ -760,7 +760,8 @@ class DXFile(DXDataObject):
                 if project is None and 'DX_JOB_ID' not in os.environ:
                     project_from_handler = self.get_proj_id()
                     # object_exists_in_project will call /file-xxxx/describe, which is skipped if the URL is cached
-                    if project_from_handler and object_exists_in_project(self.get_id(), project_from_handler):
+                    if project_from_handler and object_exists_in_project(
+                        self.get_id(), project_from_handler, **kwargs):
                         project = project_from_handler
 
                 if project is not None and project is not DXFile.NO_PROJECT_HINT:
@@ -935,7 +936,7 @@ class DXFile(DXDataObject):
     def read(self, length=None, use_compression=None, project=None, **kwargs):
         # Check if the file is present in dxfile project attribute if the project arg not specified 
         if project is None and self._exists_in_proj is None and self.get_proj_id() is not None:
-            self._exists_in_proj = object_exists_in_project(self.get_id(), self.get_proj_id())
+            self._exists_in_proj = object_exists_in_project(self.get_id(), self.get_proj_id(), **kwargs)
         # Use the DXFile attribute if the project arg is not provided
         if project is None and self._exists_in_proj:
             project = self.get_proj_id()

--- a/src/python/dxpy/bindings/dxfile_functions.py
+++ b/src/python/dxpy/bindings/dxfile_functions.py
@@ -615,7 +615,9 @@ def upload_local_file(filename=None, file=None, media_type=None, keep_open=False
             sys.stderr.write("\n")
             sys.stderr.flush()
         try:
-            handler.wait_until_parts_uploaded()
+            wait_kwargs = remaining_kwargs.copy()
+            wait_kwargs.pop("timeout", None)
+            handler.wait_until_parts_uploaded(**wait_kwargs)
         except DXError:
             if show_progress:
                 logger.warning("File {} was not uploaded correctly!".format(filename))

--- a/src/python/dxpy/utils/resolver.py
+++ b/src/python/dxpy/utils/resolver.py
@@ -199,7 +199,7 @@ def is_project_explicit(path):
     return not is_hashid(path)
 
 
-def object_exists_in_project(obj_id, proj_id):
+def object_exists_in_project(obj_id, proj_id, **kwargs):
     '''
     :param obj_id: object ID
     :type obj_id: str
@@ -215,7 +215,7 @@ def object_exists_in_project(obj_id, proj_id):
         raise ValueError("Expected proj_id to be a string")
     if not is_container_id(proj_id):
         raise ValueError('Expected %r to be a container ID' % (proj_id,))
-    return try_call(dxpy.DXHTTPRequest, '/' + obj_id + '/describe', {'project': proj_id}, always_retry=True)['project'] == proj_id
+    return try_call(dxpy.DXHTTPRequest, '/' + obj_id + '/describe', {'project': proj_id}, always_retry=True, **kwargs)['project'] == proj_id
 
 
 # Special characters in bash to be escaped: #?*: ;&`"'/!$({[<>|~

--- a/src/python/test/test_dxfile_functions.py
+++ b/src/python/test/test_dxfile_functions.py
@@ -20,8 +20,67 @@
 from __future__ import print_function, unicode_literals, division, absolute_import
 
 import unittest
+import tempfile
+import dxpy
+from mock import MagicMock, patch
 from dxpy.bindings.dxfile_functions import _verify_checksum
+from dxpy.bindings.dxfile_functions import upload_local_file
+from dxpy.bindings.dxfile import DXFile
 from dxpy.exceptions import DXFileError, DXChecksumMismatchError
+
+
+class TestUploadLocalFile(unittest.TestCase):
+    @patch('dxpy.bindings.dxfile_functions.new_dxfile')
+    def test_auth_reaches_parts_polling_without_timeout(self, new_dxfile):
+        handler = MagicMock()
+        handler._write_bufsize = 1024
+        new_dxfile.return_value = handler
+        auth = {'auth_token': 'request-token', 'auth_token_type': 'Bearer'}
+        security_context = dxpy.SECURITY_CONTEXT
+
+        with tempfile.NamedTemporaryFile() as local_file:
+            local_file.write(b'test data')
+            local_file.flush()
+            upload_local_file(filename=local_file.name, auth=auth, timeout=17,
+                              keep_open=True)
+
+        self.assertIs(dxpy.SECURITY_CONTEXT, security_context)
+        handler.wait_until_parts_uploaded.assert_called_once_with(auth=auth)
+
+
+class TestDXFileRead(unittest.TestCase):
+    @patch('dxpy.bindings.dxfile.DXFile._read2', return_value=b'file contents')
+    @patch('dxpy.DXHTTPRequest')
+    def test_auth_reaches_project_existence_check(self, dxhttp_request, read):
+        file_id = 'file-123456789012345678901234'
+        project_id = 'project-123456789012345678901234'
+        dxhttp_request.return_value = {'project': project_id}
+        dxfile = DXFile(file_id, project=project_id, mode='rb')
+        auth = {'auth_token': 'request-token', 'auth_token_type': 'Bearer'}
+        security_context = dxpy.SECURITY_CONTEXT
+
+        self.assertEqual(dxfile.read(auth=auth), b'file contents')
+
+        dxhttp_request.assert_called_once_with(
+            '/' + file_id + '/describe', {'project': project_id},
+            always_retry=True, auth=auth)
+        self.assertIs(dxpy.SECURITY_CONTEXT, security_context)
+
+    @patch('dxpy.api.file_download', return_value={'url': 'https://download', 'headers': {}})
+    @patch('dxpy.DXHTTPRequest', return_value={'project': 'project-123456789012345678901234'})
+    def test_download_url_forwards_auth_to_project_existence_check(self, dxhttp_request, file_download):
+        file_id = 'file-123456789012345678901234'
+        project_id = 'project-123456789012345678901234'
+        dxfile = DXFile(file_id, project=project_id, mode='rb')
+        auth = {'auth_token': 'request-token', 'auth_token_type': 'Bearer'}
+        security_context = dxpy.SECURITY_CONTEXT
+
+        dxfile.get_download_url(auth=auth)
+
+        dxhttp_request.assert_called_once_with(
+            '/' + file_id + '/describe', {'project': project_id},
+            always_retry=True, auth=auth)
+        self.assertIs(dxpy.SECURITY_CONTEXT, security_context)
 
 class TestVerifyPerPartChecksum(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Problem

Several DXFile operations accept request-scoped kwargs such as `auth`, but not every internal request preserved them.

Two gaps were identified:

- `upload_local_file(..., auth=...)` preserved request kwargs through the upload lifecycle, but the upload-parts polling step could fall back to ambient authentication.
- `DXFile.read()` / `get_download_url()` performed project-existence checks without preserving the caller's request kwargs.

This can cause incorrect `PermissionDenied` failures when callers intentionally use request-scoped authentication instead of the global `SECURITY_CONTEXT`.

## Fix

Propagate request kwargs through the affected internal calls:

- forward non-conflicting request kwargs to upload-parts polling;
- forward request kwargs through `DXFile.read()` / `get_download_url()` to the project-existence check and its describe request.

`timeout` is intentionally excluded from upload polling because that method already uses it as its polling deadline.

No global `SECURITY_CONTEXT` mutation is introduced.

## Impact / Risk

The change is localized to preserving request kwargs already supplied by callers. Existing ambient-auth behavior remains unchanged when custom request authentication is not provided.

Related consumer: https://github.com/dnanexus/file-apps/pull/1287