### PR TITLE
APPS-4402: VCF Loader: Intermittent DXExecDependencyError in us-east-1 from OpenJDK dpkg conffile prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Categories for each release: Added, Changed, Deprecated, Removed, Fixed, Securit
 
 * Decreased default `dx login` session expiration from 30 days to 18 hours to align with [current platform behaviour](https://documentation.dnanexus.com/user/login-and-logout#session-expiration)
 
+### Fixed
+
+* Fix intermittent apt dependency install failures in non-interactive jobs by adding dpkg conffile options (force-confdef, force-confold)
+
 ## [413.0] - beta
 
 * No significant changes

--- a/src/python/dxpy/utils/exec_utils.py
+++ b/src/python/dxpy/utils/exec_utils.py
@@ -316,7 +316,7 @@ class DXExecDependencyInstaller(object):
             print(message)
 
     def generate_shellcode(self, dep_group):
-        base_apt_shellcode = "export DEBIAN_FRONTEND=noninteractive && apt-get install --yes --no-install-recommends {p}"
+        base_apt_shellcode = "export DEBIAN_FRONTEND=noninteractive && apt-get install --yes --no-install-recommends -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" {p}"
         dx_apt_update_shellcode = "apt-get update -o Dir::Etc::sourcelist=sources.list.d/nucleus.list -o Dir::Etc::sourceparts=- -o APT::Get::List-Cleanup=0"
         apt_err_msg = "APT failed, retrying with full update against official package repository"
         apt_shellcode_template = "({dx_upd} && {inst}) || (echo {e}; apt-get update && {inst})"

--- a/src/python/test/test_dxpy_utils.py
+++ b/src/python/test/test_dxpy_utils.py
@@ -177,7 +177,7 @@ class TestDXExecDependsUtils(testutil.DXTestCaseCompat):
 
         edi = self.get_edi({"execDepends": [{"name": "git"}], "dependencies": [{"name": "tmux"}]})
         edi.install()
-        assert_cmd_ran(edi, "apt-get install --yes --no-install-recommends git tmux")
+        assert_cmd_ran(edi, r"apt-get install --yes --no-install-recommends -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" git tmux")
 
         edi = self.get_edi({"execDepends": [], "bundledDepends": [], "dependencies": []})
         edi.install()
@@ -206,7 +206,7 @@ class TestDXExecDependsUtils(testutil.DXTestCaseCompat):
                                               "stages": ["main"]}]})
         edi.install()
         assert_cmd_ran(edi, re.escape("pip install --upgrade pytz==2014.7 certifi"))
-        assert_cmd_ran(edi, "apt-get install --yes --no-install-recommends tmux")
+        assert_cmd_ran(edi, r"apt-get install --yes --no-install-recommends -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" tmux")
         assert_cmd_ran(edi, re.escape("gem install rake --version 10.3.2 && gem install nokogiri"))
         assert_cmd_ran(edi, "R -e .+ install.packages.+\"RJSONIO\".+install_version.+\"ggplot2\".+version=\"1.0.1\"")
         assert_log_contains(edi, 'Skipping bundled dependency "r1" because it does not refer to a file')
@@ -225,7 +225,7 @@ class TestDXExecDependsUtils(testutil.DXTestCaseCompat):
         edi = self.get_edi({"execDepends": [{"name": "git", "stages": ["foo", "bar"]}]},
                            job_desc={"function": "foo"})
         edi.install()
-        assert_cmd_ran(edi, "apt-get install --yes --no-install-recommends git")
+        assert_cmd_ran(edi, r"apt-get install --yes --no-install-recommends -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" git")
 
         # Job describe dict must contain "region" if the run specification
         # contains "bundledDependsByRegion".


### PR DESCRIPTION

I investigated the issue and confirmed the root cause is a non-interactive dpkg conffile prompt during OpenJDK upgrade, not an application logic error.

To validate this, I reproduced the behavior using a separate repro app with two controlled jobs:

Job 1: `job-JB8kyGQ0Yy3gp4K6021j0BJx`
- This job ran apt install for parallel and dx-spark352 without dpkg conffile handling options.
- Result: failed with the same pattern report:
```
openjdk-11-jre-headless hits a conffile prompt
dpkg cannot read stdin in non-interactive mode
openjdk-11-jdk-headless remains unconfigured
dx-spark352 remains unconfigured
apt exits with dpkg error code 1
```

Job 2: `job-JB8kyK00Yy3yqZ0JZp9g80YV`
- This job ran the same apt install, but with:
Dpkg::Options::=--force-confdef
Dpkg::Options::=--force-confold

- Result: success. The conffile conflict is resolved automatically, OpenJDK config completes, dx-spark352 installs, and the job finishes in done state.


### Conclusion:
The issue is caused by dpkg conffile interaction in a non-interactive environment. Adding force-confdef and force-confold prevents the interactive prompt and fixes the failure path.